### PR TITLE
(phi0914.phi001.lat2) Added Capitains transformation 

### DIFF
--- a/data/phi0914/__cts__.xml
+++ b/data/phi0914/__cts__.xml
@@ -1,4 +1,3 @@
-<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="latinLit:phi0914" urn="urn:cts:latinLit:phi0914">
-    <ti:groupname xml:lang="eng">Titus Livius (Livy)</ti:groupname>
-    </ti:textgroup>
-  
+<textgroup xmlns="http://chs.harvard.edu/xmlns/cts" projid="latinLit:phi0914" urn="urn:cts:latinLit:phi0914">
+    <groupname xml:lang="eng">Titus Livius (Livy)</groupname>
+</textgroup>

--- a/data/phi0914/phi001/__cts__.xml
+++ b/data/phi0914/phi001/__cts__.xml
@@ -1,12 +1,19 @@
-<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:latinLit:phi0914" projid="latinLit:phi001" urn="urn:cts:latinLit:phi0914.phi001" xml:lang="lat">
-      <ti:title xml:lang="eng">The History of Rome</ti:title>
-      <ti:translation projid="latinLit:perseus-eng3" urn="urn:cts:latinLit:phi0914.phi001.perseus-eng3" workUrn="urn:cts:latinLit:phi0914.phi001" xml:lang="eng">
-        <ti:label xml:lang="eng">The History of Rome</ti:label>
-        <ti:description xml:lang="eng">Perseus:bib:oclc,2311635, Livy. History of Rome. English
-          Translation by. Rev. Canon Roberts. New York, New York. E. P. Dutton and Co. 1912. 1.
-          Livy. History of Rome. English Translation. Rev. Canon Roberts. New York, New York. E. P.
-          Dutton and Co. 1912. 2.</ti:description>
-        <ti:memberof collection="Perseus:collection:Greco-Roman" />
-      </ti:translation>
-    </ti:work>
-  
+<work xmlns="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:latinLit:phi0914" projid="latinLit:phi001" urn="urn:cts:latinLit:phi0914.phi001" xml:lang="lat">
+    <title xml:lang="eng">The History of Rome</title>
+    <title xml:lang="lat">Ab urbe condita</title>
+    <translation projid="latinLit:perseus-eng3" urn="urn:cts:latinLit:phi0914.phi001.perseus-eng3" workUrn="urn:cts:latinLit:phi0914.phi001" xml:lang="eng">
+        <label xml:lang="eng">The History of Rome</label>
+        <description xml:lang="eng">Perseus:bib:oclc,2311635, Livy. History of Rome. English
+            Translation by. Rev. Canon Roberts. New York, New York. E. P. Dutton and Co. 1912. 1.
+            Livy. History of Rome. English Translation. Rev. Canon Roberts. New York, New York. E. P.
+            Dutton and Co. 1912. 2.</description>
+        <memberof collection="Perseus:collection:Greco-Roman" />
+    </translation>
+    <edition urn="urn:cts:latinLit:phi0914.phi001.perseus-lat2" workUrn="urn:cts:latinLit:phi0914.phi001">
+        <label xml:lang="lat">Ab urbe condita</label>
+        <description xml:lang="lat">Titi Livi ab urbe condita libri editionem priman curavit
+            Guilelmus Weissenborn editio altera auam curavit Mauritius Mueller
+            Pars I-IV. Libri I-XL. Editio Stereotypica. 1884-1911.</description>
+        <memberof collection="Perseus:collection:Greco-Roman" />
+    </edition>   
+</work>


### PR DESCRIPTION
Three students converted old files sent to me by @balmas a while ago to reconstruct a real version of Livy's work ( https://github.com/Chartes-TNAH/tite-live ). This was the original files sent to me https://github.com/Chartes-TNAH/tite-live/tree/25fb2c3a5a44409ca70060db24279ea2e4f6d313/sources

I would recommend to actually remove all other Livy's files as well and put back the other sources for these, as URNs are messed up and lat1 somewhere does not connect to lat1 somewhere else.