### PR TITLE
Revert "Correct markup (add missing closing tags for head elements)"

### DIFF
--- a/data/phi0972/phi001f/phi0972.phi001f.perseus-lat1.xml
+++ b/data/phi0972/phi001f/phi0972.phi001f.perseus-lat1.xml
@@ -57,7 +57,7 @@
     <item>split composite text and converted to unicode</item>
       </change>--><change when="2014-08-01" who="Stella Dee">edited markup</change></revisionDesc>
     </teiHeader><text xml:lang="la"><body>
-<div type="section" n="1"><head>I</head>
+<div type="section" n="1"><head>I
 <p><hi rend="italics">Servius ad Vergili Aen. III 57:</hi> <lemma>auri sacra fames</lemma> sacra id
 est execrabilis. Tractus est autem sermo ex more Gallorum. Nam Massilienses quotiens
 pestilentia laborabant, unus se ex pauperibus offerebat alendus anno integro
@@ -66,20 +66,20 @@ verbenis et vestibus sacris circumducebatur per totam civitatem cum exsecrationi
 ut in ipsum reciderent mala totius civitatis, et sic proiciebatur. Hoc autem in
 Petronio lectum est</p>
 </div>
-<div type="section" n="2"><head>II</head>
+<div type="section" n="2"><head>II
 <p><hi rend="italics">Servius ad Vergili Aen. XII 159 de feminino nominum in</hi> <term>tor</term>
 <hi rend="italics">exeuntium genere:</hi> Si autem a verbo non venerint,
 communia sunt. Nam similiter et masculina et feminina in <term>tor</term> exeunt, ut hic et haec
 senator, hic et haec balneator, licet Petronius usurpaverit
 <quote>balneatricem</quote> dicens</p>
 </div>
-<div type="section" n="3"><head>III</head>
+<div type="section" n="3"><head>III
 <p><hi rend="italics">Pseudacro ad Horati epod.</hi> 5, 48: <lemma>Canidia rodens pollicem</lemma>
 habitum et motum Canidiae expressit furentis. Petronius ut monstraret furentem,
 <quote>pollice</quote> ait <quote>usque ad periculum roso</quote></p>
 </div>
 <pb id="p.326"/>
-<div type="section" n="4"><head>IV</head>
+<div type="section" n="4"><head>IV
 <p>
 <hi rend="italics">Sidonius Apollinaris carminis XXIII:</hi>
 </p>
@@ -91,78 +91,78 @@ habitum et motum Canidiae expressit furentis. Petronius ut monstraret furentem,
 <l>Hellespontiaco parem Priapo?</l>
 </quote>
 </div>
-<div type="section" n="5"><head>V</head>
+<div type="section" n="5"><head>V
 <p><hi rend="italics">Priscianus institutionum VIII</hi> 16 <hi rend="italics">p.</hi>
 381 <hi rend="italics">et XI</hi> 29<hi rend="italics">p.</hi> 567 <hi
 rend="italics">Hertzii inter exempla quibus deponentium verborum participia
 praeteriti temporis passivam significationem habere declarat:</hi> Petronius
 <quote>animam nostro amplexam pectore</quote></p>
 </div>
-<div type="section" n="5b"><head>V<hi rend="super">b</hi></head>
+<div type="section" n="5b"><head>V<hi rend="super">b</hi>
 <p><hi rend="italics">Boethius in Porphyrium a Victorino translatum dialogo II extreme
 p. 45 exemplarium Basiliensium:</hi> Ego faciam, inquit, libentissime. Sed
 quoniam iam matutinus, ut ait Petronius, sol tectis arrisit, surgamus, et si quid
 est illud, diligentiore postea consideratione tractabitur</p>
 </div>
-<div type="section" n="6"><head>VI<hi rend="super">*</hi></head>
+<div type="section" n="6"><head>VI<hi rend="super">*</hi>
 <p><hi rend="italics">Fulgentius mythologiarum I p. 23 Munckeri:</hi> Nescis . . quantum
 saturam matronae formident. Licet mulierum verbialibus undis et causidici cedant nec
 grammatici muttiant, rhetor taceat et clamorem praeco compescat, sola est quae modum
 imponit furentibus, licet Petroniana subet Albucia</p>
 </div>
 <pb id="p.328"/>
-<div type="section" n="7"><head>VII<hi rend="super">*</hi></head>
+<div type="section" n="7"><head>VII<hi rend="super">*</hi>
 <p><hi rend="italics">Fulgentius mythologiarum III 8 p. 124 ubi sucum myrrhae valde
 fervidum esse dixit:</hi> Unde et Petronius Arbiter ad libidinis concitamentum
 myrrhinum se poculum bibisse refert</p>
 </div>
-<div type="section" n="8"><head>VIII<hi rend="super">*</hi></head>
+<div type="section" n="8"><head>VIII<hi rend="super">*</hi>
 <p><hi rend="italics">Fulgentius in expositione Virgilianae continentiaep. 156:</hi>
 Tricerberi enim fabulam iam superius exposuimus in modum iurgii forensisque litigii
 positam. Unde et Petronius in Euscion ait <quote>Cerberus forensis erat
 causidicus</quote></p>
 </div>
-<div type="section" n="9"><head>IX<hi rend="super">*</hi></head>
+<div type="section" n="9"><head>IX<hi rend="super">*</hi>
 <p><hi rend="italics">Fulgentius in expositione sermonum antiquorum 42 p. 565
 Merceri:</hi> Ferculum dicitur missum carnium. Unde et Petronius Arbiter ait
 <quote>postquam ferculum allatum est</quote></p>
 </div>
-<div type="section" n="10"><head>X<hi rend="super">*</hi></head>
+<div type="section" n="10"><head>X<hi rend="super">*</hi>
 <p><hi rend="italics">Fuigentius ibidem 46 p. 565:</hi> Valgia vero sunt labellorum
 obtortiones in supinatione factae. Sicut et Petronius ait <quote>obtorto valgiter
 labello</quote></p>
 </div>
-<div type="section" n="11"><head>XI<hi rend="super">*</hi></head>
+<div type="section" n="11"><head>XI<hi rend="super">*</hi>
 <p><hi rend="italics">Fulgentius ibidem 52 p. 566:</hi> Alucinare dicitur vana somniari,
 tractum ab alucitis, quos nos conopes dicimus. Sicut Petronius Arbiter ait
 <quote>nam contubernalem alucitae molestabant</quote></p>
 </div>
 <pb id="p.330"/>
-<div type="section" n="12"><head>XII<hi rend="super">*</hi></head>
+<div type="section" n="12"><head>XII<hi rend="super">*</hi>
 <p><hi rend="italics">Fulgentius ibidem 60 p. 567:</hi> Manubiae dicuntur ornamenta
 regum. Unde et Petronius Arbiter ait <quote>tot regum manubiae penes fugitivum
 repertae</quote></p>
 </div>
-<div type="section" n="13"><head>XIII<hi rend="super">*</hi></head>
+<div type="section" n="13"><head>XIII<hi rend="super">*</hi>
 <p><hi rend="italics">Fulgentius ibidem 61 p. 567:</hi> Aumatium dicitur locum secretum
 publicum sicut in theatris aut in circo. Unde et Petronius Arbiter ait <quote>in
 aumatium memet ipsum conieci</quote></p>
 </div>
-<div type="section" n="14"><head>XIV</head>
+<div type="section" n="14"><head>XIV
 <p><hi rend="italics">Isidorus originum V</hi> 26, 7: Dolus est mentis calliditas ab eo
 quod deludat: aliud enim agit, aliud simulat. Petronius aliter existimat dicens
 <quote>quid est, iudices, dolus? Nimirum ubi aliquid factum est quod legi dolet.
 Habetis dolum: accipite nunc malum</quote></p>
 </div>
-<div type="section" n="15"><head>XV</head>
+<div type="section" n="15"><head>XV
 <p><hi rend="italics">Glossarium S. Dionysii:</hi> Petaurus genus ludi. Petronius
 <quote>petauroque iubente modo superior.</quote></p>
 </div>
-<div type="section" n="16"><head>XVI</head>
+<div type="section" n="16"><head>XVI
 <p>Petronius <quote>satis constaret eos nisi inclinatos non solere transire cryptam
 Neapolitanam</quote><hi rend="italics">ex glossario S. Dionysii.</hi></p>
 </div>
-<div type="section" n="17"><head>XVII<hi rend="super">*</hi></head><note>Wrongly attributed to Petronius by Pithoeus through
+<div type="section" n="17"><head>XVII<hi rend="super">*</hi><note>Wrongly attributed to Petronius by Pithoeus through
 misunderstanding a marginal note of Scaliger.</note>
 <p>
 <hi rend="italics">In alio glossario:</hi>
@@ -173,14 +173,14 @@ misunderstanding a marginal note of Scaliger.</note>
 </quote>
 </div>
 <pb id="p.332"/>
-<div type="section" n="18"><head>XVIII<hi rend="super">*</hi></head>
+<div type="section" n="18"><head>XVIII<hi rend="super">*</hi>
 <p><hi rend="italics">Nicotaus Perottus Cornu copiae p.</hi> 200, 26 <hi rend="italics"
 >editionis Aldinae anni</hi> 1513: Cosmus etiam excellens unguentarius fuit, a
 quo unguenta dicta sunt Cosmiana. idem <del><hi rend="italics">luvenalis</hi> 8, 86</del>
 <quote>Cet Cosmi toto mergatur aheno.</quote> Petronius <quote>affer nobis,
 inquit, alabastrum Cosmiani</quote></p>
 </div>
-<div type="section" n="19"><head>XIX</head>
+<div type="section" n="19"><head>XIX
 <p>
 <hi rend="italics">Terentianus Maurus de metris:</hi>
 </p>
@@ -208,7 +208,7 @@ cognovimus, ut et apud Arbitrum invenimus, cuius exemplum
 </quote></note>
 </div>
 <pb id="p.334"/>
-<div type="section" n="20"><head>XX</head>
+<div type="section" n="20"><head>XX
 <p>
 <hi rend="italics">Terentianus Maurus de metris:</hi>
 </p>
@@ -232,7 +232,7 @@ cognovimus, ut et apud Arbitrum invenimus, cuius exemplum
 <l>rapidum pererret orbem”</l>
 </quote>
 </div>
-<div type="section" n="21"><head>XXI</head>
+<div type="section" n="21"><head>XXI
 <p><hi rend="italics">Diomedes in arte IIIp. 518 Keilii:</hi> Et illud hinc est comma
 quod Arbiter fecit tale</p>
 <quote rend="blockquote">
@@ -240,7 +240,7 @@ quod Arbiter fecit tale</p>
 <l>trementibus labellis”</l>
 </quote>
 </div>
-<div type="section" n="22"><head>XXII</head>
+<div type="section" n="22"><head>XXII
 <p><hi rend="italics">Servius in artem Donati p. 432,22 Keilii:</hi> Item Quirites dicit
 numero tantum plurali. Sed legimus apud Horatium hunc Quiritem, ut sit nominativus
 hic<pb id="p.336"/> Quiris. Item idem Horatius <quote>quis te
@@ -250,12 +250,12 @@ Quiritem?</quote> cuius nominativus erit hic Quirites, ut dicit Petronius</p>
 Legite in Petronio, et invenietis de nominativo singulari hoc factum. Et ait
 Petronius <quote>hic Quirites</quote></p>
 </div>
-<div type="section" n="23"><head>XXIII</head>
+<div type="section" n="23"><head>XXIII
 <p><hi rend="italics">grammaticus de dubiis nominibus p.</hi> 578,23 <hi rend="italics"
 >K:</hi> Fretum generis neutri et pluraliter freta, ut Petronius <quote>freta
 Nereidum</quote></p>
 </div>
-<div type="section" n="24"><head>XXIV<hi rend="super">*</hi></head>
+<div type="section" n="24"><head>XXIV<hi rend="super">*</hi>
 <p><milestone unit="section" n="19"/>
 <hi rend="italics">Hieronymus in epistula ad
 Demetriadem CXXX p.</hi> 995 <hi rend="italics">Vallarsii:</hi> Cincinnatulos
@@ -266,7 +266,7 @@ Arbitri est<quote rend="blockquote">
 </l>
 </quote> quasi quasdam pestes et venena pudicitiae virgo devitet</p>
 </div>
-<div type="section" n="25"><head>XXV<hi rend="super">*</hi></head>
+<div type="section" n="25"><head>XXV<hi rend="super">*</hi>
 <p><hi rend="italics">Fulgentius mythologiarum II 6 p. 80 de Prometheo:</hi> Quamvis
 Nicagoras <gap/> quod vulturi iecur praebeat, livoris quasi pingat imaginem. Unde et
 Petronius Arbiter ait<quote rend="blockquote">


### PR DESCRIPTION
Reverts PerseusDL/canonical-latinLit#221