### PR TITLE
Combine hyphenated word-halves (also over pb elements). Spellcheck

### DIFF
--- a/data/stoa0255/stoa010/stoa0255.stoa010.perseus-lat2.xml
+++ b/data/stoa0255/stoa010/stoa0255.stoa010.perseus-lat2.xml
@@ -67,6 +67,7 @@
 
 
          <change who="Thibault Clerice" when="2015-11-13">Bumped URN after CTS and Epidoc conversion</change>
+           <change who="Neven Jovanovic" when="2015-12-11">Remove hyphens, combine hyphenated words</change>
       </revisionDesc>
     </teiHeader>
    <text>
@@ -170,8 +171,7 @@ nulla pestis humano generi pluris stetit. Videbis
 caedes ac venena et reorum mutuas sordes et urbium
 clades et totarum exitia gentium et principum sub
 civili hasta capita venalia et subiectas tectis faces nec
-intra moenia coercitos ignes sed ingentia spatia regio-
- num hostili flamma relucentia.
+intra moenia coercitos ignes sed ingentia spatia regionum hostili flamma relucentia.
 </p>
                   </div>
 
@@ -208,8 +208,7 @@ promiscuam totos populos capitis damnatos <gap reason="omitted"/>
 auctoritatem contemnentibus. Quid ? Gladiatoribus
 quare populus irascitur et tam inique, ut iniuriam
 putet, quod non libenter pereunt ? Contemni se
-iudicat et vultu, gestu, ardore a spectatore in ad-
- versarium vertitur.
+iudicat et vultu, gestu, ardore a spectatore in adversarium vertitur.
 </p>
                   </div>
 
@@ -245,10 +244,10 @@ sperant." Primum diximus cupiditatem esse poenae
 exigendae, non facultatem; concupiscunt autem
 homines et quae non possunt. Deinde nemo tam
 humilis est, qui poenam vel summi hominis sperare
-non possit; ad nocendum potentes sumus. Aristo-
+non possit; ad nocendum potentes sumus. Aristotelis
 
 <pb n="p.114"/>
- telis finitio non multum a nostra abest ;
+  finitio non multum a nostra abest ;
 </p>
                   </div>
 
@@ -348,10 +347,10 @@ differentiae sunt ; inter hos morosum ponas licet,
                      <p> Quaedam enim sunt
 irae, quae intra clamorem considant, quaedam non
 minus pertinaces quam frequentes, quaedam saevae
-manu verbis parciores, quaedam in verborum male-
+manu verbis parciores, quaedam in verborum maledictorumque
 
 <pb n="p.118"/>
-dictorumque amaritudinem effusae ; quaedam ultra
+ amaritudinem effusae ; quaedam ultra
 querellas et aversationes non exeunt, quaedam altae
 gravesque sunt et introrsus versae. Mille aliae species
 sunt mali multiplicis.
@@ -445,8 +444,7 @@ sceleribus ultimis ponat, ut nemo pereat, nisi quem
                      <p> Hoc uno medentibus
 erit dissimilis, quod illi quibus vitam non potuerunt
 largiri facilem exitum praestant, hic damnatos cum
-dedecore et traductione vita exigit, non quia de-
-lectetur ullius poena—procul est enim a sapiente tam
+dedecore et traductione vita exigit, non quia delectetur ullius poena—procul est enim a sapiente tam
 inhumana feritas—sed ut documentum omnium sint,
 et quia vivi noluerunt prodesse, morte certe eorum
 res publica utatur. Non est ergo natura hominis
@@ -497,8 +495,7 @@ nam cum se in possessione posuerunt, potentiora
                      <p> Deinde
 ratio ipsa, cui freni traduntur, tam diu potens est
 quam diu diducta est ab adfectibus ; si miscuit se
-illis et inquinavit, non potest continere quos sum-
-movere potuisset. Commota enim semel et excussa
+illis et inquinavit, non potest continere quos summovere potuisset. Commota enim semel et excussa
  mens ei servit quo impellitur.
 </p>
                   </div>
@@ -525,10 +522,10 @@ vitiorum natura proclivis.
                      <p>  Optimum est primum irritamentum irae protinus spernere ipsisque repugnare seminibus et dare
 operam, ne incidamus in iram. Nam si coepit ferre
 transversos, difficilis ad salutem recursus est, quoniam
-nihil rationis est, ubi semel adfectus inductus est ius-
+nihil rationis est, ubi semel adfectus inductus est iusque
 
 <pb n="p.126"/>
-que illi aliquod voluntate nostra datum est ; faciet de
+ illi aliquod voluntate nostra datum est ; faciet de
  cetero quantum volet, non quantum permiseris.
 </p>
                   </div>
@@ -544,7 +541,7 @@ oportet procedere, sed in adfectum ipse mutatur ideoque non potest utilem illam 
                   </div>
 
                   <div type="textpart" n="3" subtype="section">
-                     <p> Non enim, ut dixi, separates ista sedes suas diductasque habent, sed
+                     <p> Non enim, ut dixi, separatas ista sedes suas diductasque habent, sed
 affectus et ratio in melius peiusque mutatio animi est.
 Quomodo ergo ratio occupata et oppressa vitiis
 resurget, quae irae cessit ? Aut quemadmodum
@@ -566,8 +563,7 @@ vos, quasi fortius aliquid ratione haberet, advocabatis.
 infirmior ? Si valentior, quomodo illi modum ratio
 poterit imponere, cum parere nisi imbecilliora non
 soleant ? Si infirmior est, sine hac per se ad rerum
-effectus sufficit ratio nec desiderat inbecillioris auxi-
- lium. " At irati quidam constant sibi et se continent.
+effectus sufficit ratio nec desiderat inbecillioris auxilium. " At irati quidam constant sibi et se continent.
 </p>
                   </div>
 
@@ -694,8 +690,7 @@ modicus affectus nihil aliud quam malum modicum est.
 ira." Nusquam minus ; ubi non effusos esse oportet
 impetus sed temperatos et oboedientes. Quid enim
 est aliud quod barbaros tanto robustiores corporibus,
-tanto patientiores laborum comminuat nisi ira in-
- festissima sibi ?
+tanto patientiores laborum comminuat nisi ira infestissima sibi ?
 </p>
                   </div>
 
@@ -837,8 +832,7 @@ vero obliviscitur Martem esse communem venitque
 
                   <div type="textpart" n="6" subtype="section">
                      <p> Deinde
-non ideo vitia in usum recipienda sunt, quia ali-
-quando aliquid effecerunt ; nam et febres quaedam
+non ideo vitia in usum recipienda sunt, quia aliquando aliquid effecerunt ; nam et febres quaedam
 genera valetudinis levant, nec ideo non ex toto illis
 caruisse melius est. Abominandum remedi genus
 est sanitatem debere morbo. Simili modo ira, etiam
@@ -872,8 +866,7 @@ et esse. Non est bonum quod incremento malum fit.
                      <p>" Utilis," inquit, " ira est, quia pugnaciores facit."
 Isto modo et ebrietas ; facit enim protervos et audaces
 multique meliores ad ferrum fuere male sobrii ; isto
-modo dic et phrenesin atque insaniam viribus neces-
- sariam, quia saepe validiores furor reddit. Quid ?
+modo dic et phrenesin atque insaniam viribus necessariam, quia saepe validiores furor reddit. Quid ?
 </p>
                   </div>
 
@@ -1200,10 +1193,10 @@ duci iussit. Constituti sunt in eodem illo loco perituri
                   <div type="textpart" n="6" subtype="section">
                      <p> O quam sollers est
 iracundia ad fingendas causas furoris ! " Te," inquit,
-" duci iubeo, quia damnatus es ; te, quia causa dam-
+" duci iubeo, quia damnatus es ; te, quia causa damnationis
 
 <pb n="p.156"/>
-nationis commilitoni fuisti ; te, quia iussus occidere
+ commilitoni fuisti ; te, quia iussus occidere
 imperatori non paruisti." Excogitavit quemadmodum
 tria crimina faceret, quia nullum invenerat.
 </p>
@@ -1316,14 +1309,12 @@ ruinam prona sunt quae sine fundamentis crevere.
 Non habet ira cui insistat. Non ex firmo mansuroque
 oritur, sed ventosa et inanis est tantumque abest a
 magnitudine animi, quantum a fortitudine audacia,
-a fiducia insolentia, ab austeritate tristitia, a severi-
- tate crudelitas.
+a fiducia insolentia, ab austeritate tristitia, a severitate crudelitas.
 </p>
                   </div>
 
                   <div type="textpart" n="3" subtype="section">
-                     <p> Multum, inquam, interest inter sub-
-limem animum et superbum. Iracundia nihil amplum
+                     <p> Multum, inquam, interest inter sublimem animum et superbum. Iracundia nihil amplum
 decorumque molitur ; contra mihi videtur veternosi
 et infelicis animi, imbecillitatis sibi conscii, saepe
 indolescere, ut exulcerata et aegra corpora, quae ad
@@ -1408,8 +1399,7 @@ ferret !
 vehemens et deos hominesque despiciens, magnum,
 nihil nobile est. Aut si videtur alicui magnum
 animum ira producere, videatur et luxuria—ebore
-sustineri vult, purpura vestiri, auro tegi, terras trans-
-ferre, maria concludere, flumina praecipitare, nemora
+sustineri vult, purpura vestiri, auro tegi, terras transferre, maria concludere, flumina praecipitare, nemora
  suspendere ;
 </p>
                   </div>
@@ -1517,15 +1507,14 @@ animi ponendus est, qui nos post opinionem iniuriae
                   </div>
 
                   <div type="textpart" n="3" subtype="section">
-                     <p> Hic subit etiam inter ludicra scaenae spec-
+                     <p> Hic subit etiam inter ludicra scaenae spectacula
 
 <pb n="p.170"/>
-tacula et lectiones rerum vetustarum. Saepe Clodio
+ et lectiones rerum vetustarum. Saepe Clodio
 Ciceronem expellenti et Antonio occidenti videmur
 irasci; quis non contra Mari arma, contra Sullae
 proscriptionem concitatur ? Quis non Theodoto et
-Achillae et ipsi puero non puerile auso facinus in-
- festus est ?
+Achillae et ipsi puero non puerile auso facinus infestus est ?
 </p>
                   </div>
 
@@ -1595,8 +1584,7 @@ sine adsensu mentis est, neque enim fieri potest ut de
 ultione et poena agatur animo nesciente. Putavit se
 aliquis laesum, voluit ulcisci, dissuadente aliqua causa
 statim resedit. Hanc iram non voco, motum animi
-rationi parentem ; illa est ira, quae rationem trans-
- silit, quae secum rapit.
+rationi parentem ; illa est ira, quae rationem transsilit, quae secum rapit.
 </p>
                   </div>
 
@@ -1648,16 +1636,14 @@ nascitur, iudicio tollitur.
                      <p>  Illud etiamnunc quaerendum est, ii qui vulgo
 saeviunt et sanguine humano gaudent an irascantur,
 cum eos occidunt, a quibus nec acceperunt iniuriam
-nec accepisse ipsi se existimant ; qualis fuit Apollo-
- dorus aut Phalaris. Haec non est ira, feritas est ;
+nec accepisse ipsi se existimant ; qualis fuit Apollodorus aut Phalaris. Haec non est ira, feritas est ;
 </p>
                   </div>
 
                   <div type="textpart" n="2" subtype="section">
                      <p>
 non enim quia accepit iniuriam nocet, sed parata est,
-dum noceat, vel accipere, nec illi verbera lacerationes-
- que in ultionem petuntur sed in voluptatem.
+dum noceat, vel accipere, nec illi verbera lacerationesque in ultionem petuntur sed in voluptatem.
 </p>
                   </div>
 
@@ -1693,7 +1679,7 @@ et circa Trasumennum et circa Cannas et novissime
                      <p> Volesus nuper sub divo
 Augusto proconsul Asiae, cum trecentos uno die
 securi percussisset, incedens inter cadavera vultu
-superbo, quasi magnificum quiddam conspiciendumque fecisset, graece proclamavit : " O rem regiam ! "
+superbo, quasi magnificum quiddam conspiciendumque fecisset, Graece proclamavit : " O rem regiam ! "
 Quid hic rex fecisset ? Non fuit haec ira sed maius
 malum et insanabile.
 </p>
@@ -1811,10 +1797,10 @@ in ludo gladiatorio vita est cum isdem bibentium
 
                   <div type="textpart" n="3" subtype="section">
                      <p> Ferarum iste conventus est, nisi quod
-illae inter se placidae sunt morsuque similium abs-
+                        illae inter se placidae sunt morsuque similium abstinent,
 
 <pb n="p.182"/>
-	tinent, hi mutua laceratione satiantur. Hoc omnino<note> hoc omnino Vahlen : hoc in uno A,
+	 hi mutua laceratione satiantur. Hoc omnino<note> hoc omnino Vahlen : hoc in uno A,
 	</note>
 ab animalibus mutis differunt, quod illa mansuescunt
 alentibus, horum rabies ipsos a quibus est nutrita
@@ -1859,10 +1845,10 @@ dato ad fas nefasque miscendum coorti sunt :
 castra ex uno partu contraria et parentium liberorumque sacramenta diversa, subiectam patriae civis
 manu flammam et agmina infestorum equitum ad inquirendas proscriptorum latebras circumvolitantia et
 violatos fontes venenis et pestilentiam manu factam et
-praeductam obsessis parentibus fossam, plenos carce-
+praeductam obsessis parentibus fossam, plenos carceres
 
 <pb n="p.184"/>
-res et incendia totas urbes concremantia dominationesque funestas et regnorum publicorumque exitiorum
+ et incendia totas urbes concremantia dominationesque funestas et regnorum publicorumque exitiorum
 clandestina consilia, et pro gloria habita, quae quam
 diu opprimi possunt, scelera sunt, raptus ac stupra et
  ne os quidem libidini exceptum.
@@ -1999,8 +1985,7 @@ timetur febris, podagra, ulcus malum ? Numquid
 ideo quicquam in istis boni est ? An contra omnia
 despecta foedaque et turpia, ipsoque eo timentur ?
 Sic ira per se deformis est et minime metuenda, at
-timetur a pluribus sicut deformis persona ab in-
- fantibus.
+timetur a pluribus sicut deformis persona ab infantibus.
 </p>
                   </div>
 
@@ -2274,10 +2259,10 @@ iracundissima? Feras putem, quibus ex raptu alimenta
 sunt, meliores quo iratiores ; patientiam laudaverim
 boum et equorum frenos sequentium. Quid est autem
 cur hominem ad tam infelicia exempla revoces, cum
-habeas mundum deumque, quem ex omnibus animali-
+habeas mundum deumque, quem ex omnibus animalibus, 
 
 <pb n="p.202"/>
- bus, ut solus imitetur, solus intellegit ? " Simplicissimi," inquit, " omnium habentur iracundi."
+ ut solus imitetur, solus intellegit ? " Simplicissimi," inquit, " omnium habentur iracundi."
 </p>
                   </div>
 
@@ -2372,8 +2357,7 @@ ignis ; frigidi mixtura timidos facit, pigrum est enim
                      <p> Volunt itaque quidam ex
 nostris iram in pectore moveri effervescente circa cor
 sanguine ; causa cur hic potissimum adsignetur irae
-locus non alia est, quam quod in toto corpore ealidis-
- simum pectus est.
+locus non alia est, quam quod in toto corpore calidissimum pectus est.
 </p>
                   </div>
 
@@ -2627,10 +2611,10 @@ ira, ut tyrannus tyrannicidae manus accommodaret
                   </div>
 
                   <div type="textpart" n="2" subtype="section">
-                     <p> Quanto ani-
+                     <p> Quanto animosius
 
 <pb n="p.216"/>
-mosius Alexander! Qui cum legisset epistulam
+ Alexander! Qui cum legisset epistulam
 matris, qua admonebatur, ut a veneno Philippi
 medici caveret, acceptam potionem non deterritus
  bibit. Plus sibi de amico suo credidit.
@@ -2715,8 +2699,7 @@ questus est, quod foliis rosae duplicatis incubuisset.
 nihil tolerabile videtur, non quia dura, sed quia
 mollis patitur. Quid est enim, cur tussis alicuius
 aut sternutamentum aut musca parum curiose fugata
-in rabiem agat aut obversatus canis aut clavis ne-
- glegentis servi manibus elapsa ?
+in rabiem agat aut obversatus canis aut clavis neglegentis servi manibus elapsa ?
 </p>
                   </div>
 
@@ -2738,8 +2721,7 @@ est, ut ictum non sentiat nisi gravem.
 
                   <div type="textpart" n="1" subtype="section">
                      <p>  Irascimur aut iis, a quibus ne accipere quidem
-potuimus iniuriam, aut iis, a quibus accipere in-
- iuriam potuimus.
+potuimus iniuriam, aut iis, a quibus accipere iniuriam potuimus.
 </p>
                   </div>
 
@@ -2799,8 +2781,7 @@ innocentia habent imprudentiam.
                      <p>  Quaedam sunt quae nocere non possunt
 nullamque vim nisi beneficam et salutarem habent,
 ut di immortales , qui nec volunt obesse nec possunt ;
-natura enim illis mitis et placida est, tam longe re-
- mota ab aliena iniuria quam a sua.
+natura enim illis mitis et placida est, tam longe remota ab aliena iniuria quam a sua.
 </p>
                   </div>
 
@@ -2879,10 +2860,10 @@ favimus ; in quibusdam innocentes sumus, quia non
 ne irascamur (cui enim non, si bonis quoque ?),
 minime diis ; non enim illorum vi,<note> vi added by Hermes.
 	
-</note> sed lege mor-
+</note> sed lege mortalitatis
 
 <pb n="p.226"/>
-talitatis patimur quidquid incommodi accidit. " At
+ patimur quidquid incommodi accidit. " At
 morbi doloresque incurrunt." Utique aliquo defungendum est domicilium putre sorti tis.
 Dicetur aliquis male de te locutus ; cogita an
  prior feceris, cogita de quam multis loquaris.
@@ -3087,8 +3068,7 @@ colla summissa et taurorum pueris pariter ac feminis
 persultantibus terga impune calcata et repentis inter
 pocula sinusque innoxio lapsu dracones et intra
 domum ursorum leonumque ora placida tractantibus
-adulantisque dominum feras ; pudebit cum anima-
- libus permutasse mores. Nefas est nocere patriae ;
+adulantisque dominum feras ; pudebit cum animalibus permutasse mores. Nefas est nocere patriae ;
 </p>
                   </div>
 
@@ -3130,8 +3110,7 @@ dulce est dolorem reddere." Minime ; non enim ut
 in beneficiis honestum est merita meritis repensare,
 ita iniurias iniuriis. Illic vinci turpe est, hic vincere.
 Inhumanum verbum est et quidem pro iusto receptum ultio, et talio non multum differt <note> et quidem  <gap reason="omitted"/> differt AL: ultio et deleted by most
-	editors : et vitiose quidem pro iusto receptum, talio. pro-
-	posed by Gertz: et quidem pro iusta receptum ultione
+	editors : et vitiose quidem pro iusto receptum, talio. proposed by Gertz: et quidem pro iusta receptum ultione
 	" talio." Non multum differt nisi ordine, qui dolorem
 	regerit: P. Thomas.
 </note> nisi ordine ;
@@ -3188,10 +3167,10 @@ vindicare non expedit, ut ne fateri quidem expediat.
 
                   <div type="textpart" n="3" subtype="section">
                      <p> C. Caesar Pastoris splendidi equitis Romani filium
-cum in custodia habuisset munditiis eius et cul-
+                        cum in custodia habuisset munditiis eius et cultioribus
 
 <pb n="p.240"/>
-tioribus capillis offensus, rogante patre ut salutem
+ capillis offensus, rogante patre ut salutem
 sibi filii concederet, quasi de supplicio admonitus
 duci protinus iussit; ne tamen omnia inhumane
 faceret adversum patrem, ad cenam illum eo die
@@ -3217,8 +3196,7 @@ passus est ; cenavit tamquam pro filio exorasset.
 Priamus ? Non dissimulavit iram et regis genua
 complexus est, funestam perfusamque cruore fili
 manum ad os suum retulit, cenavit ? Sed tamen
-sine unguento, sine coronis, et illum hostis saevis-
-simus multis solaciis, ut cibum caperet, hortatus est,
+sine unguento, sine coronis, et illum hostis saevissimus multis solaciis, ut cibum caperet, hortatus est,
 non ut pocula ingentia super caput posito custode
 siccaret.
 </p>
@@ -3307,15 +3285,13 @@ revocare non possit ? Atqui tale ira telum est;
 vix retrahitur. Arma nobis expedita prospicimus,
 gladium commodum et habilem; non vitabimus
 impetus animi istos <note> istos Gertz:  <gap reason="omitted"/> hos A 1 A 5.
-</note> graves et onerosos et irre-
- vocabiles ?
+</note> graves et onerosos et irrevocabiles ?
 </p>
                   </div>
 
                   <div type="textpart" n="2" subtype="section">
                      <p> Ea demum velocitas placet, quae ubi
-iussa est vestigium sistit nec ultra destinata pro-
-currit flectique et a cursu ad gradum reduci potest ;
+iussa est vestigium sistit nec ultra destinata procurrit flectique et a cursu ad gradum reduci potest ;
 aegros scimus nervos esse, ubi invitis nobis moventur ;
 senex aut infirmi corporis est, qui cum ambulare
 vult currit. Animi motus eos putemus sanissimos
@@ -3400,14 +3376,12 @@ se. Et quantulum ex vera deformitate imago illa
                      <p> Animus si ostendi
 et si in ulla materia perlucere posset, intuentis nos
 confunderet ater maculosusque et aestuans et
-distortus et tumidus. Nunc quoque tanta de-
-formitas eius est per ossa carnesque et tot impedimenta effluentis ; quid si nudus ostenderetur ?
+distortus et tumidus. Nunc quoque tanta deformitas eius est per ossa carnesque et tot impedimenta effluentis ; quid si nudus ostenderetur ?
 </p>
                   </div>
 
                   <div type="textpart" n="3" subtype="section">
-                     <p> Speculo quidem neminem deterritum ab ira credi-
-	deris : quid ergo est <note> est added by Gertz.
+                     <p> Speculo quidem neminem deterritum ab ira credideris : quid ergo est <note> est added by Gertz.
 	</note> ? Qui ad speculum venerat,
 ut se mutaret, iam mutaverat ; iratis quidem nulla
 est formonsior effigies quam atrox et horrida, qualesque esse etiam videri volunt.
@@ -3465,14 +3439,12 @@ in quem non ira dominetur.</p>
 
                   <div type="textpart" n="1" subtype="section">
                      <p>  Quod maxime desiderasti. Novate, nunc facere
-temptabimus, iram excidere animis aut certe re-
-frenare et impetus eius inhibere. Id aliquando
+temptabimus, iram excidere animis aut certe refrenare et impetus eius inhibere. Id aliquando
 palam aperteque faciendum est, ubi minor vis mali
 patitur, aliquando ex occulto, ubi nimium ardet
 omnique impedimento exasperatur et crescit; refert
 quantas vires quamque integras habeat, utrum
-reverberanda et agenda retro sit an cedere ei de-
-beamus, dum tempestas prima desaevit, ne remedia
+reverberanda et agenda retro sit an cedere ei debeamus, dum tempestas prima desaevit, ne remedia
 ipsa secum ferat.
 </p>
                   </div>
@@ -3689,8 +3661,7 @@ ut aliquem esse cupientium non alium sonum quam
 est apris tela sua adtritu acuentibus ; adice articulorum crepitum, cum se ipsae manus frangunt, et
 pulsatum saepius pectus, anhelitus crebros tractosque
 altius gemitus, instabile corpus, incerta verba subitis
-exclamationibus, trementia labra interdumque com-
- pressa et dirum quiddam exsibilantia.
+exclamationibus, trementia labra interdumque compressa et dirum quiddam exsibilantia.
 </p>
                   </div>
 
@@ -3864,8 +3835,7 @@ incursitandum est et aliubi labi necesse est, aliubi
 
 <pb n="p.270"/>
 retineri, aliubi respergi, ita in hoc vitae actu dissipato et vago multa impedimenta, multae querellae
-incidunt. Alius spem nostram fefellit, alius dis-
-tulit, alius intercepit; non ex destinato proposita
+incidunt. Alius spem nostram fefellit, alius distulit, alius intercepit; non ex destinato proposita
  fluxerunt.
 </p>
                   </div>
@@ -3952,10 +3922,10 @@ profuit utilis regio et salubrius caelum quam animis
 quantum possit intelleges, si videris feras quoque
 convictu nostro mansuescere nullique etiam immani
 bestiae vim suam permanere, si hominis contubernium
-diu passa est; retunditur omnis asperitas paulatim-
+diu passa est; retunditur omnis asperitas paulatimque
 
 <pb n="p.274"/>
-que inter placida dediscitur. Accedit huc, quod
+ inter placida dediscitur. Accedit huc, quod
 non tantum exemplo melior fit qui cum quietis
 hominibus vivit, sed quod causas irascendi non
 invenit nec vitium suum exercet. Fugere itaque
@@ -3991,12 +3961,11 @@ Cum quo, ut aiunt, cenabat in cubiculo lectae
 patientiae cliens, sed difficile erat illi in copulam
 coniecto rixam eius cum quo cohaerebat effugere;
 optimum iudicavit quidquid dixisset sequi et secundas
-agere. Non tulit Caelius adsentientem et exclama-
-vit : " Dic aliquid contra, ut duo simus ! " Sed ille
-quoque, quod non irasceretur iratus, cito sine adver-
+agere. Non tulit Caelius adsentientem et exclamavit : " Dic aliquid contra, ut duo simus ! " Sed ille
+quoque, quod non irasceretur iratus, cito sine adversario
 
 <pb n="p.276"/>
- sario desit.
+  desit.
 </p>
                   </div>
 
@@ -4037,8 +4006,7 @@ et historia fabulis detineat ; mollius delicatiusque
                   <div type="textpart" n="2" subtype="section">
                      <p> Pythagoras perturbationes animi lyra
 componebat; quis autem ignorat lituos et tubas
-concitamenta esse, sicut quosdam cantus blandi-
-menta, quibus mens resolvatur ? Confusis oculis
+concitamenta esse, sicut quosdam cantus blandimenta, quibus mens resolvatur ? Confusis oculis
 prosunt virentia et quibusdam coloribus infirma
 acies adquiescit, quorundam splendore praestringitur;
  sic mentes aegras studia laeta permulcent.
@@ -4048,11 +4016,10 @@ acies adquiescit, quorundam splendore praestringitur;
                   <div type="textpart" n="3" subtype="section">
                      <p> Forum,
 advocationes, iudicia fugere debemus et omnia quae
-exulcerant vitium, aeque cavere lassitudinem corpo-
+exulcerant vitium, aeque cavere lassitudinem corporis ;
 
 <pb n="p.278"/>
-ris ; consumit enim quidquid in nobis mite placidum-
- que est et aeria concitat.
+ consumit enim quidquid in nobis mite placidumque est et aeria concitat.
 </p>
                   </div>
 
@@ -4087,8 +4054,7 @@ sine querella aegra tanguntur.
 
                   <div type="textpart" n="1" subtype="section">
                      <p>  Optimum est itaque ad primum mali sensum
-mederi sibi, tum verbis quoque suis minimum liber-
- tatis dare et inhibere impetum.
+mederi sibi, tum verbis quoque suis minimum libertatis dare et inhibere impetum.
 </p>
                   </div>
 
@@ -4122,8 +4088,7 @@ si <note> aut si A : <del>aut</del> si Hermes.
                      <p> Prodest morbum suum nosse
 et vires eius antequam spatientur opprimere. Videamus quid sit, quod nos maxime concitet. Alium
 verborum, alium rerum contumeliae movent; hic
-vult nobilitati, hic formae suae parci; hic elegantis-
-simus haberi cupit, ille doctissimus ; hic superbiae
+vult nobilitati, hic formae suae parci; hic elegantissimus haberi cupit, ille doctissimus ; hic superbiae
 impatiens est, hic contumaciae ; ille servos non putat
 dignos quibus irascatur, hic intra domum saevus est,
 foris mitis ; ille rogari invidiam iudicat, hic non rogari
@@ -4186,8 +4151,7 @@ oculis in se incurrisset.
                   <div type="textpart" n="1" subtype="section">
                      <p>  Magna pars querellas manu fecit aut falsa
 suspicando aut levia adgravando. Saepe ad nos ira
-venit, saepius nos ad illam. Quae numquam arces-
- senda est ; etiam cum incidit, reiciatur.
+venit, saepius nos ad illam. Quae numquam arcessenda est ; etiam cum incidit, reiciatur.
 </p>
                   </div>
 
@@ -4391,8 +4355,7 @@ Id de quo nunc agitur apparet, iram supprimi posse.
 
                   <div type="textpart" n="5" subtype="section">
                      <p> Non male dixit regi, nullum emisit ne calamitosi
-quidem verbum, cum aeque cor suum quam fili trans-
-fixum videret. Potest dici merito devorasse verba ;
+quidem verbum, cum aeque cor suum quam fili transfixum videret. Potest dici merito devorasse verba ;
 nam si quid tamquam iratus dixisset, nihil tamquam
  pater facere potuisset.
 </p>
@@ -4439,7 +4402,7 @@ nascentem iram abscondi et ad verba contraria sibi
 
 <pb n="p.294"/>
 hoc sortitis vitae genus et ad regiam adhibitis mensam.
-Sic estur apud illos. Sic blbitur. Sic respondetur,
+Sic estur apud illos. Sic bibitur. Sic respondetur,
 funeribus suis adridendum est. An tanti sit vita
 videbimus ; alia ista quaestio est. Non consolabimur
 tam triste ergastulum, non adhortabimur ferre
@@ -4473,7 +4436,7 @@ Quaelibet in corpore tuo vena ! "
                <div type="textpart" n="16" subtype="chapter">
 
                   <div type="textpart" n="1" subtype="section">
-                     <p>  Quam diu quidem nihil tam intolerable nobis
+                     <p>  Quam diu quidem nihil tam intolerabile nobis
 videtur, ut nos expellat e vita, iram, in quocumque
 
 <pb n="p.296"/>
@@ -4718,8 +4681,7 @@ tenerrima frondium et cacumina arborum, tum coria
 igne mollita et quidquid necessitas cibum fecerat ;
 postquam inter harenas radices quoque et herbae
 defecerant apparuitque inops etiam animalium
-solitudo, decimum quemque sortiti alimentum ha-
- buerunt fame saevius.
+solitudo, decimum quemque sortiti alimentum habuerunt fame saevius.
 </p>
                   </div>
 
@@ -4761,7 +4723,7 @@ regis comitatus auferentem eo redacturum, ut
                   <div type="textpart" n="3" subtype="section">
                      <p> Hoc
 deinde omnem transtulit belli apparatum et tam
-diu adsedit operi, donec centum et octoginta cumculis divisum alveum in trecentos et sexaginta rivos
+diu adsedit operi, donec centum et octoginta cuniculis divisum alveum in trecentos et sexaginta rivos
 dispergeret, siccum relinqueret in diversum fluentibus
  aquis.
 </p>
@@ -4792,8 +4754,7 @@ causa dirutae quaeritur.
                   <div type="textpart" n="1" subtype="section">
                      <p>  Et haec cogitanda sunt exempla, quae vites,
 et illa ex contrario, quae sequaris, moderata, lenia,
-quibus nec ad irascendum causa defuit nec ad ulci-
- scendum potestas.
+quibus nec ad irascendum causa defuit nec ad ulciscendum potestas.
 </p>
                   </div>
 
@@ -4854,20 +4815,19 @@ sibi. Ex his duobus tamen qui leoni obiectus est
                   </div>
 
                   <div type="textpart" n="2" subtype="section">
-                     <p> Non habuit hoc avitum ille vitium, ne pater-
-num quidem ; nam si qua alia in Philippo virtus, fuit
+                     <p> Non habuit hoc avitum ille vitium, ne paternum quidem ; nam si qua alia in Philippo virtus, fuit
 et contumeliarum patientia, ingens instrumentum
 ad tutelam regni. Demochares ad illum Parrhesiastes ob nimiam et procacem linguam appellatus
 inter alios Atheniensium legatos venerat. Audita
 benigne legatione Philippus: " Dicite," inquit,
 " mihi, facere quid possim, quod sit Atheniensibus
 gratum." Excepit Demochares et: " Te," inquit,
- " suspendere.
+ " suspendere."
 </p>
                   </div>
 
                   <div type="textpart" n="3" subtype="section">
-                     <p>" Indignatio circumstantium ad tam
+                     <p> Indignatio circumstantium ad tam
 inhumanum responsum exorta erat ; quos Philippus
 conticiscere iussit et Thersitam illum salvum incolumemque dimittere. " At vos," inquit, " ceteri
 legati, nuntiate Atheniensibus multo superbiores
@@ -4943,10 +4903,10 @@ potuit ? Ille tamen contentus fuit a conviciatore
 
                   <div type="textpart" n="2" subtype="section">
                      <p>" Quid est quare ego servi mei clarius
-responsum et contumaciorem voltum et non per-
+                        responsum et contumaciorem voltum et non pervenientem
 
 <pb n="p.316"/>
-venientem usque ad me murmurationem flagellis
+ usque ad me murmurationem flagellis
 et compedibus expiem ? Quis sum, cuius aures
 laedi nefas sit ? Ignoverunt multi hostibus ; ego
 non ignoscam pigris, neglegentibus, garrulis ?
@@ -5004,7 +4964,7 @@ ipse se castigabit. Denique debeat poenas ; non
                   <div type="textpart" n="3" subtype="section">
                      <p> Illud non veniet
 in dubium, quin se exemerit turbae et altius steterit
-quisquis despexit laeessentis. Proprium est magnitudinis verae non sentire percussum. Sic immanis
+quisquis despexit lacessentis. Proprium est magnitudinis verae non sentire percussum. Sic immanis
 fera ad latratum canum lenta respexit, sic irritus
 ingenti scopulo fluctus adsultat. Qui non irascitur,
 inconcussus iniuria perstitit, qui irascitur, motus
@@ -5029,8 +4989,7 @@ latura sit dubium est."
                <div type="textpart" n="26" subtype="chapter">
 
                   <div type="textpart" n="1" subtype="section">
-                     <p>  " Non possum," inquis, " pati; grave est in-
-iuriam sustinere." Mentiris ; quis enim iniuriam
+                     <p>  " Non possum," inquis, " pati; grave est iniuriam sustinere." Mentiris ; quis enim iniuriam
 non potest ferre, qui potest iram ? Adice nunc quod
 id agis, ut et iram feras et iniuriam. Quare fers aegri
 rabiem et phrenetici verba, puerorum protervas
@@ -5111,8 +5070,7 @@ nesciunt." Primum quam iniquus est, apud quem
 hominem esse ad impetrandam veniam nocet !
 Deinde, si cetera animalia hoc irae tuae subducit,
 quod consilio carent, eodem loco tibi sit quisquis
-consilio caret ; quid enim refert an alia mutis dis-
-similia habeat, si hoc, quod in omni peccato muta
+consilio caret ; quid enim refert an alia mutis dissimilia habeat, si hoc, quod in omni peccato muta
  defendit, simile habet, caliginem mentis ? Peccavit ;
 </p>
                   </div>
@@ -5122,8 +5080,7 @@ similia habeat, si hoc, quod in omni peccato muta
 hoc enim primum ? Hoc enim extremum ? Non
 est quod illi credas, etiam si dixerit: " Iterum non
 faciam." Et iste peccabit et in istum alius et tota
-vita inter errores volutabitur. Mansuete imman-
- sueta tractanda sunt.
+vita inter errores volutabitur. Mansuete immansueta tractanda sunt.
 </p>
                   </div>
 
@@ -5156,11 +5113,9 @@ a se !
                   <div type="textpart" n="1" subtype="section">
                      <p>  Huic irasceris, deinde illi; servis, deinde
 libertis ; parentibus, deinde liberis ; notis, deinde
-ignotis; ubique enim causae supersunt, nisi de-
-precator animus accessit. Hinc te illo furor rapiet,
+ignotis; ubique enim causae supersunt, nisi deprecator animus accessit. Hinc te illo furor rapiet,
 illinc alio, et novis subinde irritamentis orientibus
-continuabitur rabies. Age, infelix, ecquando ama-
-bis ? O quam bonum tempus in re mala perdis !
+continuabitur rabies. Age, infelix, ecquando amabis ? O quam bonum tempus in re mala perdis !
 </p>
                   </div>
 
@@ -5184,8 +5139,7 @@ fixit. Multos iracundia mancos, multos debiles
 fecit, etiam ubi patientem est <note> est added by Petschenig.
 </note> nancta materiam.
 Adice nunc quod nihil tam imbecille natum est, ut
-sine elidentis periculo pereat; imbecillos valentis-
- simis alias dolor, alias casus exaequat.
+sine elidentis periculo pereat; imbecillos valentissimis alias dolor, alias casus exaequat.
 </p>
                   </div>
 
@@ -5263,8 +5217,7 @@ leonesque mappa proritat ; omnia, quae natura fera
                   </div>
 
                   <div type="textpart" n="2" subtype="section">
-                     <p> Idem in-
-quietis et stolidis ingeniis evenit. Rerum suspicione
+                     <p> Idem inquietis et stolidis ingeniis evenit. Rerum suspicione
 feriuntur, adeo quidem, ut interdum iniurias vocent
 modica beneficia, in quibus frequentissima, certe
 acerbissima iracundiae materia est. Carissimis enim
@@ -5388,14 +5341,13 @@ respicienda.
                   <div type="textpart" n="1" subtype="section">
                      <p>  Circa pecuniam plurimum vociferationis est.
 Haec fora defetigat, patres liberosque committit,
-venena miscet, gladios tam percussoribus quam legio-
+venena miscet, gladios tam percussoribus quam legionibus
 
 <pb n="p.334"/>
-nibus tradit ; haec est sanguine nostro delibuta ;
+ tradit ; haec est sanguine nostro delibuta ;
 propter hanc uxorum maritorumque noctes strepunt
 litibus et tribunalia magistratuum premit turba,
-reges saeviunt rapiuntque et civitates longo saeculorum labore constructas evertunt, ut aurum argen-
- tumque in cinere urbium scrutentur.
+reges saeviunt rapiuntque et civitates longo saeculorum labore constructas evertunt, ut aurum argentumque in cinere urbium scrutentur.
 </p>
                   </div>
 
@@ -5439,8 +5391,7 @@ educunt!
                   <div type="textpart" n="1" subtype="section">
                      <p>  Cedo nunc, persequere cetera, cibos, potiones
 horumque causa paratas in ambitionem munditias,
-verba contumeliosa, motus corporum parum honori-
-ficos, contumacia iumenta et pigra mancipia, et
+verba contumeliosa, motus corporum parum honorificos, contumacia iumenta et pigra mancipia, et
 
 <pb n="p.336"/>
 suspiciones et interpretationes malignas vocis alienae,
@@ -5477,11 +5428,9 @@ excitant.
                <div type="textpart" n="35" subtype="chapter">
 
                   <div type="textpart" n="1" subtype="section">
-                     <p>  Respondisse tibi servum indignans libertum-
-que et uxorem et clientem ; deinde idem de re
+                     <p>  Respondisse tibi servum indignans libertumque et uxorem et clientem ; deinde idem de re
 publica libertatem sublatam quereris, quam domi
-sustulisti. Rursus, si tacuit interrogatus, contu-
- maciam vocas. Et loquatur et taceat et rideat !
+sustulisti. Rursus, si tacuit interrogatus, contumaciam vocas. Et loquatur et taceat et rideat !
 </p>
                   </div>
 
@@ -5490,10 +5439,10 @@ sustulisti. Rursus, si tacuit interrogatus, contu-
 " Coram domino ? " inquis. Immo coram patre
 familiae. Quid clamas ? Quid vociferans ? Quid
 flagella media cena petis, quod servi loquuntur, quod
-non eodem loco turba contionis est, silentium soli-
+non eodem loco turba contionis est, silentium solitudinis ?
 
 <pb n="p.338"/>
- tudinis ?
+ 
 </p>
                   </div>
 
@@ -5552,8 +5501,7 @@ sciet sibi cotidie ad iudicem esse veniendum. Quicquam ergo pulchrius hac consue
 totum diem ? Qualis ille somnus post recognitionem
 sui sequitur, quam tranquillus, quam altus ac liber,
 cum aut laudatus est animus aut admonitus et
-speculator sui censorque secretus cognovit de mori-
- bus suis !
+speculator sui censorque secretus cognovit de moribus suis !
 </p>
                   </div>
 
@@ -5588,10 +5536,10 @@ patitur."
 
                   <div type="textpart" n="1" subtype="section">
                      <p>  In convivio quorundam te sales et in dolorem
-tuum iacta verba tetigerunt. Vitare volgares con-
+                        tuum iacta verba tetigerunt. Vitare volgares convictus
 
 <pb n="p.342"/>
-victus memento ; solutior est post vinum licentia,
+ memento ; solutior est post vinum licentia,
  quia ne sobriis quidem pudor est.
 </p>
                   </div>
@@ -5634,8 +5582,7 @@ aequis quendam oculis vidisti, quia de ingenio tuo
 male locutus est. Recipis hanc legem ? Ergo te
 Ennius, quo non delectaris, odisset, et Hortensius,
 si orationes eius improbares,<note> si . . improbares added by Haupt.
-</note> simultates tibi in-
-diceret, et Cicero, si derideres carmina eius,
+</note> simultates tibi indiceret, et Cicero, si derideres carmina eius,
 
 <pb n="p.344"/>
 inimicus esset. Vis tu aequo animo pati candidatus
@@ -5711,8 +5658,7 @@ inferet vel gratos vel novos et cupiditate cognoscendi
 avocabit. Medicum aiunt, cum regis filiam curare
 deberet nec sine ferro posset, dum tumentem
 mammam leniter fovet, scalpellum spongea tectum
-induxisse. Repugnasset puella remedio palam ad-
-moto, . eadem, quia non expectavit, dolorem tulit.
+induxisse. Repugnasset puella remedio palam admoto, . eadem, quia non expectavit, dolorem tulit.
 Quaedam non nisi decepta sanantur.
 </p>
 
@@ -5758,7 +5704,7 @@ illum quidem mitti, crustallina autem omnia coram
                   <div type="textpart" n="4" subtype="section">
                      <p> Fuit Caesari
 sic castigandus amicus ; bene usus est viribus suis :
-" E convivio rapi homines imp eras et novi generis
+" E convivio rapi homines imperas et novi generis
 poenis lancinari ? Si calix tuus fractus est, viscera
 hominis distrahentur ? Tantum tibi placebis, ut
  ibi aliquem duci iubeas, ubi Caesar est ?
@@ -5901,8 +5847,7 @@ qui vulnus inimici quam qui pusulam concupiscit ;
 hic enim non tantum mali animi est, sed pusilli.
 Sive de ultimis suppliciis cogitas sive de levioribus,
 quantulum est temporis, quo aut ille poena sua
-torqueatur aut tu malum gaudium ex aliena per-
- cipias ! Iam istum spiritum exspuemus.
+torqueatur aut tu malum gaudium ex aliena percipias ! Iam istum spiritum exspuemus.
 </p>
                   </div>
 
@@ -5911,9 +5856,7 @@ torqueatur aut tu malum gaudium ex aliena per-
 dum trahimus, dum inter homines sumus, colamus
 humanitatem. Non timori cuiquam, non periculo
 simus, detrimenta, iniurias, convicia, vellicationes
-contemnamus et magno animo brevia feramus in-
-commoda. Dum respicimus, quod aiunt, versamus-
-que nos, iam mortalitas aderit.</p>
+contemnamus et magno animo brevia feramus incommoda. Dum respicimus, quod aiunt, versamusque nos, iam mortalitas aderit.</p>
 
                   </div>
                </div>


### PR DESCRIPTION
In Seneca De ira 2, remove all hyphens and combine separated word parts, including those separated by a pb element (move the second part to the prior page). Perform Latin spellcheck, correct typos. Some uncertain (older and variant) spellings remain.