### PR TITLE
Correct typo dent > deerit in phi0474.phi056.perseus-lat1.xml

### DIFF
--- a/data/phi0474/phi056/phi0474.phi056.perseus-lat1.xml
+++ b/data/phi0474/phi056/phi0474.phi056.perseus-lat1.xml
@@ -9991,7 +9991,7 @@ quam coniunctissimos. </p></div3>
 <div3 type="section" n="5"><p>
 <reg>quibus</reg> me voluisti agere gratias egi et me a te certiorem factum esse scripsi.
 
-<milestone unit="para"/><reg>quod</reg> ad me, mea Terentia, scribis te vicum vendituram, quid, obsecro te, me miserum! quid futurum est? et si nos premet eadem fortuna, quid puero misero fiet? <reg>non</reg> queo reliqua scribere ; tanta vis lacrimarum est ; neque te in eundem fletum adducam ; tantum scribo : <reg>si</reg> erunt in officio amici, pecunia non dent ; si non erunt, tu efficere tua pecunia non poteris.  <reg>per</reg> fortunas miseras nostras, vide ne puerum perditum perdamus ; cui si aliquid erit ne egeat, mediocri virtute opus est et mediocri fortuna ut
+<milestone unit="para"/><reg>quod</reg> ad me, mea Terentia, scribis te vicum vendituram, quid, obsecro te, me miserum! quid futurum est? et si nos premet eadem fortuna, quid puero misero fiet? <reg>non</reg> queo reliqua scribere ; tanta vis lacrimarum est ; neque te in eundem fletum adducam ; tantum scribo : <reg>si</reg> erunt in officio amici, pecunia non deerit ; si non erunt, tu efficere tua pecunia non poteris.  <reg>per</reg> fortunas miseras nostras, vide ne puerum perditum perdamus ; cui si aliquid erit ne egeat, mediocri virtute opus est et mediocri fortuna ut
 
 cetera consequatur. </p></div3>
 


### PR DESCRIPTION
This is a possible Latin form (so it would pass any spellcheck), but wrong in the context; I compared it with several editions on the internet.