### PR TITLE
(1017.013.lat2) Remove hyphenation

### DIFF
--- a/data/phi1017/phi013/phi1017.phi013.perseus-lat2.xml
+++ b/data/phi1017/phi013/phi1017.phi013.perseus-lat2.xml
@@ -63,6 +63,7 @@
   <revisionDesc>
    <change when="2009-01-01" who="gcrane">Tagging</change>
    <change when="2015-11-12" who="Thibault Clerice">New URN, Epidoc and CTS</change>
+   <change when="2018-05-07" who="Thibault Clerice">Removed hyphenation (pb are now after the complete word)</change>
   </revisionDesc>
  </teiHeader>
  <text>
@@ -102,7 +103,7 @@
       <div type="textpart" subtype="section" n="4">
        <p> Multos experimur ingratos, plures facimus, quia alias graves exprobratores exactoresque
         sumus, alias leves et quos paulo post muneris sui paeniteat, alias queruli et minima momenta
-        calumniantes. Gratiam omnem corrumpimus non tantum postquam dedimus bene- ficia, sed dum
+        calumniantes. Gratiam omnem corrumpimus non tantum postquam dedimus beneficia, sed dum
         damus. </p>
       </div>
 
@@ -110,12 +111,12 @@
        <p> Quis nostrum contentus fuit aut leviter rogari aut semel ? Quis non, cum aliquid a se
         peti suspicatus est, frontem adduxit, vultum avertit, occupationes simulavit, longis
         sermonibus et de industria non invenientibus exitum occasionem petendi abstulit et variis
-        artibus necessitates prope- rantes elusit ; </p>
+        artibus necessitates properantes elusit ; </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
        <p> in angusto vero comprensus aut distulit, id est timide negavit, aut promisit, sed
-        difficulter, sed subductis superciliis, sed malignis et vix exeunti- bus verbis ? </p>
+        difficulter, sed subductis superciliis, sed malignis et vix exeuntibus verbis ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="7">
@@ -243,7 +244,7 @@
         manibus in se redeuntium chorus ? Ob hoc, quia ordo beneficii <pb xml:id="p.14"/> per manus
         transeuntis nihilo minus ad dantem revertitur et totius speciem perdit, si usquam
         interruptus est, pulcherrimus, si cohaeret et vices servat. In eo est aliqua tamen maioris
-        dignatio, sicut pro- merentium. </p>
+        dignatio, sicut promerentium. </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">
@@ -301,7 +302,7 @@
         ut ne circa rem quidem sint, relinquam. Tu modo nos tuere, si quis mihi obiciet, quod
         Chrysippum in ordinem coegerim, magnum mehercules virum, sed tamen Graecum, cuius acumen
         nimis tenue retunditur et in se saepe replicatur ; etiam cum agere aliquid videtur, pungit,
-        non per- forat. Hic vero quod acumen est ? </p>
+        non perforat. Hic vero quod acumen est ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -321,14 +322,14 @@
       <div type="textpart" subtype="section" n="4">
        <p> Ad hanc honestissimam contentionem beneficiis beneficia vincendi sic nos adhortatur
         Chrysippus, ut dicat verendum esse, ne, quia Charites Iovis filiae sunt, parum se grate
-        gerere sacri- legium sit et tam bellis puellis fiat iniuria ! </p>
+        gerere sacrilegium sit et tam bellis puellis fiat iniuria ! </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">
        <p> Tu me aliquid eorum doce, per quae beneficentior gratiorque adversus bene merentes fiam,
         per quae obligantium <pb xml:id="p.20"/> obligatorumque animi certent, ut, qui
         praestiterunt, obliviscantur, pertinax sit memoria debentium. Istae vero ineptiae poetis
-        relinquantur, quibus aures oblec- tare propositum est et dulcem fabulam nectere. </p>
+        relinquantur, quibus aures oblectare propositum est et dulcem fabulam nectere. </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
@@ -344,7 +345,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Sed quemadmodum supervacua transcurram, ita exponam necesse est hoc primum nobis esse
         discendum, quid accepto beneficio debeamus. Debere enim se ait<note> ait added by Madvig.
-        </note> alius pecuniam, quam accepit, alius con- sulatum, alius sacerdotium, alius
+        </note> alius pecuniam, quam accepit, alius consulatum, alius sacerdotium, alius
         provinciam. </p>
       </div>
 
@@ -610,7 +611,7 @@
       <div type="textpart" subtype="section" n="3">
        <p> Nemo tam stultus est, ut monendus sit, ne cui gladiatores aut venationem iam munere edito
         mittat et vestimenta aestiva bruma, hiberna solstitio. Sit in beneficio sensus communis ;
-        tempus, locum ob- <pb xml:id="p.40"/> servet, personas, quia momentis quaedam grata et
+        tempus, locum observet<pb xml:id="p.40"/>, personas, quia momentis quaedam grata et
         ingrata sunt. Quanto acceptius est, si id damus, quod quis non habet, quam cuius copia
         abundat, quod diu quaerit nec invenit, quam quod ubique visurus est ! </p>
       </div>
@@ -637,7 +638,7 @@
         cogitavit, non qui sibi civitatem darent, sed cui dedissent ; et homo gloriae deditus, cuius
         nec naturam nec modum noverat. Herculis Liberique vestigia sequens ac ne ibi quidem
         resistens, ubi illa defecerant, ad socium honoris sui respexit a dantibus, tamquam caelum,
-        quod mente vanissima complecte- <pb xml:id="p.42"/> batur, teneret, quia Herculi aequabatur
+        quod mente vanissima complectebatur<pb xml:id="p.42"/>, teneret, quia Herculi aequabatur
         ! </p>
       </div>
 
@@ -818,7 +819,7 @@
        <p> At plerique sunt, qui beneficia asperitate verborum et supercilio in odium adducunt eo
         sermone usi, ea superbia, ut impetrasse paeniteat. Aliae deinde post rem promissam secuntur
         morae ; nihil autem est acerbius, quam ubi quoque, quod<note> quod commonly added. </note>
-        im- petrasti, rogandum est. </p>
+        impetrasti, rogandum est. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -903,7 +904,7 @@
        <p> Ti. Caesar rogatus a Nepote Mario praetorio, ut aeri alieno eius succurreret, edere illum
         sibi nomina creditorum iussit ; hoc non est donare sed creditores convocare. Cum edita
         essent, scripsit Nepoti iussisse se pecuniam solvi adiecta contumeliosa admonitione.
-        Effecit, ut Nepos nec aes alienum haberet nec bene- <pb xml:id="p.62"/> fidum; liberavit
+        Effecit, ut Nepos nec aes alienum haberet nec benefidum<pb xml:id="p.62"/>; liberavit
         illum a creditoribus, sibi non obligavit. Aliquid Tiberius secutus est ; </p>
       </div>
 
@@ -1012,7 +1013,7 @@
       <div type="textpart" subtype="section" n="4">
        <p> Deinde adicienda omnis humanitas. Perdet agricola, quod sparsit, si labores suos
         destituit in semine; multa cura sata perducuntur ad segetem ; nihil in fructum pervenit,
-        quod non a primo usque ad ex- tremum aequalis cultura prosequitur. Eadem beneficiorum
+        quod non a primo usque ad extremum aequalis cultura prosequitur. Eadem beneficiorum
         condicio est. </p>
       </div>
 
@@ -1028,7 +1029,7 @@
       <div type="textpart" subtype="section" n="6">
        <p> Nihil aeque in beneficio dando vitandum est quam superbia. Quid opus arrogantia vultus,
         quid tumore verborum? Ipsa res te extollit. Detrahenda est inanis iactatio; res loquentur
-        nobis tacentibus. Non tantum in- gratum, sed invisum est beneficium superbe datum. </p>
+        nobis tacentibus. Non tantum ingratum, sed invisum est beneficium superbe datum. </p>
       </div>
      </div>
 
@@ -1073,7 +1074,7 @@
 
       <div type="textpart" subtype="section" n="3">
        <p> Uno modo istis persuadebimus, ne beneficia sua insolentia perdant, si ostenderimus non
-        ideo videri maiora, quod tumul- <pb xml:id="p.74"/> tuosius data sunt ; ne ipsos quidem ob
+        ideo videri maiora, quod tumultuosius<pb xml:id="p.74"/> data sunt ; ne ipsos quidem ob
         id cuiquam posse maiores videri; vanam esse superbiae magnitudinem et quae in odium etiam
         amanda perducat. </p>
       </div>
@@ -1086,7 +1087,7 @@
         aestimabimus itaque utilitatem potius quam voluntatem petentium. Saepe enim noxia
         concupiscimus, nec dispicere, quam perniciosa sunt, licet, quia iudicium interpellat
         adfectus ; sed cum subsedit cupiditas, cum impetus ille flagrantis animi, qui consilium
-        fugat, cecidit, detes- tamur perniciosos malorum munerum auctores. </p>
+        fugat, cecidit, detestamur perniciosos malorum munerum auctores. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -1094,7 +1095,7 @@
         contra se usurus ardor petit, sic omnino,<note> omnino Préchac after Gertz: omnium N, Hosius
          : omnia most editors. </note> quae nocitura sunt, impense ac summisse,non numquam etiam
         miserabiliter rogantibus perseverabimus non dare. Cum initia beneficiorum suorum spectare
-        tum etiam exitus decet et ea dare, quae non tantum accipere, sed etiam acce- pisse delectet.
+        tum etiam exitus decet et ea dare, quae non tantum accipere, sed etiam accepisse delectet.
         Multi sunt, qui dicant : </p>
       </div>
 
@@ -1135,7 +1136,7 @@
       <div type="textpart" subtype="section" n="2">
        <p> Nullum beneficium dabo, quod turpiter peterem. Nec exiguum dilatabo nec magna pro parvis
         accipi patiar ; nam ut qui, quod dedit,<note> dedit commonly added. </note> imputat, gratiam
-        destruit, ita qui, quantum det, ostendit, munus suum commendat, non expro- brat. </p>
+        destruit, ita qui, quantum det, ostendit, munus suum commendat, non exprobrat. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -1181,7 +1182,7 @@
       <div type="textpart" subtype="section" n="2">
        <p> Si me interrogas, probo ; est enim intolerabilis res poscere nummos et contemnere.
         Indixisti pecuniae odium; hoc professus es, hanc personam induisti : agenda est.
-        Iniquissimum est te pecuniam sub gloria egestatis ad- <pb xml:id="p.82"/> quirere.
+        Iniquissimum est te pecuniam sub gloria egestatis adquirere<pb xml:id="p.82"/>.
         Adspicienda ergo non minus sua cuique persona est quam eius, de quo iuvando quis cogitat.
        </p>
       </div>
@@ -1272,7 +1273,7 @@
 
       <div type="textpart" subtype="section" n="6">
        <p> " Non semper," inquit, " mihi licet dicere : ' nolo '; aliquando beneficium accipiendum
-        est et invito. Dat tyrannus crudelis et iracundus, qui munus suum fasti- dire te iniuriam
+        est et invito. Dat tyrannus crudelis et iracundus, qui munus suum fastidire te iniuriam
         iudicaturus est : non accipiam ? Eodem loco latronem pone, piratam, regem animum latronis ac
         piratae habentem. Quid faciam ? Parum dignus est, cui debeam ? </p>
       </div>
@@ -1281,7 +1282,7 @@
        <p> " Cum eligendum dico, cui debeas, vim maiorem et metum excipio, quibus adhibitis electio
         perit. Si liberum est tibi, si arbitrii tui est, utrum velis an non, id apud te ipse
         perpendes ; si necessitas tollit arbitrium, scies te non accipere, sed parere. Nemo id
-        accipiendo obligatur, quod illi re- <pb xml:id="p.90"/> pudiare non licuit ; si vis scire,
+        accipiendo obligatur, quod illi repudiare<pb xml:id="p.90"/> non licuit ; si vis scire,
         an velim, effice, ut possim nolle. " Vitam tamen tibi dedit ! </p>
       </div>
 
@@ -1342,8 +1343,7 @@
 
       <div type="textpart" subtype="section" n="1">
        <p> Illud magis venire in aliquam disputationem potest, quid faciendum sit captivo, cui
-        redemptionis pretium homo prostituti corporis et infamis ore pro- <pb xml:id="p.94"/>
-        mittit. Patiar me ab impuro servari ? Servatus deinde quam illi gratiam referam ? Vivam cum
+        redemptionis pretium homo prostituti corporis et infamis ore promittit<pb xml:id="p.94"/>. Patiar me ab impuro servari ? Servatus deinde quam illi gratiam referam ? Vivam cum
         obsceno ? Non vivam cum redemptore ? Quid ergo placeat, dicam. </p>
       </div>
 
@@ -1401,7 +1401,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Sunt quidam, qui nolint nisi secreto accipere ; testem beneficii et conscium vitant ;
         quos scias licet male cogitare. Quomodo danti in tantum producenda notitia est muneris sui,
-        in quantum de- <pb xml:id="p.98"/> lectatura est, cui datur, ita accipienti adhibenda contio
+        in quantum delectatura<pb xml:id="p.98"/> est, cui datur, ita accipienti adhibenda contio
         est ; quod pudet debere, ne acceperis. Quidam furtive gratias agunt et in angulo et ad aurem
         ; </p>
       </div>
@@ -1410,7 +1410,7 @@
        <p> non est ista verecundia, sed infitiandi genus ; ingratus est, qui remotis arbitris agit
         gratias. Quidam nolunt nomina secum fieri nec interponi pararios nec signatores advocari,
          chirographum<note> chirographum N, Préchac: vix chirographum Hosius after Havet. </note>
-        dare. Idem faciunt, qui dant operam, ut beneficium in ipsos conlatum quam ignotis- simum
+        dare. Idem faciunt, qui dant operam, ut beneficium in ipsos conlatum quam ignotissimum
         sit. </p>
       </div>
 
@@ -1562,7 +1562,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Vide, quam iniqui sint divinorum munerum aestimatores et quidem professi sapientiam.
         Queruntur, quod non magnitudine corporum aequemus elephantos, velocitate cervos, levitate
-        aves, impetu tauros ; quod solida sit cutis beluis, decentior dam- <pb xml:id="p.108"/> mis,
+        aves, impetu tauros ; quod solida sit cutis beluis, decentior dammis<pb xml:id="p.108"/>,
         densior ursis, mollior fibris; quod sagacitate nos narium canes vincant, quod acie luminum
         aquilae, spatio aetatis corvi, multa animalia nandi facilitate. </p>
       </div>
@@ -1576,7 +1576,7 @@
       </div>
 
       <div type="textpart" subtype="section" n="3">
-       <p> Quanto satius est ad contemplationem tot tantorum- que beneficiorum reverti et agere
+       <p> Quanto satius est ad contemplationem tot tantorumque beneficiorum reverti et agere
         gratias, quod nos in hoc pulcherrimo domicilio voluerunt secundas sortiri, quod terrenis
         praefecerunt ! Aliquis ea animalia comparat nobis, quorum potestas penes nos est ? Quidquid
         nobis negatum est, dari non potuit. </p>
@@ -1608,7 +1608,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Haec, mi Liberalis, necessaria credidi, et quia loquendum aliquid de maximis beneficiis
         erat, cum de minutis loqueremur, et quia inde manat etiam in cetera huius detestabilis vitii
-        audacia. Cui enim respondebit grate, quod munus existimabit aut ma- gnum aut reddendum, qui
+        audacia. Cui enim respondebit grate, quod munus existimabit aut magnum aut reddendum, qui
         summa beneficia spernit ? Cui salutem, cui spiritum debebit, qui vitam accepisse se a dis
         negat, quam cotidie ab illis petit ? </p>
       </div>
@@ -1638,7 +1638,7 @@
        <p> Quotiens, quod proposuit, quisque consequitur, capit operis sui fructum. Qui beneficium
         dat, quid proponit ? Prodesse ei, cui dat, et voluptati esse. Si, quod voluit, effecit
         pervenitque ad me animus eius ac mutuo gaudio adfecit, tulit, quod petit. Non enim in vicem
-        aliquid sibi reddi voluit ; aut non fuit bene- ficium, sed negotiatio. </p>
+        aliquid sibi reddi voluit ; aut non fuit beneficium, sed negotiatio. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -1693,7 +1693,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Beneficium mihi dedit ; accepi non aliter, quam ipse accipi voluit : iam habet, quod
         petit, et quod unum petit, ergo gratus sum. Post hoc usus mei restat et aliquod ex homine
-        grato commodum ; hoc non imperfecti officii reliqua pars est, sed perfecti ac- cessio. Facit
+        grato commodum ; hoc non imperfecti officii reliqua pars est, sed perfecti accessio. Facit
         Phidias statuam ; </p>
       </div>
 
@@ -1727,7 +1727,7 @@
         commodaveris mihi et cogitaveris plures esse res quam verba. Ingens copia est rerum sine
         nomine, quas non propriis appellationibus notamus, sed alienis commodatisque. Pedem et
         nostrum dicimus et lecti et veli et carminis, canem et venaticum et marinum et sidus ; quia
-        non suffici- mus, ut singulis singula adsignemus, quotiens opus est, mutuamur. </p>
+        non sufficimus, ut singulis singula adsignemus, quotiens opus est, mutuamur. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -1784,7 +1784,7 @@
        <p> " Hic ipse est, quo ille suum ostendit ! Excipe beneficium, amplexare, gaude, non quod
         accipias, sed quod reddas debiturusque sis ; non adibis tam magnae rei periculum, ut casus
         ingratum facere te possit. Nullas tibi proponam difficultates, ne despondeas animum, ne
-        laborum ac longae servitutis expectatione deficias ; non differo te, de praesenti- bus fiat.
+        laborum ac longae servitutis expectatione deficias ; non differo te, de praesentibus fiat.
         Numquam eris gratus, nisi statim es. </p>
       </div>
 
@@ -1820,7 +1820,7 @@
       <div type="textpart" subtype="section" n="3">
        <p> Multa sunt genera ingratorum, ut furum, ut homicidarum, quorum una culpa est, ceterum in
         partibus varietas magna. Ingratus est, qui beneficium accepisse se negat, quod accepit ;
-        ingratus est, qui dis- <pb xml:id="p.128"/> simulat; ingratus, qui non reddit, ingratissimus
+        ingratus est, qui dissimulat<pb xml:id="p.128"/>; ingratus, qui non reddit, ingratissimus
         omnium, qui oblitus est. </p>
       </div>
 
@@ -1917,8 +1917,7 @@
 
       <div type="textpart" subtype="section" n="1">
        <p> Quemadmodum, mi Liberalis, quaedam res semel perceptae haerent, quaedam, ut scias, non
-        est satis didicisse (intercidit enim eorum scientia, nisi con- <pb xml:id="p.134"/>
-        tinuetur), geometriam dico et sublimium cursum et si qua alia propter suptilitatem lubrica
+        est satis didicisse (intercidit enim eorum scientia, nisi continuetur<pb xml:id="p.134"/>), geometriam dico et sublimium cursum et si qua alia propter suptilitatem lubrica
         sunt, ita beneficia quaedam magnitudo non patitur excidere, quaedam minora sed numero
         plurima et temporibus diversa effluunt, quia, ut dixi, non subinde illa tractamus nec
         libenter, quid cuique debeamus, recognoscimus. </p>
@@ -1944,8 +1943,7 @@
       </div>
 
       <div type="textpart" subtype="section" n="2">
-       <p> Nostri maiores, maximi scilicet viri, ab hostibus tantum res repe- <pb xml:id="p.136"/>
-        tierunt, beneficia magno animo dabant, magno perdebant; excepta Macedonum gente non est in
+       <p> Nostri maiores, maximi scilicet viri, ab hostibus tantum res repetierunt<pb xml:id="p.136"/>, beneficia magno animo dabant, magno perdebant; excepta Macedonum gente non est in
         ulla data adversus ingratum actio. Magnumque hoc argumentum est dandam non fuisse, quia
         adversus maleficium omne consensimus, et homicidii, veneficii, parricidii, violatarum
         religionum aliubi atque aliubi diversa poena est, sed ubique aliqua, hoc frequentissimum
@@ -1996,7 +1994,7 @@
 
       <div type="textpart" subtype="section" n="6">
        <p> refert, quam benigne illud interpretetur iudex. Quid sit ingratus, nulla lex monstrat ;
-        saepe et qui reddidit, quod accepit, in- gratus est, et qui non reddidit, gratus. </p>
+        saepe et qui reddidit, quod accepit, ingratus est, et qui non reddidit, gratus. </p>
       </div>
 
       <div type="textpart" subtype="section" n="7">
@@ -2021,7 +2019,7 @@
         sed toto patrimonio cessurus. Summa eadem est, beneficium idem non est. Etiamnunc adice :
         hic pecuniam pro addicto dependit, sed cum illam domo protulisset; ille dedit eandem, sed
         mutuam sumpsit aut rogavit et se obligari ingenti merito passus est. Eodem existimas loco
-        esse illum, qui beneficium ex facili largitus est, et hunc, qui ac- cepit, ut daret ? </p>
+        esse illum, qui beneficium ex facili largitus est, et hunc, qui accepit, ut daret ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -2036,7 +2034,7 @@
       <div type="textpart" subtype="section" n="4">
        <p> Dedit hic mihi beneficium, sed non libenter, sed dedisse se questus est, sed superbius
         me, quam solebat, adspexit, sed tam tarde dedit, ut plus praestaturus fuerit, si cito
-        negasset. Horum quomodo iudex inibit aestimatio- nem, cum sermo et dubitatio et vultus
+        negasset. Horum quomodo iudex inibit aestimationem, cum sermo et dubitatio et vultus
         meriti gratiam destruant ? </p>
       </div>
      </div>
@@ -2052,7 +2050,7 @@
        <p> Beneficium vocas dedisse potentis populi civitatem, in quattuordecim deduxisse et
         defendisse capitis reum. Quid utilia suasisse ? Quid retinuisse, ne in scelus rueret ? Quid
         gladium excussisse morituro ? Quid efficacibus remediis lugentem et, quos desiderabat. <pb
-         xml:id="p.144"/> volentem sequi ad vitae consilium reduxisse ? Quid ad- sedisse aegro et,
+         xml:id="p.144"/> volentem sequi ad vitae consilium reduxisse ? Quid adsedisse aegro et,
         cum valetudo eius ac salus momentis constaret, excepisse idonea cibo tempora et cadentes
         venas vino refecisse et medicum adduxisse morienti ? </p>
       </div>
@@ -2080,8 +2078,7 @@
       <div type="textpart" subtype="section" n="3">
        <p> Quam deinde poenam ingratis constituimus ? Unam omnibus, cum disparia sint ? Inaequalem
         et pro cuiusque beneficio maiorem, aut minorem ? Age, intra pecuniam versabitur taxatio.
-        Quid, quod quaedam vitae beneficia sunt et maiora vita ? His quae pro- <pb xml:id="p.146"/>
-        nuntiantur poena ? Minor beneficio ? Iniqua est. Par et capitalis ? Quid inhumanius quam
+        Quid, quod quaedam vitae beneficia sunt et maiora vita ? His quae pronuntiantur<pb xml:id="p.146"/> poena ? Minor beneficio ? Iniqua est. Par et capitalis ? Quid inhumanius quam
         cruentos esse beneficiorum exitus ? </p>
       </div>
      </div>
@@ -2112,7 +2109,7 @@
 
       <div type="textpart" subtype="section" n="3">
        <p> Deinde omnium parentium unum erat beneficium, itaque aestimari semel potuit ; alia
-        diversa sunt, dis- similia, infinitis inter se intervallis distantia; itaque sub nullam
+        diversa sunt, dissimilia, infinitis inter se intervallis distantia; itaque sub nullam
         regulam cadere potuerunt, cum aequius esset omnia relinqui quam omnia aequari. </p>
       </div>
      </div>
@@ -2136,8 +2133,8 @@
       <div type="textpart" subtype="section" n="3">
        <p> Praeterea creditorem mihi ipse eligo, beneficium saepe ab eo accipio, a quo nolo, et
         aliquando ignorans obligor. Quid facies ? Ingratum vocabis eum, cui beneficium inscio et, si
-        scisset, non accepturo impositum est ? Non vocabis eum, qui utcumque ac- <pb xml:id="p.150"
-        /> ceptum non reddidit ? </p>
+        scisset, non accepturo impositum est ? Non vocabis eum, qui utcumque acceptum<pb xml:id="p.150"
+        /> non reddidit ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
@@ -2207,8 +2204,8 @@
 
       <div type="textpart" subtype="section" n="2">
        <p> Sed necessaria optimis praetulerunt et cogere fidem quam expectare malunt. Adhibentur ab
-        utraque parte testes. Ille per tabulas plurium nomina inter- positis parariis facit ; ille
-        non est interrogatione con- <pb xml:id="p.154"/> tentus, nisi reum manu sua tenuit. </p>
+        utraque parte testes. Ille per tabulas plurium nomina interpositis parariis facit ; ille
+        non est interrogatione contentus<pb xml:id="p.154"/>, nisi reum manu sua tenuit. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -2276,8 +2273,7 @@
        <p> Testes ingratorum <pb xml:id="p.158"/> omnium deos metuit, urit illum et angit intercepti
         beneficii conscientia. Denique satis haec ipsa poena magna est, quod rei, ut dicebam,
         iucundissimae fructum non percipit. At quem iuvat accepisse, aequali perpetuaque voluptate
-        fruitur et animum eius, a quo accepit, non rem intuens gaudet. Gratum hominem semper bene-
-        ficium delectat, ingratum semel. </p>
+        fruitur et animum eius, a quo accepit, non rem intuens gaudet. Gratum hominem semper beneficium delectat, ingratum semel. </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
@@ -2359,7 +2355,7 @@
        <p> Vide, ne eo maius <pb xml:id="p.164"/> sit, quo rarius est exemplum virtutis in servis,
         eoque gratius, quod, cum fere invisa imperia sint et omnis necessitas gravis, commune
         servitutis odium in aliquo domini caritas vicit. Ita non ideo beneficium non est, quia a
-        servo profectum est, sed ideo maius, quia de- terrere ab illo ne servitus quidem potuit.
+        servo profectum est, sed ideo maius, quia deterrere ab illo ne servitus quidem potuit.
        </p>
       </div>
      </div>
@@ -2391,7 +2387,7 @@
       </div>
 
       <div type="textpart" subtype="section" n="2">
-       <p> Est aliquid, quod dominus prae- <pb xml:id="p.166"/> stare servo debeat, ut cibaria, ut
+       <p> Est aliquid, quod dominus praestare<pb xml:id="p.166"/> servo debeat, ut cibaria, ut
         vestiarium ; nemo hoc dixit beneficium. At indulsit, liberalius educavit, artes, quibus
         erudiuntur ingenui, tradidit : beneficium est. Idem e contrario fit in persona servi.
         Quidquid est, quod servilis officii formulam excedit, quod non ex imperio, sed ex voluntate
@@ -2442,7 +2438,7 @@
        <p> Claudius Quadrigarius in duodevicensimo annalium tradit, cum obsideretur Grumentum et iam
         ad summam desperationem ventum esset, duos servos ad hostem transfugisse et operae pretium
         fecisse. Deinde urbe capta passim discurrente victore illos per nota itinera ad domum, in
-        qua servierant, praecucurrisse et dominam suam ante egisse ; quaerentibus, quae- nam esset,
+        qua servierant, praecucurrisse et dominam suam ante egisse ; quaerentibus, quaenam esset,
         dominam et quidem crudelissimam ad supplicium ab ipsis duci professes esse. Eductam deinde
         extra mures summa cura celasse, donec hostilis ira consideret ; deinde, ut satiatus miles
         cito ad Romanos mores rediit, illos quoque ad suos redisse et dominam <pb xml:id="p.170"/>
@@ -2460,7 +2456,7 @@
        <p> In tanta confusione captae civitatis eum sibi quisque consuleret, omnes ab illa praeter
         transfugas fugerunt ; at hi, ut ostenderent, quo animo facta esset prior illa transitio, a
         victoribus ad captivam transfugerunt personam parricidarum ferentes ; quod in illo beneficio
-        maximum fuit, tanti iudicaverunt, ne domina occide- retur, videri dominam occidisse. Non
+        maximum fuit, tanti iudicaverunt, ne domina occideretur, videri dominam occidisse. Non
         est, mihi crede, non dico<note> non dico O, Préchac : condicio Hosius. </note> servilis, sed
          vilis<note> sed vilis added by Préchac. </note> animi egregium factum fama sceleris emisse.
        </p>
@@ -2530,7 +2526,7 @@
 
       <div type="textpart" subtype="section" n="2">
        <p> Usus consilio descendenti Caesari occurrit et, cum malam mentem habuisse se pridie
-        iurasset, id ut in se et in filios suos redderet, optavit et Caesarem, ut igno- sceret sibi
+        iurasset, id ut in se et in filios suos redderet, optavit et Caesarem, ut ignosceret sibi
         rediretque in gratiam secum, rogavit. </p>
       </div>
 
@@ -2553,7 +2549,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Post tot exempla num dubium est, quin beneficium aliquando a servo dominus accipiat ?
         Quare potius persona rem minuat, quam personam res ipsa cohonestet ? Eadem omnibus principia
-        eademque origo ; nemo altero nobilior, nisi cui rectius in- genium et artibus bonis aptius.
+        eademque origo ; nemo altero nobilior, nisi cui rectius ingenium et artibus bonis aptius.
        </p>
       </div>
 
@@ -2569,7 +2565,7 @@
        <p> Neminem despexeris, etiam si circa illum obsoleta sunt nomina et parum indulgente adiuta
         fortuna. Sive libertini ante vos <pb xml:id="p.178"/> habentur sive servi sive exterarum
         gentium homines, erigite audacter animos et, quidquid in medio sordidi iacet, transilite ;
-        expectat vos in summo magna nobili- tas. </p>
+        expectat vos in summo magna nobilitas. </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
@@ -2604,7 +2600,7 @@
       </div>
 
       <div type="textpart" subtype="section" n="2">
-       <p> Illud conceditur multos filios maiores potentiores- que extitisse quam parentes suos ;
+       <p> Illud conceditur multos filios maiores potentioresque extitisse quam parentes suos ;
         aeque et illud meliores fuisse. Quod si constat, potest fieri, ut meliora tribuerint, cum et
         fortuna illis maior esset et melior voluntas. </p>
       </div>
@@ -2621,20 +2617,20 @@
        <p> Nulla non res principia sua magno gradu transit. Semina omnium rerum causae sunt et tamen
         minimae partes sunt eorum, quae gignunt. Adspice Rhenum, adspice Euphraten, omnes denique
         inclutos amnes. Quid sunt, si illos illic, unde effluunt, aestimes ? Quidquid est, quo
-        timentur, quo nominan- tur, in processu paraverunt. </p>
+        timentur, quo nominantur, in processu paraverunt. </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">
        <p> Adspice trabes, sive proceritatem aestimes, altissimas, sive crassitudinem spatiumque
         ramorum, latissime fusas. Quantulum est his comparatum illud, quod radix tenui fibra
-        complec- titur ! Tolle radicem : nemora non surgent, nec tanti <pb xml:id="p.182"/> montes
+        complectitur ! Tolle radicem : nemora non surgent, nec tanti <pb xml:id="p.182"/> montes
         vestientur. Innituntur fundamentis suis templa excelsa urbis ; tamen, quae in firmamentum
         totius operis iacta sunt, latent. Idem in ceteris evenit; </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
        <p> principia sua semper sequens magnitudo obruet. Non potuissem quicquam consequi, nisi
-        parentum beneficium antecessisset ; sed non ideo, quidquid con- secutus sum, minus est eo,
+        parentum beneficium antecessisset ; sed non ideo, quidquid consecutus sum, minus est eo,
         sine quo consecutus non essem. </p>
       </div>
 
@@ -2669,7 +2665,7 @@
 
       <div type="textpart" subtype="section" n="3">
        <p> Servavi patrem meum et ad summam provexi dignitatem et principem urbis suae feci nec
-        tantum rebus a me gestis nobilitavi, sed ipsi quoque gerendarum in- gentem ac facilem nec
+        tantum rebus a me gestis nobilitavi, sed ipsi quoque gerendarum ingentem ac facilem nec
         tutam minus quam gloriosam dedi materiam ; honores, opes, quidquid humanos ad se animos
         rapit, congessi, et eum supra omnes starem, infra illum steti. Die nunc : </p>
       </div>
@@ -2742,16 +2738,15 @@
       <div type="textpart" subtype="section" n="4">
        <p> Utrum maius beneficium dedit M. Agrippae pater ne post Agrippam quidem notus, an patri
         dedit Agrippa navali corona insignis, unicum adeptus inter dona militaria decus, qui tot in
-        urbe maxima opera excitavit, quae et priorem magnifi- <pb xml:id="p.190"/> centiam vincerent
+        urbe maxima opera excitavit, quae et priorem magnificentiam<pb xml:id="p.190"/> vincerent
         et nulla postea vincerentur ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">
        <p> Utrum Octavius maius beneficium dedit filio an patri divus Augustus, quamvis illum umbra
         adoptivi patris abscondit ? Quantam cepisset voluptatem, si illum post debellata arma
-        civilia vidisset securae paci prae- sidentem, non adgnoscens bonum suum nec satis credens,
-        quotiens ad se respexisset, potuisse illum virum in domo sua nasci ! Quid nunc ceteros pro-
-        sequar, quos iam consumpsisset oblivio, nisi illos filiorum gloria e tenebris eruisset et
+        civilia vidisset securae paci praesidentem, non adgnoscens bonum suum nec satis credens,
+        quotiens ad se respexisset, potuisse illum virum in domo sua nasci ! Quid nunc ceteros prosequar, quos iam consumpsisset oblivio, nisi illos filiorum gloria e tenebris eruisset et
         adhuc in luce retineret ? </p>
       </div>
 
@@ -2770,7 +2765,7 @@
        <p> Servavit in proelio patrem Scipio et praetextatus in hostes ecum concitavit. Parum est,
         quod, ut perveniret ad patrem, tot pericula maximos duces eum maxime prementia contempsit,
         tot oppositas difficultates, quod ad primam pugnam exiturus tiro per <pb xml:id="p.192"/>
-        veteranorum corpora cucurrit, quod annos suos tran- siluit ? </p>
+        veteranorum corpora cucurrit, quod annos suos transiluit ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -3049,7 +3044,7 @@
        <p> " Non dat deus beneficia." Unde ergo ista, quae possides, quae das, quae negas, quae
         servas, quae rapis ? Unde haec innumerabilia oculos, aures, <pb xml:id="p.212"/> animum
         mulcentia ? Unde illa luxuriam quoque instruens copia (neque enim necessitatibus tantummodo
-        nostris provisum est ; usque in delicias ama- mur) ? </p>
+        nostris provisum est ; usque in delicias amamur) ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -3181,7 +3176,7 @@
         dandis sequimur, quemadmodum in arando serendoque ; neque enim serere per se res expetenda
         est. Praeterea quaeritis, ubi et quomodo detis<note> ubi et quomodo detis added by Gertz.
         </note> beneficium, quod non esset faciendum, si per se beneficium dare expetenda res esset,
-        quoniam, quocumque loco et quocumque modo da- retur, beneficium erat." </p>
+        quoniam, quocumque loco et quocumque modo daretur, beneficium erat." </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -3408,7 +3403,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Idem isti gratiam referre ipsos fatentur, non quia honestum est, sed quia utile. Quod non
         esse ita minore opera probandum est, quia, quibus argumentis collegimus beneficium dare per
-        se rem ex- petendam esse, isdem etiam hoc colligimus. </p>
+        se rem expetendam esse, isdem etiam hoc colligimus. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -3674,8 +3669,7 @@
 
       <div type="textpart" subtype="section" n="1">
        <p> Quid ergo ? Non caperis tantae molis adspectu, etiam si te non tegat, non custodiat, non
-        foveat generetque ac spiritu suo riget ? Quemadmodum haec cum primum usum habeant et neces-
-         <pb xml:id="p.254"/> saria vitaliaque sint, maiestas tamen eorum totam mentem occupat, ita
+        foveat generetque ac spiritu suo riget ? Quemadmodum haec cum primum usum habeant et necessaria<pb xml:id="p.254"/> vitaliaque sint, maiestas tamen eorum totam mentem occupat, ita
         omnis illa virtus et in primis grati animi multum quidem praestat, sed non vult ob hoc
         diligi ; amplius quiddam in se habet nec satis ab eo intellegitur a quo inter utilia
         numeratur. </p>
@@ -3718,7 +3712,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> " Si deos," inquit, " imitaris, da et ingratis beneficia ; nam et sceleratis sol oritur
         et piratis patent maria." Hoc loco interrogant, an vir bonus daturus sit beneficium ingrato
-        sciens ingratum esse. Permitte mihi aliquid interloqui, ne interrogatione insi- diosa
+        sciens ingratum esse. Permitte mihi aliquid interloqui, ne interrogatione insidiosa
         capiamur. </p>
       </div>
 
@@ -3727,7 +3721,7 @@
         stultus etiam malus est ; quia malus est, nullo vitio caret : ergo et ingratus est. Sic
         omnes malos intemperantes dicimus, avaros,luxuriosos, malignos, non quia omnia ista singulis
         magna et nota vitia sunt, sed quia esse possunt ; et sunt, etiam si latent. Alter est
-        ingratus, qui volgo dicitur, in hoc vitium natura pro- pensus. </p>
+        ingratus, qui volgo dicitur, in hoc vitium natura propensus. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -3754,7 +3748,7 @@
         cunctando restituit rem,' temerarius est ? Quid ergo ? Decius mortem timet ? Mucius proditor
         est ? Camillus desertor ? " Non hoc dicimus sic omnia vitia esse in omnibus, quomodo in
         quibusdam singula eminent, sed malum ac stultum nullo vitio vacare ; ne audacem quidem
-        timoris absol- vimus, ne prodigum quidem avaritia liberamus. </p>
+        timoris absolvimus, ne prodigum quidem avaritia liberamus. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -3787,7 +3781,7 @@
         autem etiam malis, quia separari non possunt. Satius est autem prodesse etiam malis propter
         bonos, quam bonis deesse propter malos. Ita, quae refers, diem, solem, hiemis aestatisque
         cursus et media veris autumnique temperamento imbres et fontium haustus, ventorum statos
-        flatus pro universis in- venerunt ; excerpere singulos non potuerunt. </p>
+        flatus pro universis invenerunt ; excerpere singulos non potuerunt. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -3801,14 +3795,14 @@
        <p> Deus quoque quaedam munera universo humano generi dedit, a quibus excluditur nemo. Nec
         enim poterat fieri, ut ventus bonis viris secundus esset, contrarius malis, communi autem
         bono erat patere commercium maris et regnum humani generis relaxari ; nec poterat lex
-        casuris imbribus dici, ne in malorum improborum- que rura defluerent. Quaedam in medio
+        casuris imbribus dici, ne in malorum improborumque rura defluerent. Quaedam in medio
         ponuntur. </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
        <p> Tam bonis quam malis conduntur urbes ; monumenta ingeniorum et ad indignos perventura
         publicavit editio ; medicina etiam sceleratis opem monstrat ; compositiones remediorum
-        salutarium nemo sup- pressit, ne sanarentur indigni. </p>
+        salutarium nemo suppressit, ne sanarentur indigni. </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">
@@ -3816,7 +3810,7 @@
         non in his, quae promiscue turbam admittunt. Multum enim refert, utrum aliquem non excludas
         an eligas. Ius et furi dicitur ; pace et homicidae fruuntur ; sua repetunt etiam, qui aliena
         rapuerunt ; percussores et domi ferrum exercentes murus ab hoste defendit ; legum praesidio,
-        qui pluri- mum in illas peccaverunt,proteguntur. </p>
+        qui plurimum in illas peccaverunt,proteguntur. </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
@@ -3840,7 +3834,7 @@
         efficiant. Primum rei magnitudo ; quaedam enim sunt infra huius nominis mensuram. Quis
         beneficium dixit quadram panis aut stipem aeris abiecti aut ignis accendendi factam
         potestatem ? Et interdum ista plus prosunt, quam maxima ; sed tamen vilitas sua illis, etiam
-        ubi temporis necessitate facta sunt neces- saria, detrahit pretium. </p>
+        ubi temporis necessitate facta sunt necessaria, detrahit pretium. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -3873,7 +3867,7 @@
        <p> Hoc debemus virtutibus, ut non praesentes solum illas, sed etiam ablatas e conspectu
         colamus ; quomodo illae id egerunt, ut non in unam aetatem prodessent, sed beneficia sua
         etiam post ipsas relinquerent, ita nos non una aetate grati simus. Hic magnos viros genuit :
-        dignus est beneficiis, qualis- cumque est; dignos dedit. </p>
+        dignus est beneficiis, qualiscumque est; dignos dedit. </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
@@ -3895,7 +3889,7 @@
        <p> Illi putas hoc datum ? Patri eius datum est et fratri. " Quare C<note> C. added by
          Muretus. </note> Caesarem orbi terrarum praefecit, hominem sanguinis humani avidissimum,
         quem non aliter fluere in conspectu suo iubebat, quam si ore excepturus esset ? " Quid ergo
-        ? Tu hoc illi datum existimas ? Patri eius Germanico datum, avo pro- avoque et ante hos
+        ? Tu hoc illi datum existimas ? Patri eius Germanico datum, avo proavoque et ante hos
         aliis non minus claris viris, etiam si privati paresque aliis vitam exegerunt. Quid ? </p>
       </div>
 
@@ -4012,7 +4006,7 @@
         quam quod factum est, nihil melius constitui, quam constitutum est ; ceterum ad omnia cum
         exceptione venit : "Si nihil inciderit, quod impediat." Ideo omnia illi succedere dicimus et
         nihil contra opinionem accidere, quia praesumit animo posse aliquid intervenire, quod
-        destinata pro- hibeat. </p>
+        destinata prohibeat. </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">
@@ -4037,7 +4031,7 @@
       <div type="textpart" subtype="section" n="2">
        <p> Tunc fidem fallam, tunc inconstantiae crimen audiam, si, cum eadem omnia sint, quae erant
         promittente me, non praestitero promissum ; alioquin, quidquid mutatur, libertatem facit de
-        integro con- <pb xml:id="p.278"/> sulendi et me fide liberat. Promisi advocationem : postea
+        integro consulendi<pb xml:id="p.278"/> et me fide liberat. Promisi advocationem : postea
         apparuit per illam causam praeiudicium in patrem meum quaeri; promisi me peregre exiturum :
         sed iter infestari latrociniis nuntiatur ; in rem praesentem venturus fui : sed aeger
         filius, sed puerpera uxor tenet. </p>
@@ -4056,7 +4050,7 @@
        <p> Inspiciam tamen et, quantum sit, de quo agitur; dabit mihi consilium promissae rei modus.
         Si exiguum est, dabo, non quia dignus es, sed quia promisi, nec tamquam munus dabo, sed
         verba mea redimam et aurem mihi pervellam. Damno castigabo promittentis temeritatem : "
-        Ecce, ut doleat tibi, ut postea consideratius loquaris ! " Quod dicere sole- mus, linguarium
+        Ecce, ut doleat tibi, ut postea consideratius loquaris ! " Quod dicere solemus, linguarium
         dabo. </p>
       </div>
 
@@ -4140,7 +4134,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> " Quare ergo," inquit, " Zeno vester, cum quingentos denarios cuidam mutuos promisisset
         et ipse illum parum idoneum comperisset, amicis suadentibus, ne daret, perseveravit credere,
-        quia pro- miserat ? </p>
+        quia promiserat ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -4156,7 +4150,7 @@
        <p> Ad cenam, quia promisi, ibo, etiam si frigus erit; non quidem, si nives cadent. Surgam ad
          <pb xml:id="p.286"/> sponsalia, quia promisi, quamvis non concoxerim ; sed non, si
         febricitavero. Sponsum descendam, quia promisi; sed non, si spondere me in<note> in added by
-         Erasmus. </note> incertum iube- bis, si fisco obligabis. Subest, inquam, tacita exceptio :
+         Erasmus. </note> incertum iubebis, si fisco obligabis. Subest, inquam, tacita exceptio :
         "Si potero, si debebo, si haec ita erunt." </p>
       </div>
 
@@ -4180,8 +4174,8 @@
        <p> Quid enim regi, quid pauper diviti reddam, utique cum quidam recipere beneficium iniuriam
         iudicent et beneficia subinde aliis beneficiis onerent ? Quid amplius in horum persona
         possum quam velle ? Nec enim ideo beneficium novum reicere debeo, quia nondum prius reddidi.
-        Accipiam tam libenter, quam dabitur, et praebebo me amico meo exercendae boni- <pb
-         xml:id="p.288"/> tatis suae capacem materiam. Qui nova accipere non vult, acceptis
+        Accipiam tam libenter, quam dabitur, et praebebo me amico meo exercendae bonitatis<pb
+         xml:id="p.288"/> suae capacem materiam. Qui nova accipere non vult, acceptis
         offenditur. Non refero gratiam: </p>
       </div>
 
@@ -4422,7 +4416,7 @@
        <p> Sed iam ista sidera hoc et illo diducet velocitas sua ; iam recipient diem terrae, et hic
         ibit ordo per saecula dispositosque ac praedictos dies habet, quibus sol intercursu lunae
         vetetur omnes radios effundere. Paulum expecta ; iam emerget, iam istam velut nubem
-        relinquet, iam exsolutus im- <pb xml:id="p.306"/> pedimentis lucem suam libere mittet." </p>
+        relinquet, iam exsolutus impedimentis<pb xml:id="p.306"/> lucem suam libere mittet." </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
@@ -4448,7 +4442,7 @@
 
       <div type="textpart" subtype="section" n="1">
        <p> Satis, ut existimo, hanc partem tractavimus, an turpe esset beneficiis vinci. Quod qui
-        quaerit, scit non solere homines sibi ipsos dare beneficium ; mani- festum enim fuisset non
+        quaerit, scit non solere homines sibi ipsos dare beneficium ; manifestum enim fuisset non
         esse turpe a se ipsum vinci. </p>
       </div>
 
@@ -4471,7 +4465,7 @@
       <div type="textpart" subtype="section" n="4">
        <p> Tam alieni corporis leno male audit quam sui. Nempe reprenditur adsentator et aliena
         subsequens verba, paratus ad falsa laudator ; non minus placens sibi et se suspiciens, ut
-        ita dicam, adsentator suus. Vitia non tantum, cum foris pec- eant, invisa sunt, sed cum in
+        ita dicam, adsentator suus. Vitia non tantum, cum foris peceant, invisa sunt, sed cum in
         se retorquentur. </p>
       </div>
 
@@ -4498,7 +4492,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Natura prius est, ut quis debeat, deinde, ut gratiam referat ; debitor non est sine
         creditore, non magis quam maritus sine uxore aut sine filio pater ; aliquis dare debet, ut
-        aliquis accipiat. Non est dare nec accipere in dexteram manum ex sinistra trans- ferre. </p>
+        aliquis accipiat. Non est dare nec accipere in dexteram manum ex sinistra transferre. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -4527,12 +4521,12 @@
 
       <div type="textpart" subtype="section" n="5">
        <p> Rerum natura nihil dicitur perdere, quia, quidquid illi avellitur, ad illam redit, nec
-        perire quicquam potest, quod, quo excidat, non habet, sed eodem re- volvitur, unde discedit.
+        perire quicquam potest, quod, quo excidat, non habet, sed eodem revolvitur, unde discedit.
         " Quid simile," inquis, " hoc exemplum habet huic propositae quaestioni ? " </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
-       <p> Dicam. Puta te ingratum esse : non perit bene- <pb xml:id="p.314"/> ficium, habet illud,
+       <p> Dicam. Puta te ingratum esse : non perit beneficium<pb xml:id="p.314"/>, habet illud,
         qui dedit. Puta te recipere nolle : apud te est, antequam redditur. Non potes quicquam
         amittere, quia, quod detrahitur, nihilo minus tibi adquiritur. Intra te ipsum orbis agitur ;
         accipiendo das, dando accipis. </p>
@@ -4709,7 +4703,7 @@
 
       <div type="textpart" subtype="section" n="7">
        <p> Ergo nihil potest ad malos pervenire, quod prosit, immo nihil, quod non noceat.
-        Quaecumque enim illis con- <pb xml:id="p.326"/> tigerunt, in naturam suam vertunt et extra
+        Quaecumque enim illis contigerunt<pb xml:id="p.326"/>, in naturam suam vertunt et extra
         speciosa profuturaque, si meliori darentur, illis pestifera sunt. Ideo nec beneficium dare
         possunt, quoniam nemo potest, quod non habet, dare ; hic bene faciendi voluntate caret. </p>
       </div>
@@ -4723,7 +4717,7 @@
         fortunae. Illa animi bona a stulto ac malo submoventur ; ad haec admittitur, quae et
         accipere potest et debet reddere, et, si non reddit, ingratus est. Nec hoc ex nostra tantum
         constitutione. Peripatetici quoque, qui felicitatis humanae longe lateque terminos ponunt,
-        aiunt minuta beneficia perventura ad malos ; haec qui non reddit, in- gratus est. </p>
+        aiunt minuta beneficia perventura ad malos ; haec qui non reddit, ingratus est. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -4753,7 +4747,7 @@
 
       <div type="textpart" subtype="section" n="1">
        <p> Cleanthes vehementius agit. " Licet," inquit, " beneficium non sit, quod accepit, ipse
-        tamen ingratus est, quia non fuit redditurus, etiam si ac- cepisset. </p>
+        tamen ingratus est, quia non fuit redditurus, etiam si accepisset. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -4775,7 +4769,7 @@
       <div type="textpart" subtype="section" n="4">
        <p> Aes alienum habere dicitur et qui aureos debet et qui corium forma publica percussum,
         quale apud Lacedaemonios fuit, quod usum numeratae pecuniae praestat. Quo genere obligatus
-        es, hoc fidem ex- solve. </p>
+        es, hoc fidem exsolve. </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">
@@ -4915,7 +4909,7 @@
        <p> Illud in confesso est : quis sine querella moritur ? Quis extremo die dicere audet :
          <quote rend="blockquote"><l part="N">Vixi et quem dederat cursum fortuna peregi
          ?</l></quote> Quis non recusans, quis non gemens exit ? Atqui hoc ingrati est non esse
-        contentum praeterito tem- <pb xml:id="p.340"/> pore. Semper pauci dies erunt, si illos
+        contentum praeterito tempore<pb xml:id="p.340"/>. Semper pauci dies erunt, si illos
         numeraveris. </p>
       </div>
 
@@ -4974,7 +4968,7 @@
        <p> " Non," inquit ; " quaedam enim in alios conferuntur, sed ad nos usque permanant ; ab eo
         autem exigi quidque debet, in quem confertur, sicut pecunia ab eo petitur, cui credita est,
         quamvis ad me illa aliquo modo venerit. Nullum beneficium est, cuius non commodum et
-        proximos tangat, non num- quam etiam longius positos ; </p>
+        proximos tangat, non numquam etiam longius positos ; </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
@@ -4982,7 +4976,7 @@
          xml:id="p.344"/> primo collocetur ; a reo tibi ipso et a capite repetitio est." Quid ergo ?
         Oro te, non dicis : " Filium mihi donasti, et, si hic perisset, victurus non fui " ? Pro
         eius vita beneficium non debes, cuius vitam tuae praefers ? Etiamnunc, cum filium tuum
-        servavi, ad genua procumbis, dis vota solvis tamquam ipse ser- vatus ; illae voces exeunt
+        servavi, ad genua procumbis, dis vota solvis tamquam ipse servatus ; illae voces exeunt
         tibi : </p>
       </div>
 
@@ -5116,7 +5110,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Multi sunt, qui nec negare sciant, quod acceperunt, nec referre, qui nec tam boni sunt
         quam grati nec tam mali quam ingrati, segnes et tardi, lenta nomina, non mala. Hos ego non
-        appellabo, sed commonefaciam et ad officium aliud agentes re- <pb xml:id="p.354"/> ducam.
+        appellabo, sed commonefaciam et ad officium aliud agentes reducam<pb xml:id="p.354"/>.
         Qui statim mihi sic respondebunt : " Ignosce ; non mehercules scivi hoc te desiderare,
         alioqui ultro obtulissem ; rogo, ne me ingratum existimes ; memini, quid mihi praestiteris."
         Hos ego quare dubitem et sibi meliores et mihi facere ? Quemcumque potuero, peccare
@@ -5262,7 +5256,7 @@
        <p> An beneficium eripi posset, quaesitum est. Quidam negant posse ; non enim res est, sed
         actio. Quomodo aliud est munus, aliud ipsa donatio, aliud qui navigat, aliud navigatio, et,
         quamvis in morbo aeger sit, non tamen idem est aeger et morbus, ita aliud est beneficium
-        ipsum, aliud quod ad unum- quemque nostrum beneficio pervenit. Illud incorporale est,
+        ipsum, aliud quod ad unumquemque nostrum beneficio pervenit. Illud incorporale est,
         irritum non fit ; </p>
       </div>
 
@@ -5385,7 +5379,7 @@
        <p> Videris mihi dicere : " Perdis operam ; quorsus <pb xml:id="p.374"/> enim pertinet scire
         me, an maneat, quod non debetur? Iuris consultorum istae acutae ineptiae sunt, qui
         hereditatem negant usu capi posse sed ea, quae in hereditate sunt, tamquam quicquam aliud
-        sit here- ditas, quam ea, quae in hereditate sunt. </p>
+        sit hereditas, quam ea, quae in hereditate sunt. </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
@@ -5410,7 +5404,7 @@
         sequi. Lex legi non miscetur, utraque sua via it. Depositum habet actionem propriam tam
         mehercules quam furtum. Beneficium nulli legi subiectum est, me arbitro utitur ; licet mihi
         inter se comparare, quantum profuerit mihi quisque aut quantum nocuerit, <pb xml:id="p.376"
-        /> tum pronuntiare, utrum plus debeatur mihi an de- beam. </p>
+        /> tum pronuntiare, utrum plus debeatur mihi an debeam. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -5454,7 +5448,7 @@
         immodicus superfluxit tardeque decessit ; nec ventus beneficium dat, licet lenis et secundus
         adspiret, nec utilis et salubris cibus. Nam qui beneficium mihi daturus est, debet non
         tantum prodesse, sed velle. Ideo nec mutis animalibus quicquam debetur : et quam multos e
-        periculo velocitas equi rapuit ! nec arboribus : et quam multos aestu laborantes ra- morum
+        periculo velocitas equi rapuit ! nec arboribus : et quam multos aestu laborantes ramorum
         opacitas texit ! </p>
       </div>
 
@@ -5481,7 +5475,7 @@
       <div type="textpart" subtype="section" n="2">
        <p> An existimas me debere ei quicquam, cuius manus, cum me peteret, percussit hostem meum,
         qui nocuisset, nisi errasset ? Saepe testis, dum aperte peierat, etiam veris testibus
-        abrogavit fidem et reum velut factione circumventum misera- bilem reddidit. </p>
+        abrogavit fidem et reum velut factione circumventum miserabilem reddidit. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -5611,7 +5605,7 @@
        <p> Alteri illi, qui beneficium dat sua causa, respondebo : " Usus me quare potius te mihi
         profuisse dicas quam me tibi ? " " Puta," inquit, " aliter fieri non posse me magistratum,
         quam si decem captos cives ex magno captivorum numero redemero ; nihil debebis mihi, cum te
-        servitute ac vinculis liberavero ? Atqui mea id causa faciam." Adversus hoc respon- deo : "
+        servitute ac vinculis liberavero ? Atqui mea id causa faciam." Adversus hoc respondeo : "
         Aliquid istic tua causa facis, aliquid mea : </p>
       </div>
 
@@ -5635,7 +5629,7 @@
 
       <div type="textpart" subtype="section" n="1">
        <p> " Quid ergo ? " inquit ; " si in sortem nomina vestra coici iussissem, et tuum nomen
-        inter redimen- dos exisset, nihil deberes mihi ? </p>
+        inter redimendos exisset, nihil deberes mihi ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -5690,7 +5684,7 @@
 
       <div type="textpart" subtype="section" n="5">
        <p> Deinde, etiam si pluris ista sunt, non tamen ullum istic tuum munus est, ut non ex usu
-        effectuve, sed ex con- suetudine et annona aestimetur. </p>
+        effectuve, sed ex consuetudine et annona aestimetur. </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
@@ -5746,13 +5740,13 @@
       <div type="textpart" subtype="section" n="5">
        <p> gemitus meos non securus audivit; in turba multorum invocantem ego illi potissima curatio
         fui ; tantum aliis vacavit, quantum mea valetudo permiserat : huic ego non tamquam medico
-        sed tamquam amico ob- <pb xml:id="p.398"/> ligatus sum. </p>
+        sed tamquam amico obligatus<pb xml:id="p.398"/> sum. </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
        <p> Alter rursus docendo et laborem et taedium tulit ; praeter illa, quae a praecipientibus
         in commune dicuntur, aliqua instillavit ac tradidit, hortando bonam indolem erexit et modo
-        laudibus fecit animum, modo admonitionibus discussit de- sidiam ; </p>
+        laudibus fecit animum, modo admonitionibus discussit desidiam ; </p>
       </div>
 
       <div type="textpart" subtype="section" n="7">
@@ -5814,11 +5808,11 @@
 
       <div type="textpart" subtype="section" n="3">
        <p> noluit mihi civitatem proprie dare nec in me direxit animum ; ita quare ei debeam, qui me
-        sibi non sub- stituit, cum facturus esset, quod fecit ? </p>
+        sibi non substituit, cum facturus esset, quod fecit ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
-       <p> " Primum, cum cogitavit Gallis omnibus prodesse, et mihi cogi- <pb xml:id="p.402"/> tavit
+       <p> " Primum, cum cogitavit Gallis omnibus prodesse, et mihi cogitavit<pb xml:id="p.402"/>
         prodesse ; eram enim Gallus et me etiam si non mea, publica tamen nota comprendit. Deinde
         ego quoque illi non tamquam proprium debebo, sed tamquam commune munus ; unus<note> unus
          added by Fickert. </note> ex populo non tamquam pro me solvam, sed tamquam pro patria
@@ -5948,7 +5942,7 @@
        <p> Inter maxima rerum suarum natura nihil habet, quo magis glorietur, aut certe, cui
         glorietur. Quantus iste furor est controversiam dis muneris sui facere ! Quomodo adversus
         eos hic erit gratus, quibus gratia referri sine impendio non potest, qui negat se ab iis
-        accepisse, a quibus cum maxime accepit, qui et semper daturi sunt et numquam re- cepturi ?
+        accepisse, a quibus cum maxime accepit, qui et semper daturi sunt et numquam recepturi ?
        </p>
       </div>
 
@@ -5983,13 +5977,13 @@
       <div type="textpart" subtype="section" n="1">
        <p> His ingratis et repudiantibus beneficia, non quia nolunt, sed ne debeant, similes sunt ex
         diverso nimis grati, qui aliquid incommodi precari solent iis, quibus obligati sunt, aliquid
-        adversi, in quo adfectum me- morem accepti beneficii approbent. </p>
+        adversi, in quo adfectum memorem accepti beneficii approbent. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
        <p> An hoc recte faciant et pia voluntate, quaeritur ; quorum animus simillimus est pravo
-        amore flagrantibus, qui amicae suae optant exilium, ut desertam fugientemque comi- <pb
-         xml:id="p.414"/> tentur, optant inopiam, ut magis desiderant donent, optant morbum, ut
+        amore flagrantibus, qui amicae suae optant exilium, ut desertam fugientemque comitentur<pb
+         xml:id="p.414"/>, optant inopiam, ut magis desiderant donent, optant morbum, ut
         adsideant, et, quidquid inimicus optaret, amantes vovent. Fere idem itaque exitus est odii
         et amoris insani. </p>
       </div>
@@ -6004,7 +5998,7 @@
        <p> Quid, si gubernator a dis tempestates infestissimas et procellas petat, ut gratior ars
         sua periculo fiat ? Quid, si imperator deos oret, ut magna vis hostium circumfusa castris
         fossas subito impetu compleat et vallum trepidante exercitu vellat et in ipsis portis
-        infesta signa constituat, quo maiore cum gloria rebus lassis pro- fligatisque succurrat ?
+        infesta signa constituat, quo maiore cum gloria rebus lassis profligatisque succurrat ?
        </p>
       </div>
 
@@ -6020,7 +6014,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> " Non nocet," inquit, " illi votum meum, quia simul opto et periculum et remedium." Hoc
         dicis non nihil te peccare sed minus, quam si sine remedio periculum optares. Nequitia est
-        ut extrahas mer- <pb xml:id="p.416"/> gere, evertere ut suscites, ut emittas includere. Non
+        ut extrahas mergere<pb xml:id="p.416"/>, evertere ut suscites, ut emittas includere. Non
         est beneficium iniuriae finis, nec umquam id detraxisse meritum est, quod ipse, qui
         detraxit, intulerat. </p>
       </div>
@@ -6111,8 +6105,8 @@
       <div type="textpart" subtype="section" n="1">
        <p> Quanto hoc honestius votum est : " Opto, in eo statu sit, quo semper beneficia
         distribuat, numquam desideret ; sequatur illum materia, qua tam benigne utitur, largiendi
-        iuvandique ; numquam illi sit dandorum beneficiorum inopia, datorum paeni- <pb
-         xml:id="p.422"/> tentia ; naturam per se pronam ad misericordiam, humanitatem, clementiam
+        iuvandique ; numquam illi sit dandorum beneficiorum inopia, datorum paenitentia<pb
+         xml:id="p.422"/> ; naturam per se pronam ad misericordiam, humanitatem, clementiam
         irritet ac provocet turba gratorum, quos illi et habere contingat nec experiri necesse sit ;
         ipse nulli implacabilis sit, ipsi nemo placandus ; tam aequali in eum fortuna indulgentia
         perseveret, ut nemo in illum possit esse nisi conscientia gratus." </p>
@@ -6151,7 +6145,7 @@
       </div>
 
       <div type="textpart" subtype="section" n="4">
-       <p> Non vides, quemadmodum illos in praeceps agat extincta libertas et fides in ob- sequium
+       <p> Non vides, quemadmodum illos in praeceps agat extincta libertas et fides in obsequium
         servile submissa ? </p>
       </div>
 
@@ -6160,7 +6154,7 @@
         amicorum omnium officium, una contentio, quis blandissime fallat, ignoravere vires suas, et,
         dum se tam magnos, quam audiunt, credunt, attraxere supervacua et in discrimen rerum omnium
         perventura bella, utilem et necessariam rupere concordiam, secuti iram, quam nemo revocabat,
-        multorum san- guinem hauserunt fusuri novissime suum ; </p>
+        multorum sanguinem hauserunt fusuri novissime suum ; </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
@@ -6177,13 +6171,13 @@
       <div type="textpart" subtype="section" n="1">
        <p> Cum bellum Graeciae indiceret Xerxes, animum tumentem oblitumque, quam caducis
         confideret, nemo non impulit. Alius aiebat non laturos nuntium belli et ad primam adventus
-        famam terga ver- suros ; </p>
+        famam terga versuros ; </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
        <p> alius nihil esse dubii, quin illa mole non vinci solum Graecia, sed obrui posset ; magis
         verendum, ne vacuas desertasque urbes invenirent et profugis hostibus vastae solitudines
-        relinquerentur non habi- turis, ubi tantas vires exercere possent ; </p>
+        relinquerentur non habituris, ubi tantas vires exercere possent ; </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -6254,11 +6248,11 @@
      <div type="textpart" subtype="chapter" n="32">
 
       <div type="textpart" subtype="section" n="1">
-       <p> Divus Augustus filiam ultra impudicitiae male- dictum impudicam relegavit et flagitia
+       <p> Divus Augustus filiam ultra impudicitiae maledictum impudicam relegavit et flagitia
         principalis domus in publicum emisit : admissos gregatim adulteros, pererratam nocturnis
         comissationibus civitatem, forum ipsum ac rostra, ex quibus pater legem de adulteriis
         tulerat, filiae in stupra placuisse, cotidianum ad Marsyam concursum, cum ex adultera in
-        quae- <pb xml:id="p.432"/> stuariam versa ius omnis licentiae sub ignoto adultero peteret.
+        quaestuariam<pb xml:id="p.432"/> versa ius omnis licentiae sub ignoto adultero peteret.
        </p>
       </div>
 
@@ -6289,9 +6283,8 @@
 
       <div type="textpart" subtype="section" n="1">
        <p> Sed ut me ad propositum reducam, vides, quam facile sit gratiam referre felicibus et in
-        summo hu- <pb xml:id="p.434"/> manarum opum positis. Dic illis, non quod volunt audire, sed
-        quod audisse semper volent ; plenas aures adulationibus aliquando vera vox intret ; da con-
-        silium utile. Quaeris, quid felici praestare possis ? </p>
+        summo humanarum<pb xml:id="p.434"/> opum positis. Dic illis, non quod volunt audire, sed
+        quod audisse semper volent ; plenas aures adulationibus aliquando vera vox intret ; da consilium utile. Quaeris, quid felici praestare possis ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -6299,7 +6292,7 @@
         Parum in illum contuleris, si illi stultam fiduciam permansurae semper potentiae excusseris
         docuerisque mobilia esse, quae dedit casus, et maiore cursu fugere, quam veniunt, nec iis
         portionibus, quibus ad summa perventum est, retro iri, sed saepe inter maximam fortunam et
-        ulti- mam nihil interesse ? </p>
+        ultimam nihil interesse ? </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -6321,13 +6314,13 @@
        <p> Consuetudo ista vetus est regibus regesque simulantibus populum amicorum discribere, et
         proprium superbiae magno aestimare introitum ac tactum sui liminis et pro honore dare, ut
         ostio suo propius adsideas, ut gradum prior intra domum ponas, in qua <pb xml:id="p.436"/>
-        deinceps multa sunt ostia, quae receptos quoque ex- cludant. </p>
+        deinceps multa sunt ostia, quae receptos quoque excludant. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
        <p> Apud nos primi omnium C.<note> C. added by Muretus. </note> Gracchus et mox Livius Drusus
         instituerunt segregare turbam suam et alios in secretum recipere, alios cum pluribus, alios
-        universos. Habuerunt itaque isti amicos primos, ha- buerunt secundos, numquam veros. </p>
+        universos. Habuerunt itaque isti amicos primos, habuerunt secundos, numquam veros. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -6370,7 +6363,7 @@
       <div type="textpart" subtype="section" n="3">
        <p> Multum interest, utrum properes referre gratiam, ut reddas beneficium, an ne debeas. Qui
         reddere vult, illius se commodo aptabit et idoneum illi venire tempus volet ; qui nihil
-        aliud quam ipse liberari vult, quomodocumque ad hoc cupiet per- venire, quod est pessimae
+        aliud quam ipse liberari vult, quomodocumque ad hoc cupiet pervenire, quod est pessimae
         voluntatis. </p>
       </div>
 
@@ -6441,8 +6434,8 @@
        <p> In quibusdam civitatibus impium votum sceleris vicem tenuit. Demades certe Athenis eum,
         qui necessaria funeribus venditabat, damnavit, cum probasset magnum lucrum optasse, quod
         contingere illi sine multorum morte non poterat. Quaeri tamen solet, an merito damnatus sit.
-        Fortasse optavit, non ut multis venderet, sed ut care, ut parvo sibi con- <pb xml:id="p.444"
-        /> starent, quae venditurus esset. </p>
+        Fortasse optavit, non ut multis venderet, sed ut care, ut parvo sibi constarent<pb xml:id="p.444"
+        />, quae venditurus esset. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -6464,8 +6457,7 @@
         sunt, non putas eadem habere quae dissignatores et libitinarios vota ? Illi tamen, quorum
         mortes optent, nesciunt, hi familiarissimum quemque, ex quo propter amicitiam spei plurimum
         est, mori cupiunt. Illorum damno nemo vivit, hos, quisquis differt, exhaurit ; optant ergo
-        non tantum, ut accipiant, quod turpi servitute meruerunt, sed etiam, ut tributo gravi libe-
-        rentur. </p>
+        non tantum, ut accipiant, quod turpi servitute meruerunt, sed etiam, ut tributo gravi liberentur. </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">
@@ -6659,7 +6651,7 @@
         animus inerti otio torpet. Dicat sibi ipse : " Voluptas fragilis est, brevis, fastidio
         obiecta, quo avidius hausta est citius in contrarium recidens, cuius subinde necesse est aut
         paeniteat aut pudeat, in qua nihil est magnificum aut quod naturam hominis dis proximi
-        deceat, res humilis, membrorum turpium aut vilium mini- sterio veniens, exitu foeda. </p>
+        deceat, res humilis, membrorum turpium aut vilium ministerio veniens, exitu foeda. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -6679,8 +6671,8 @@
 
       <div type="textpart" subtype="section" n="5">
        <p> Et ne illum existimes parvo esse contentum, omnia illius sunt, non sic, quemadmodum
-        Alexandri fuerunt, cui, quamquam in litore rubri maris steterat, plus de- <pb xml:id="p.462"
-        /> erat, quam qua venerat. Illius ne ea quidem erant, quae tenebat aut vicerat, cum in
+        Alexandri fuerunt, cui, quamquam in litore rubri maris steterat, plus deerat<pb xml:id="p.462"
+        />, quam qua venerat. Illius ne ea quidem erant, quae tenebat aut vicerat, cum in
         oceano Onesicritus praemissus explorator erraret et bella in ignoto mari quaereret. </p>
       </div>
 
@@ -6791,7 +6783,7 @@
       <div type="textpart" subtype="section" n="2">
        <p> Nec mirum est aliquid ei, cuius est totum, posse donari. Conduxi domum a te ; in hac
         aliquid tuum est, aliquid meum : res tua est, usus rei tuae meus est. Itaque nec fructus
-        tanges colono tuo prohibente, quamvis in tua pos- <pb xml:id="p.470"/> sessione nascantur,
+        tanges colono tuo prohibente, quamvis in tua possessione<pb xml:id="p.470"/> nascantur,
         et, si annona carior fuerit aut fames. Heu ! frustra magnum alterius spectabis acervum in
         tuo natum, in tuo positum, in horrea iturum tua. </p>
       </div>
@@ -6821,7 +6813,7 @@
       </div>
 
       <div type="textpart" subtype="section" n="3">
-       <p> Caesar omnia habet, fiscus eius privata tan- <pb xml:id="p.472"/> tum ac sua ; et
+       <p> Caesar omnia habet, fiscus eius privata tantum<pb xml:id="p.472"/> ac sua ; et
         universa in imperio eius sunt, in patrimonio propria. Quid eius sit, quid non sit, sine
         diminutione imperii quaeritur ; nam id quoque, quod tamquam alienum abiudicatur, aliter
         illius est. Sic sapiens animo universa possidet, iure ac dominio sua. </p>
@@ -6988,7 +6980,7 @@
       <div type="textpart" subtype="section" n="1">
        <p> Itaque cum C.<note> C. added by Pincianus. </note> Caesar illi ducenta donaret, ridens
         reiecit ne dignam quidem summam iudicans, qua non accepta gloriaretur. Di deaeque, quam
-        pusillo animo illum aut honorare voluit aut corrum- pere ! Reddendum egregio viro
+        pusillo animo illum aut honorare voluit aut corrumpere ! Reddendum egregio viro
         testimonium est ; </p>
       </div>
 
@@ -7062,7 +7054,7 @@
       <div type="textpart" subtype="section" n="2">
        <p> " Ut scias," inquit, " illum non reddidisse, omnia fecit, ut redderet ; apparet ergo non
         esse id factum, cuius faciendi occasionem non habuit. Et creditori suo pecuniam non solvit
-        is, qui, ut solveret, ubique quaesivit nec in- venit." </p>
+        is, qui, ut solveret, ubique quaesivit nec invenit." </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -7114,7 +7106,7 @@
       <div type="textpart" subtype="section" n="2">
        <p> At mehercules Athenienses Harmodium et Aristogitonem tyrannicidas vocant, et Mucio manus
         in hostili ara relicta instar occisi Porsinae fuit, et semper contra fortunam luctata virtus
-        etiam citra effectum pro- <pb xml:id="p.492"/> positi operis enituit. Plus praestitit, qui
+        etiam citra effectum propositi<pb xml:id="p.492"/> operis enituit. Plus praestitit, qui
         fugientes occasiones secutus est et alia atque alia captavit, per quae referre gratiam
         posset, quam quem sine ullo sudore gratum prima fecit occasio. </p>
       </div>
@@ -7122,8 +7114,7 @@
       <div type="textpart" subtype="section" n="3">
        <p> " Duas," inquit, " res ille tibi praestitit, voluntatem et rem ; tu quoque illi duas
         debes." Merito istud diceres ei, qui tibi reddidit voluntatem otiosam, huic vero, qui et
-        vult et conatur et nihil intemptatum relinquit, id non potes dicere ; utrumque enim prae-
-        stat, quantum in se est. </p>
+        vult et conatur et nihil intemptatum relinquit, id non potes dicere ; utrumque enim praestat, quantum in se est. </p>
       </div>
 
       <div type="textpart" subtype="section" n="4">
@@ -7246,14 +7237,13 @@
        <p> " Quid ? si," inquit, " non tantum malus factus est, sed ferus, sed immanis, qualis
         Apollodorus aut Phalaris,et huic beneficium,quod acceperas,reddes ?" Mutationem sapientis
         tantam natura non patitur. Non in pessima ab optimis lapsus ; necesse est etiam in malo
-        vestigia boni teneat ; numquam tantum virtus extinguitur, ut non certiores animo notas im-
-        primat, quam ut illas eradat ulla mutatio. </p>
+        vestigia boni teneat ; numquam tantum virtus extinguitur, ut non certiores animo notas imprimat, quam ut illas eradat ulla mutatio. </p>
       </div>
 
       <div type="textpart" subtype="section" n="6">
        <p> Ferae inter nos educatae si in silvas eruperunt, aliquid mansuetudinis pristinae retinent
         tantumque a placidissimis absunt, quantum a veris feris et numquam humanam manum passis.
-        Nemo in summam ne- quitiam incidit, qui umquam haesit sapientiae ; altius <pb xml:id="p.502"
+        Nemo in summam nequitiam incidit, qui umquam haesit sapientiae ; altius <pb xml:id="p.502"
         /> infectus est, quam ut ex toto elui et transire in colorem malum possit. </p>
       </div>
 
@@ -7289,14 +7279,13 @@
        <p> Sed quamvis hoc ita sit et ex eo tempore omnia mihi in illum libera sint, ex quo
         corrumpendo fas omne, ut nihil in eum nefas esset, effecerit, illum mihi servandum modum
         credam, ut, si beneficium illi meum neque vires maiores daturum est in exitium commune nec
-        confirmaturum, quas habet, id autem erit, quod illi reddi sine pernicie publica possit, red-
-        dam. Servabo filium eius infantem ; </p>
+        confirmaturum, quas habet, id autem erit, quod illi reddi sine pernicie publica possit, reddam. Servabo filium eius infantem ; </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
        <p> quid hoc beneficium obest cuiquam eorum, quos crudelitas eius lacerat ? Pecuniam, quae
         satellitem stipendio teneat, non subministrabo. Si marmora et vestes desideraverit, nihil
-        oberit cuiquam id, quo luxuria eius in- struitur ; militem et arma non suggeram. </p>
+        oberit cuiquam id, quo luxuria eius instruitur ; militem et arma non suggeram. </p>
       </div>
 
       <div type="textpart" subtype="section" n="3">
@@ -7342,11 +7331,11 @@
 
       <div type="textpart" subtype="section" n="1">
        <p> Quod debes, quaere, cui reddas, et, si nemo poscet, ipse te appella. Malus an bonus, ad
-        te non pertinet ; redde et accusa. Oblitus es, quem- <pb xml:id="p.508"/> admodum inter vos
+        te non pertinet ; redde et accusa. Oblitus es, quemadmodum<pb xml:id="p.508"/> inter vos
         officia divisa sint : illi oblivio imperata est, tibi meminisse mandavimus. Errat tamen, si
         quis existimat, cum dicimus eum, qui beneficium dedit, oblivisci oportere, excutere nos illi
         memoriam rei praesertim honestissimae ; quaedam praecipimus ultra modum, ut ad verum et suum
-        re- deant. Cum dicimus : </p>
+        redeant. Cum dicimus : </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -7394,7 +7383,7 @@
       </div>
 
       <div type="textpart" subtype="section" n="2">
-       <p> " Emissem," inquit, " pallium, si num- mos haberem." Post hoc quisquis properaverit, sero
+       <p> " Emissem," inquit, " pallium, si nummos haberem." Post hoc quisquis properaverit, sero
         dat ; iam Socrati defuit. Propter acerbos exactores repetere prohibemus, non, ut numquam
         fiat, sed ut parce. </p>
       </div>
@@ -7414,8 +7403,8 @@
       <div type="textpart" subtype="section" n="2">
        <p> Numquam ne querens quidem dicam : eiectum litore, egentem excepi et regni demens in parte
         locavi. Non est ista admonitio, convicium est ; hoc est in odium beneficia perducere, hoc
-        est efficere, ut in- gratum esse aut liceat aut iuvet. Satis abundeque est submissis et
-        familiaribus verbis memoriam re- vocare : si bene quid de te merui, fuit aut tibi quicquam
+        est efficere, ut ingratum esse aut liceat aut iuvet. Satis abundeque est submissis et
+        familiaribus verbis memoriam revocare : si bene quid de te merui, fuit aut tibi quicquam
         dulce meum. Ille in vicem dicat : " Quidni merueris ? Eiectum litore, egentem excepisti."
        </p>
       </div>
@@ -7432,8 +7421,8 @@
       <div type="textpart" subtype="section" n="2">
        <p> Placido animo, mansueto, magno. Numquam te tam inhumanus et immemor et ingratus offendat,
         ut non tamen dedisse delectet ; numquam in has voces iniuria impellat : " Vellem, non
-        fecissem." Beneficii tui tibi etiam infelicitas placeat ; semper illum pae- <pb
-         xml:id="p.514"/> nitebit, si te ne nunc quidem paenitet. Non est, quod indigneris, tamquam
+        fecissem." Beneficii tui tibi etiam infelicitas placeat ; semper illum paenitebit<pb
+         xml:id="p.514"/>, si te ne nunc quidem paenitet. Non est, quod indigneris, tamquam
         aliquid novi acciderit; magis mirari deberes, si non accidisset. </p>
       </div>
 
@@ -7495,7 +7484,7 @@
         nullum umquam apud te perierit officium, an omnium te beneficiorum memoria comitetur.
         Videbis, quae puero data sunt, ante adulescentiam elapsa, quae in iuvenem conlata sunt, non
         perdurasse in senectutem. Quaedam perdidimus, quaedam proiecimus, quaedam e conspectu nostro
-        paulatim exierunt, a quibusdam oculos aver- timus. </p>
+        paulatim exierunt, a quibusdam oculos avertimus. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -7519,11 +7508,10 @@
      <div type="textpart" subtype="chapter" n="29">
 
       <div type="textpart" subtype="section" n="1">
-       <p> " Perdidi beneficium." Numquid, quae con- <pb xml:id="p.520"/> secravimus, perdidisse nos
+       <p> " Perdidi beneficium." Numquid, quae consecravimus<pb xml:id="p.520"/>, perdidisse nos
         dicimus ? Inter consecrata beneficium est, etiam si male respondit, bene conlatum. Non est
         ille, qualem speravimus ; simus nos, quales fuimus, ei dissimiles. Damnum non tunc factum :
-        apparuit. Ingratus non sine nostro pudore protrahitur, quoniam quidem querella amissi bene-
-        ficti non<note> non commonly added. </note> bene dati signum est. </p>
+        apparuit. Ingratus non sine nostro pudore protrahitur, quoniam quidem querella amissi beneficti non<note> non commonly added. </note> bene dati signum est. </p>
       </div>
 
       <div type="textpart" subtype="section" n="2">
@@ -7579,12 +7567,12 @@
       </div>
 
       <div type="textpart" subtype="section" n="4">
-       <p> Nihilo minus tamen more optimorum parentium, qui maledictis suorum in- fantium arrident,
+       <p> Nihilo minus tamen more optimorum parentium, qui maledictis suorum infantium arrident,
         non cessant di beneficia congerere <pb xml:id="p.524"/> de beneficiorum auctore
         dubitantibus, sed aequali tenore bona sua per gentes populosque distribuunt; unam potentiam,
         prodesse, sortiti spargunt opportunis imbribus terras, maria flatu movent, siderum cursu
         notant tempora, hiemes aestatesque interventu lenioris spiritus molliunt, errorem labentium
-        ani- marum placidi ac propitii ferunt. Imitemur illos ; </p>
+        animarum placidi ac propitii ferunt. Imitemur illos ; </p>
       </div>
 
       <div type="textpart" subtype="section" n="5">


### PR DESCRIPTION
As I was retrieving some extract, I saw that hyphenation was still in this file. Just removed it using following rules in this exact order applied only on `//p` in Oxygen: 

| Pattern | Replacement |
| --------- | ----------------- |
| `(\w+)\-\s+(\w+)` | `$1$2` |  
| `(\w+)\-\s*(\<pb\s+xml:id="p.\d+"\s*\/\>)\s*(\w+)` | `$1$3$2` |