### PR TITLE
minor cts and betacode fixes

### DIFF
--- a/data/phi0448/phi001/__cts__.xml
+++ b/data/phi0448/phi001/__cts__.xml
@@ -2,22 +2,21 @@
 
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:latinLit:phi0448" urn="urn:cts:latinLit:phi0448.phi001" xml:lang="lat">
         <ti:title xml:lang="eng">Gallic War</ti:title>
+        <ti:title xml:lang="lat">De Bello Gallico</ti:title>
     
     <ti:edition workUrn="urn:cts:latinLit:phi0448.phi001" urn="urn:cts:latinLit:phi0448.phi001.perseus-lat2">
-            <ti:label xml:lang="lat">
-                Gallic War, C. Iuli Caesaris Commentarii rerum in Gallia gestarum VII A. Hirti Commentarius VIII
-            </ti:label>
+            <ti:label xml:lang="lat">De Bello Gallico</ti:label>
             <ti:description xml:lang="eng">
-                Caesar, Julius, creator; Hirtius, Aulus, creator; Holmes, T. Rice (Thomas Rice), 1855-1933, editor
+                C. Iuli Commentarii Rerum in Gallia Gestarum VII A. Hirti Commentarius VII; Caesar, Julius, creator; Hirtius, Aulus, creator; Holmes, T. Rice (Thomas Rice), 1855-1933, editor
             </ti:description>
         </ti:edition>
     
     <ti:translation urn="urn:cts:latinLit:phi0448.phi001.perseus-eng2" workUrn="urn:cts:latinLit:phi0448.phi001" xml:lang="eng">
         <ti:label xml:lang="eng">
-            Gallic War, Caesar's Commentaries on the Gallic and civil wars with the supplementary books attributed to Hirtius : including the Alexandrian, African and Spanish Wars
+            Gallic War
         </ti:label>
         <ti:description xml:lang="eng">
-            Caesar, Julius, creator; Hirtius, Aulus, creator, Author of Book VIII; Hirtius, Aulus, creator; McDevitte, W. A. (William Alexander), translator; Bohn, W. S, translator
+            Gallic War, Caesar's Commentaries on the Gallic and civil wars with the supplementary books attributed to Hirtius : including the Alexandrian, African and Spanish Wars. Caesar, Julius, creator; Hirtius, Aulus, creator, Author of Book VIII; Hirtius, Aulus, creator; McDevitte, W. A. (William Alexander), translator; Bohn, W. S, translator
         </ti:description>
     </ti:translation>
     

--- a/data/phi0448/phi002/__cts__.xml
+++ b/data/phi0448/phi002/__cts__.xml
@@ -2,6 +2,7 @@
 
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:latinLit:phi0448" urn="urn:cts:latinLit:phi0448.phi002" xml:lang="lat">
         <ti:title xml:lang="eng">Civil War</ti:title>
+        <ti:title xml:lang="lat">De Bello Civili</ti:title>
     
     <ti:edition workUrn="urn:cts:latinLit:phi0448.phi002" urn="urn:cts:latinLit:phi0448.phi002.perseus-lat2" xml:lang="lat">
             <ti:label xml:lang="lat">De Bello Civili</ti:label>
@@ -9,7 +10,7 @@
         </ti:edition>
     
     <ti:translation urn="urn:cts:latinLit:phi0448.phi002.perseus-eng2" workUrn="urn:cts:latinLit:phi0448.phi002" xml:lang="eng">
-        <ti:label xml:lang="eng">Caesar's Commentaries of the Civil War</ti:label>
+        <ti:label xml:lang="eng">Civil War</ti:label>
         <ti:description xml:lang="eng">Caesar, Julius. The Commentaries of Caesar. Duncan, William, editor, translator. St. Louis: Edwards and Bushnell, 1856.</ti:description>
     </ti:translation>
     

--- a/data/phi0474/phi002/phi0474.phi002.perseus-lat2.xml
+++ b/data/phi0474/phi002/phi0474.phi002.perseus-lat2.xml
@@ -2,14 +2,14 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"
 schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader xml:lang="eng">
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-	           <title>Sextus Roscius</title>
-	           <title>Pro Sex. Roscio, De imperio Cn. Pompei, Pro Cluentio, In Catilinam, Pro Murena, Pro Caelio</title>
-	           <title type="sub">Machine readable text</title>
-	           <author n="Cic.">M. Tullius Cicero</author>
-	           <editor role="editor" n="OCT">Albert Clark</editor>
+            <title>Sextus Roscius</title>
+            <title>Pro Sex. Roscio, De imperio Cn. Pompei, Pro Cluentio, In Catilinam, Pro Murena, Pro Caelio</title>
+            <title type="sub">Machine readable text</title>
+            <author n="Cic.">M. Tullius Cicero</author>
+            <editor role="editor" n="OCT">Albert Clark</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -22,7 +22,6 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
                <name>David Smith</name>
             </respStmt>
             <funder n="org:NEH">National Endowment For The Humanities (NEH)</funder>
-      
          </titleStmt>
          <publicationStmt>
             <publisher>Trustees of Tufts University</publisher>
@@ -30,34 +29,33 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
             <authority>Perseus Project</authority>
             <date type="release">1997-10-28</date>
          </publicationStmt>
-	
          <sourceDesc>
-	           <biblStruct>
-	              <monogr>
-	                 <author>M. Tullius Cicero</author>
-	                 <title>M. Tulli Ciceronis Orationes:
+            <biblStruct>
+               <monogr>
+                  <author>M. Tullius Cicero</author>
+                  <title>M. Tulli Ciceronis Orationes:
 Recognovit brevique adnotatione critica instruxit
 Albertus Curtis Clark
 Collegii Reginae Socius</title>
-	                 <editor role="editor">Albert Curtis Clark</editor>
-	                 <imprint>
-	                    <pubPlace>Oxonii</pubPlace>
-	                    <publisher>e Typographeo Clarendoniano</publisher>
-	                    <date>1908</date>
-	                 </imprint>
-	              </monogr>
-	              <series>	    
+                  <editor role="editor">Albert Curtis Clark</editor>
+                  <imprint>
+                     <pubPlace>Oxonii</pubPlace>
+                     <publisher>e Typographeo Clarendoniano</publisher>
+                     <date>1908</date>
+                  </imprint>
+               </monogr>
+               <series>
                   <title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
-	              </series>
-                 <ref target="https://archive.org/details/orationesrecogno01ciceuoft">Internet Archive</ref>
-	           </biblStruct>
+               </series>
+               <ref target="https://archive.org/details/orationesrecogno01ciceuoft">Internet Archive</ref>
+            </biblStruct>
          </sourceDesc>
       </fileDesc>
-    
       <encodingDesc>
          <refsDecl n="CTS">
-            <cRefPattern n="section" matchPattern="(\w+)"
-               replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+            <cRefPattern n="section"
+                         matchPattern="(\w+)"
+                         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
                <p>This pointer pattern extracts section</p>
             </cRefPattern>
          </refsDecl>
@@ -75,14 +73,12 @@ Collegii Reginae Socius</title>
 	           <refState unit="chapter"/>
          </refsDecl>-->
       </encodingDesc>
-    
       <profileDesc>
          <langUsage>
-	           <language ident="lat">Latin</language>
+            <language ident="lat">Latin</language>
             <language ident="grc">Greek</language>
          </langUsage>
       </profileDesc>
-    
       <revisionDesc>
          <change when="2016-01-29" who="Lisa Cerrato">made section canonical scheme</change>
          <change when="2014-11-06" who="Thibault Clerice">Moving to Epidoc with new URN</change>
@@ -121,351 +117,460 @@ Collegii Reginae Socius</title>
    </teiHeader>
    <text>
       <body>
-         <div type="edition"  xml:lang="lat" n="urn:cts:latinLit:phi0474.phi002.perseus-lat2">
-               <head>
-                  <choice><abbr>M.</abbr><expan>M<ex>arci</ex></expan></choice> Tulli Ciceronis pro Sex. Roscio Amerino Oratio</head>
-               
-         <milestone n="1" unit="chapter"/><milestone unit="para"/>
-            <div type="textpart" subtype="section" n="1"><p>
-               <reg>credo</reg> ego vos, iudices, mirari quid sit quod, cum<note>
-                  <app><lem>cum</lem></app> quom <hi rend="italics">A<foreign xml:lang="grc">p2y2w</foreign>
-                  </hi>
-               </note> tot summi oratores 
-hominesque nobilissimi sedeant, ego potissimum surrexerim<note>surrexerim is <foreign xml:lang="grc">S</foreign>, <hi rend="italics">Naugerius</hi> (2): surrexerimus <hi rend="italics">
-                     <foreign xml:lang="grc">A</foreign>
-                  </hi>: surrexerim <hi rend="italics">cett.</hi>
-               </note>, is qui 
+         <div type="edition"
+              xml:lang="lat"
+              n="urn:cts:latinLit:phi0474.phi002.perseus-lat2">
+            <head>
+               <choice>
+                  <abbr>M.</abbr>
+                  <expan>M<ex>arci</ex>
+                  </expan>
+               </choice> Tulli Ciceronis pro Sex. Roscio Amerino Oratio</head>
+            <milestone n="1" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="1">
+               <p>
+                  <reg>credo</reg> ego vos, iudices, mirari quid sit quod, cum<note>
+                     <app>
+                        <lem>cum</lem>
+                     </app> quom <hi rend="italics">A<foreign xml:lang="grc">π2ψ2ω</foreign>
+                     </hi>
+                  </note> tot summi oratores 
+hominesque nobilissimi sedeant, ego potissimum surrexerim<note>surrexerim is <foreign xml:lang="grc">ς</foreign>, <hi rend="italics">Naugerius</hi> (2): surrexerimus <hi rend="italics">
+                        <foreign xml:lang="grc">α</foreign>
+                     </hi>: surrexerim <hi rend="italics">cett.</hi>
+                  </note>, is qui 
 neque aetate neque ingenio neque auctoritate sim cum his qui 
 sedeant comparandus.  <reg>omnes</reg> hi quos videtis adesse in hac causa 
 iniuriam novo scelere conflatam putant oportere defendi, defendere 
 ipsi<note>ipsi autem <hi rend="italics">V</hi>
-               </note> propter iniquitatem temporum non audent.  <reg>ita</reg> fit ut adsint propterea 
+                  </note> propter iniquitatem temporum non audent.  <reg>ita</reg> fit ut adsint propterea 
 quod officium sequuntur, taceant autem idcirco quia 
 periculum vitant.<note>vitant <hi rend="italics">V</hi>, <hi rend="italics">Auct. Schem. Dianoeas (Rhet. M. p.</hi> 73): metuunt <hi rend="italics">cett.</hi>
-               </note></p></div> 
-
-               <div type="textpart" subtype="section" n="2"><p>
-               <reg>quid</reg> ergo? audacissimus ego ex omnibus?  <reg>minime</reg>.  
+                  </note>
+               </p>
+            </div>
+            <div type="textpart" subtype="section" n="2">
+               <p>
+                  <reg>quid</reg> ergo? audacissimus ego ex omnibus?  <reg>minime</reg>.  
 <reg>an</reg>
-               <note>An <hi rend="italics">Schol.</hi>: at (ac <hi rend="italics">V<foreign xml:lang="grc">w</foreign>
-                  </hi>) <hi rend="italics">codd.</hi>
-               </note> tanto officiosior quam ceteri? <reg>ne</reg> istius quidem laudis ita sum<note>
-                  <app><lem>sum</lem></app> sim <hi rend="italics">V<foreign xml:lang="grc">w</foreign>
-                  </hi>
-               </note> 
+                  <note>An <hi rend="italics">Schol.</hi>: at (ac <hi rend="italics">V<foreign xml:lang="grc">ω</foreign>
+                     </hi>) <hi rend="italics">codd.</hi>
+                  </note> tanto officiosior quam ceteri? <reg>ne</reg> istius quidem laudis ita sum<note>
+                     <app>
+                        <lem>sum</lem>
+                     </app> sim <hi rend="italics">V<foreign xml:lang="grc">ω</foreign>
+                     </hi>
+                  </note> 
 cupidus ut aliis eam praereptam velim.  <reg>quae</reg> me igitur res praeter 
 ceteros impulit ut causam Sex. Rosci reciperem? <reg>quia</reg>, si qui istorum 
 dixisset quos videtis adesse, in quibus summa auctoritas est atque 
 amplitudo, si verbum de re publica fecisset, id quod in hac causa fieri 
-necesse est, multo plura dixisse quam dixisset putaretur.</p></div>  
-
-<div type="textpart" subtype="section" n="3"><p>
-               <reg>ego</reg> autem 
+necesse est, multo plura dixisse quam dixisset putaretur.</p>
+            </div>
+            <div type="textpart" subtype="section" n="3">
+               <p>
+                  <reg>ego</reg> autem 
 si<note>autem si <hi rend="italics">V</hi>: etiam si <hi rend="italics">cett.</hi>: <hi rend="italics">om. Charisius (K.</hi> 1.203)</note> omnia quae dicenda sunt libere dixero, nequaquam tamen similiter 
 oratio mea exire atque<note>
-                  <app><lem>atque</lem></app> 
-                  <q>atquo</q> ne <foreign xml:lang="grc">S</foreign>: <hi rend="italics">fort.</hi> neque</note> in volgus emanare poterit.  <reg>deinde</reg> quod 
+                     <app>
+                        <lem>atque</lem>
+                     </app>
+                     <q>atquo</q> ne <foreign xml:lang="grc">ς</foreign>: <hi rend="italics">fort.</hi> neque</note> in volgus emanare poterit.  <reg>deinde</reg> quod 
 ceterorum neque dictum obscurum potest esse propter nobilitatem et 
 amplitudinem<note>potest esse <hi rend="italics">post</hi> amplitudinem <hi rend="italics">hab. A.</hi>
-               </note> neque temere dicto concedi propter aetatem et
+                  </note> neque temere dicto concedi propter aetatem et
 prudentiam.  <reg>ego</reg> si quid liberius dixero, vel occultum esse propterea 
 quod nondum ad rem publicam accessi, vel ignosci adulescentiae 
 meae<note>meae <hi rend="italics">om. V</hi>
-               </note> poterit; tametsi non modo ignoscendi ratio verum etiam 
-   cognoscendi consuetudo iam de civitate sublata est.</p></div>
-
-<div type="textpart" subtype="section" n="4"><p>
-               <reg>accedit</reg> illa 
+                  </note> poterit; tametsi non modo ignoscendi ratio verum etiam 
+   cognoscendi consuetudo iam de civitate sublata est.</p>
+            </div>
+            <div type="textpart" subtype="section" n="4">
+               <p>
+                  <reg>accedit</reg> illa 
 quoque causa quod a ceteris forsitan ita petitum sit ut dicerent, ut 
 utrumvis salvo officio se facere<note>se facere <hi rend="italics">mei</hi>: fa.... e <hi rend="italics">V</hi> (<hi rend="italics">litt. med. abscisis</hi>): facere se <hi rend="italics">ed. Ven.</hi>
-               </note> posse arbitrarentur; a me autem ei 
+                  </note> posse arbitrarentur; a me autem ei 
 contenderunt qui apud me et amicitia et beneficiis et dignitate 
 plurimum possunt, quorum ego nec<note>ego nec <hi rend="italics">V</hi>: ego neque <hi rend="italics">cett.</hi>
-               </note> benevolentiam erga me ignorare 
+                  </note> benevolentiam erga me ignorare 
 nec auctoritatem aspernari nec voluntatem neglegere debebam<note>debebam <hi rend="italics">Ernesti</hi>: debeam <hi rend="italics">codd.</hi> (<hi rend="italics">cf. Zielinski p.</hi> 191)</note>.  
 
 </p>
-         </div>
-         <milestone n="2" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="5"><p>
-
-               <reg>his</reg> 
+            </div>
+            <milestone n="2" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="5">
+               <p>
+                  <reg>his</reg> 
 de causis ego huic causae patronus exstiti, non electus unus qui 
 maximo ingenio sed relictus ex omnibus qui minimo periculo possem<note>possim <hi rend="italics">V</hi>
-               </note> 
+                  </note> 
 dicere, neque uti satis firmo praesidio defensus Sex. Roscius verum 
 uti ne omnino desertus esset.
 
 
                <reg>forsitan</reg> quaeratis qui iste terror sit et quae tanta formido quae tot 
 ac talis viros impediat quo minus pro capite et fortunis alterius quem 
-ad modum consuerunt<note>consueverunt <foreign xml:lang="grc">fw</foreign> (<hi rend="italics">ita</hi> §8 <foreign xml:lang="grc">w</foreign>, §12 <foreign xml:lang="grc">xyw</foreign>)</note> causam velint dicere.  <reg>quod</reg> adhuc vos 
+ad modum consuerunt<note>consueverunt <foreign xml:lang="grc">φω</foreign> (<hi rend="italics">ita</hi> §8 <foreign xml:lang="grc">ω</foreign>, §12 <foreign xml:lang="grc">χψω</foreign>)</note> causam velint dicere.  <reg>quod</reg> adhuc vos 
 ignorare non mirum est, propterea quod consulto ab accusatoribus 
-eius rei quae conflavit hoc iudicium mentio facta non est.</p></div> 
-
-<div type="textpart" subtype="section" n="6"><p>
-               <reg>quae</reg> res 
+eius rei quae conflavit hoc iudicium mentio facta non est.</p>
+            </div>
+            <div type="textpart" subtype="section" n="6">
+               <p>
+                  <reg>quae</reg> res 
 ea est? <reg>bona</reg> patris huiusce Sex. Rosci quae sunt sexagiens, quae de<note>
-                  <app><lem>quae de</lem></app> de <hi rend="italics">Weiske</hi>
-               </note> 
+                     <app>
+                        <lem>quae de</lem>
+                     </app> de <hi rend="italics">Weiske</hi>
+                  </note> 
 viro fortissimo et clarissimo<note>
-                  <app><lem>fortissimo et clarissimo</lem></app> 
-                  <hi rend="italics">om.</hi> fortissimo et <hi rend="italics">A</hi>: clarissimo et fortissimo <foreign xml:lang="grc">y</foreign>, <hi rend="italics">Arusian.</hi> (<hi rend="italics">K.</hi> vii. 470)</note> 
-               <choice><abbr>L.</abbr><expan>L<ex>ucio</ex></expan></choice> Sulla, quem honoris causa nomino, 
+                     <app>
+                        <lem>fortissimo et clarissimo</lem>
+                     </app>
+                     <hi rend="italics">om.</hi> fortissimo et <hi rend="italics">A</hi>: clarissimo et fortissimo <foreign xml:lang="grc">ψ</foreign>, <hi rend="italics">Arusian.</hi> (<hi rend="italics">K.</hi> vii. 470)</note>
+                  <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucio</ex>
+                     </expan>
+                  </choice> Sulla, quem honoris causa nomino, 
 duobus milibus nummum sese dicit emisse adulescens vel 
-potentissimus hoc tempore nostrae civitatis, <choice><abbr>L.</abbr><expan>L<ex>ucius</ex></expan></choice> Cornelius 
+potentissimus hoc tempore nostrae civitatis, <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucius</ex>
+                     </expan>
+                  </choice> Cornelius 
 Chrysogonus.  <reg>is</reg> a vobis, iudices, hoc postulat ut, quoniam in alienam 
 pecuniam tam plenam atque praeclaram nullo iure invaserit, 
 quoniamque ei pecuniae vita Sex. Rosci obstare atque officere 
 videatur, deleatis ex
-animo suo suspicionem omnem metumque<note>omnemque metum <foreign xml:lang="grc">w</foreign>
-               </note> tollatis; sese hoc incolumi 
+animo suo suspicionem omnem metumque<note>omnemque metum <foreign xml:lang="grc">ω</foreign>
+                  </note> tollatis; sese hoc incolumi 
 non arbitratur huius innocentis patrimonium tam amplum et 
-copiosum posse obtinere, damnato et eiecto sperat<note>sperat <foreign xml:lang="grc">sx</foreign>: speret <hi rend="italics">cett.</hi>
-               </note> se posse quod 
-adeptus est per scelus, id per luxuriam<note>luxoriam <foreign xml:lang="grc">S<hi rend="italics">A</hi>y2</foreign> (<hi rend="italics">ita</hi> 
-                  <foreign xml:lang="grc">S</foreign> 
-                  <hi rend="italics">semper</hi>)</note> effundere atque consumere. 
+copiosum posse obtinere, damnato et eiecto sperat<note>sperat <foreign xml:lang="grc">σχ</foreign>: speret <hi rend="italics">cett.</hi>
+                  </note> se posse quod 
+adeptus est per scelus, id per luxuriam<note>luxoriam <foreign xml:lang="grc">ς<hi rend="italics">α</hi>ψ2</foreign> (<hi rend="italics">ita</hi>
+                     <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">semper</hi>)</note> effundere atque consumere. 
 <reg>hunc</reg> sibi ex animo scrupulum qui se dies noctesque stimulat ac<note>stimulet ac punget <hi rend="italics">Ernesti</hi>
-               </note> 
+                  </note> 
 pungit ut evellatis postulat, ut ad hanc suam praedam tam nefariam 
-adiutores vos profiteamini.</p></div>
-
-               <div type="textpart" subtype="section" n="7"><p>
-               <reg>si</reg>
-               <note>
-                  <app><lem>si</lem></app> nisi <hi rend="italics">w, Halm</hi> (2)</note> vobis aequa et honesta postulatio<note>
-                  <app><lem>postulatio</lem></app> ista postulatio <hi rend="italics">Richter</hi> (<hi rend="italics">fort.</hi> ea postulatio)</note> videtur, iudices, ego contra 
+adiutores vos profiteamini.</p>
+            </div>
+            <div type="textpart" subtype="section" n="7">
+               <p>
+                  <reg>si</reg>
+                  <note>
+                     <app>
+                        <lem>si</lem>
+                     </app> nisi <hi rend="italics">w, Halm</hi> (2)</note> vobis aequa et honesta postulatio<note>
+                     <app>
+                        <lem>postulatio</lem>
+                     </app> ista postulatio <hi rend="italics">Richter</hi> (<hi rend="italics">fort.</hi> ea postulatio)</note> videtur, iudices, ego contra 
 brevem postulationem adfero et, quo modo mihi persuadeo, 
 aliquanto aequiorem. 
-         <milestone n="3" unit="chapter"/><milestone unit="para"/>
-               <reg>primum</reg> a Chrysogono peto ut pecunia 
+         <milestone n="3" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>primum</reg> a Chrysogono peto ut pecunia 
 fortunisque nostris contentus sit, sanguinem et vitam ne petat; 
 deinde a vobis, iudices, ut audacium sceleri resistatis,<note>insistatis <hi rend="italics">A</hi>
-               </note> innocentium 
+                  </note> innocentium 
 calamitatem levetis et in causa Sex. Rosci periculum quod in omnis 
-intenditur propulsetis.</p></div>
-
-<div type="textpart" subtype="section" n="8"><p>
-               <reg>quod</reg> si aut causa criminis aut facti suspicio 
+intenditur propulsetis.</p>
+            </div>
+            <div type="textpart" subtype="section" n="8">
+               <p>
+                  <reg>quod</reg> si aut causa criminis aut facti suspicio 
 aut quaelibet denique vel minima res reperietur<note>reperiretur <hi rend="italics">A</hi>
-               </note> quam ob rem 
+                  </note> quam ob rem 
 videantur illi non nihil tamen in deferendo nomine secuti, postremo 
 si praeter eam praedam quam dixi quicquam aliud causae 
 inveneritis, non recusamus quin illorum<note>
-                  <app><lem>illorum</lem></app> eorum <hi rend="italics">w, prob. Halm</hi>
-               </note> libidini Sex. Rosci vita 
+                     <app>
+                        <lem>illorum</lem>
+                     </app> eorum <hi rend="italics">w, prob. Halm</hi>
+                  </note> libidini Sex. Rosci vita 
 dedatur.  <reg>sin</reg> aliud agitur nihil nisi ut eis ne quid desit quibus satis 
 nihil est, si hoc solum hoc tempore pugnatur ut ad illam opimam 
 praeclaramque praedam damnatio Sex. Rosci velut cumulus accedat, 
 nonne cum multa indigna tum vel hoc indignissimum est, vos idoneos 
 habitos per quorum sententias iusque iurandum id adsequantur 
 quod antea ipsi scelere et ferro adsequi consuerunt<note>consuerant <hi rend="italics">Ernesti</hi>
-               </note>? qui ex civitate 
+                  </note>? qui ex civitate 
 in senatum propter dignitatem, ex senatu in hoc consilium delecti 
 estis propter severitatem, ab his<note>
-                  <app><lem>his</lem></app> iis <hi rend="italics">coni. Halm</hi>
-               </note> hoc postulare 
+                     <app>
+                        <lem>his</lem>
+                     </app> iis <hi rend="italics">coni. Halm</hi>
+                  </note> hoc postulare 
 homines sicarios atque gladiatores, non modo ut supplicia vitent 
 quae a vobis pro maleficiis suis metuere atque horrere debent verum 
-etiam ut spoliis ex<note>spoliis ex <hi rend="italics">w</hi>: spoliis sex <foreign xml:lang="grc">Sp</foreign>: spoliis Sex. <hi rend="italics">A<foreign xml:lang="grc">fyw</foreign>
-                  </hi>: spoliis Sex. Roscii <foreign xml:lang="grc">sx</foreign>
-</note> hoc iudicio ornati auctique discedant?</p></div>
-
-         <milestone n="4" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="9"><p>
-               <reg>his</reg> de rebus tantis tamque atrocibus neque satis me commode 
+etiam ut spoliis ex<note>spoliis ex <hi rend="italics">w</hi>: spoliis sex <foreign xml:lang="grc">σπ</foreign>: spoliis Sex. <hi rend="italics">A<foreign xml:lang="grc">φψω</foreign>
+                     </hi>: spoliis Sex. Roscii <foreign xml:lang="grc">σχ</foreign>
+                  </note> hoc iudicio ornati auctique discedant?</p>
+            </div>
+            <milestone n="4" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="9">
+               <p>
+                  <reg>his</reg> de rebus tantis tamque atrocibus neque satis me commode 
 dicere neque satis graviter conqueri neque satis libere vociferari 
 posse intellego.  <reg>nam</reg> commoditati ingenium, gravitati aetas, libertati 
 tempora sunt impedimento.  <reg>huc</reg> accedit summus timor quem mihi 
 natura pudorque meus attribuit et vestra dignitas et vis 
-adversariorum et Sex. Rosci pericula<note>periculum <hi rend="italics">Bake</hi> (<hi rend="italics">cf.</hi> §§148, 152), <hi rend="italics">fort. recte</hi> (<hi rend="italics">Fuitne in archetypo</hi> peric., <hi rend="italics">quod hab.</hi> 
-                  <foreign xml:lang="grc">S</foreign> 
-                  <hi rend="italics">Mur.</hi> 84?)</note>.  <reg>quapropter</reg> vos oro atque 
-                  obsecro, iudices, ut attente bonaque cum venia verba mea audiatis.</p></div>  
-
-<div type="textpart" subtype="section" n="10"><p>
-               <reg>fide</reg> sapientiaque vestra fretus plus oneris sustuli quam ferre me 
+adversariorum et Sex. Rosci pericula<note>periculum <hi rend="italics">Bake</hi> (<hi rend="italics">cf.</hi> §§148, 152), <hi rend="italics">fort. recte</hi> (<hi rend="italics">Fuitne in archetypo</hi> peric., <hi rend="italics">quod hab.</hi>
+                     <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">Mur.</hi> 84?)</note>.  <reg>quapropter</reg> vos oro atque 
+                  obsecro, iudices, ut attente bonaque cum venia verba mea audiatis.</p>
+            </div>
+            <div type="textpart" subtype="section" n="10">
+               <p>
+                  <reg>fide</reg> sapientiaque vestra fretus plus oneris sustuli quam ferre me 
 posse intellego.  <reg>hoc</reg> onus si vos aliqua ex parte adlevabitis, feram ut 
 potero studio et industria, iudices; sin a vobis, id quod non spero, 
 deserar, tamen animo non deficiam et id quod suscepi quoad potero 
-perferam.  <reg>quod</reg> si perferre non potero<note>perferre non potero perferri <foreign xml:lang="grc">S</foreign>
-               </note>, opprimi me onere offici malo 
+perferam.  <reg>quod</reg> si perferre non potero<note>perferre non potero perferri <foreign xml:lang="grc">ς</foreign>
+                  </note>, opprimi me onere offici malo 
 quam id quod mihi cum fide semel impositum est aut propter 
-perfidiam abicere aut propter infirmitatem animi deponere.</p></div>  
-
-
-               <div type="textpart" subtype="section" n="11"><p>
-               <reg>te</reg> quoque magno opere, <choice><abbr>M.</abbr><expan>M<ex>arci</ex></expan></choice> Fanni, quaeso ut, qualem te iam antea 
-populo Romano praebuisti, cum huic eidem<note>eidem <foreign xml:lang="grc">w</foreign>, <hi rend="italics">Ant. Augustinus</hi>: idem <hi rend="italics">cett.</hi>.</note> quaestioni iudex<note>iudex <hi rend="italics">om.</hi> 
-                  <foreign xml:lang="grc">w</foreign>, <hi rend="italics">del. Halm</hi> (<hi rend="italics">contra Mart. Cap., Rhet. M. p.</hi> 470)</note> 
+perfidiam abicere aut propter infirmitatem animi deponere.</p>
+            </div>
+            <div type="textpart" subtype="section" n="11">
+               <p>
+                  <reg>te</reg> quoque magno opere, <choice>
+                     <abbr>M.</abbr>
+                     <expan>M<ex>arci</ex>
+                     </expan>
+                  </choice> Fanni, quaeso ut, qualem te iam antea 
+populo Romano praebuisti, cum huic eidem<note>eidem <foreign xml:lang="grc">ω</foreign>, <hi rend="italics">Ant. Augustinus</hi>: idem <hi rend="italics">cett.</hi>.</note> quaestioni iudex<note>iudex <hi rend="italics">om.</hi>
+                     <foreign xml:lang="grc">ω</foreign>, <hi rend="italics">del. Halm</hi> (<hi rend="italics">contra Mart. Cap., Rhet. M. p.</hi> 470)</note> 
 praeesses, talem te et nobis et rei<note>rei p. <hi rend="italics">Arusian.</hi> (<hi rend="italics">K.</hi> vii. 481): populo Rom. <hi rend="italics">codd. et Mart. Cap.</hi>
-               </note> publicae hoc tempore impertias.  
-         <milestone n="5" unit="chapter"/><milestone unit="para"/>
-
-               <reg>quanta</reg> multitudo hominum convenerit ad hoc iudicium vides; quae 
-sit omnium mortalium exspectatio, quae cupiditas ut acria<note>acria <foreign xml:lang="grc">y2</foreign>: acra <hi rend="italics">cett.</hi>
-               </note> ac 
+                  </note> publicae hoc tempore impertias.  
+         <milestone n="5" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>quanta</reg> multitudo hominum convenerit ad hoc iudicium vides; quae 
+sit omnium mortalium exspectatio, quae cupiditas ut acria<note>acria <foreign xml:lang="grc">ψ2</foreign>: acra <hi rend="italics">cett.</hi>
+                  </note> ac 
 severa iudicia fiant intellegis.  <reg>longo</reg> intervallo iudicium inter 
 sicarios hoc primum committitur, cum interea caedes indignissimae 
-maximaeque factae sunt<note>sint <foreign xml:lang="grc">f2</foreign>, <hi rend="italics">ed. R</hi>
-               </note>; omnes hanc quaestionem te praetore 
-manifestis maleficiis cotidianoque sanguine dignissimam<note>dignissimam <hi rend="italics">Madvig</hi> (<hi rend="italics">cf. May in Phil. Rundsch.</hi> x. 223): dimissui <foreign xml:lang="grc">S</foreign>: dimissius (demissius <foreign xml:lang="grc">y</foreign>: dimissus <foreign xml:lang="grc">w</foreign>) <hi rend="italics">cett.</hi>: remedio (remedium) esse <hi rend="italics">E. F. Eberhard, Landgraf</hi>: (de manifestis maleficiis ante admissis cotidianoque sanguine <hi rend="italics">Lambinus</hi>)</note> sperant 
-                  futuram.</p></div>
-
-               <div type="textpart" subtype="section" n="12"><p>
-               <reg>qua</reg> vociferatione in ceteris iudiciis accusatores uti consuerunt, ea nos 
-hoc tempore utimur qui causam dicimus. <reg>petimus</reg> abs te, <choice><abbr>M.</abbr><expan>M<ex>arce</ex></expan></choice> Fanni, a 
+maximaeque factae sunt<note>sint <foreign xml:lang="grc">φ2</foreign>, <hi rend="italics">ed. R</hi>
+                  </note>; omnes hanc quaestionem te praetore 
+manifestis maleficiis cotidianoque sanguine dignissimam<note>dignissimam <hi rend="italics">Madvig</hi> (<hi rend="italics">cf. May in Phil. Rundsch.</hi> x. 223): dimissui <foreign xml:lang="grc">ς</foreign>: dimissius (demissius <foreign xml:lang="grc">ψ</foreign>: dimissus <foreign xml:lang="grc">ω</foreign>) <hi rend="italics">cett.</hi>: remedio (remedium) esse <hi rend="italics">E. F. Eberhard, Landgraf</hi>: (de manifestis maleficiis ante admissis cotidianoque sanguine <hi rend="italics">Lambinus</hi>)</note> sperant 
+                  futuram.</p>
+            </div>
+            <div type="textpart" subtype="section" n="12">
+               <p>
+                  <reg>qua</reg> vociferatione in ceteris iudiciis accusatores uti consuerunt, ea nos 
+hoc tempore utimur qui causam dicimus. <reg>petimus</reg> abs te, <choice>
+                     <abbr>M.</abbr>
+                     <expan>M<ex>arce</ex>
+                     </expan>
+                  </choice> Fanni, a 
 vobisque, iudices, ut quam acerrime maleficia vindicetis, ut quam 
 fortissime hominibus audacissimis resistatis, ut hoc cogitetis, nisi in 
 hac causa qui vester animus sit ostendetis<note>
-                  <app><lem>ostendetis</lem></app> ostenderitis <hi rend="italics">Ernesti</hi>: ostendatis <hi rend="italics">Matthiae</hi>
-               </note>, eo prorumpere hominum 
+                     <app>
+                        <lem>ostendetis</lem>
+                     </app> ostenderitis <hi rend="italics">Ernesti</hi>: ostendatis <hi rend="italics">Matthiae</hi>
+                  </note>, eo prorumpere hominum 
 cupiditatem et scelus et audaciam ut non modo clam verum etiam hic 
-in foro ante tribunal tuum, <choice><abbr>M.</abbr><expan>M<ex>arci</ex></expan></choice> Fanni, ante pedes vestros, iudices, 
-                  inter ipsa subsellia caedes futurae sint. </p></div>
-
-<div type="textpart" subtype="section" n="13"><p>
-               <reg>etenim</reg> quid aliud hoc iudicio 
+in foro ante tribunal tuum, <choice>
+                     <abbr>M.</abbr>
+                     <expan>M<ex>arci</ex>
+                     </expan>
+                  </choice> Fanni, ante pedes vestros, iudices, 
+                  inter ipsa subsellia caedes futurae sint. </p>
+            </div>
+            <div type="textpart" subtype="section" n="13">
+               <p>
+                  <reg>etenim</reg> quid aliud hoc iudicio 
 temptatur nisi ut id fieri liceat? <reg>accusant</reg> ei qui in fortunas huius 
 invaserunt, causam dicit is cui praeter calamitatem nihil reliquerunt; 
 accusant ei quibus occidi patrem Sex. Rosci bono fuit, causam dicit is 
 cui non modo luctum mors patris attulit verum etiam egestatem; 
 accusant ei qui hunc ipsum<note>
-                  <app><lem>ipsum</lem></app> ipsi <hi rend="italics">coni. Halm</hi>
-               </note> iugulare summe cupierunt, causam dicit 
+                     <app>
+                        <lem>ipsum</lem>
+                     </app> ipsi <hi rend="italics">coni. Halm</hi>
+                  </note> iugulare summe cupierunt, causam dicit 
 is qui etiam ad hoc ipsum iudicium cum praesidio venit ne hic ibidem 
 ante oculos vestros trucidetur; denique accusant ei quos populus 
 poscit, causam dicit is qui unus relictus ex illorum nefaria caede 
-restat.</p></div> 
-
-<div type="textpart" subtype="section" n="14"><p>
-               <reg>atque</reg> ut facilius intellegere possitis, iudices, ea quae facta 
+restat.</p>
+            </div>
+            <div type="textpart" subtype="section" n="14">
+               <p>
+                  <reg>atque</reg> ut facilius intellegere possitis, iudices, ea quae facta 
 sunt indigniora esse quam haec sunt quae dicimus, ab initio res quem 
 ad modum gesta sit vobis<note>vobis <hi rend="italics">om. A</hi>
-               </note> exponemus, quo facilius et huius hominis 
-innocentissimi miserias et illorum audacias<note>audacias <foreign xml:lang="grc">S</foreign> (<hi rend="italics">cf. Verr.</hi> iii. 208, <hi rend="italics">Sull.</hi> 76): audaciam <hi rend="italics">cett.</hi>
-               </note> cognoscere possitis et rei 
-   publicae calamitatem.</p></div>
-
-         <milestone n="6" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="15"><p>Sex. Roscius, pater huiusce, municeps Amerinus fuit, cum genere et 
+                  </note> exponemus, quo facilius et huius hominis 
+innocentissimi miserias et illorum audacias<note>audacias <foreign xml:lang="grc">ς</foreign> (<hi rend="italics">cf. Verr.</hi> iii. 208, <hi rend="italics">Sull.</hi> 76): audaciam <hi rend="italics">cett.</hi>
+                  </note> cognoscere possitis et rei 
+   publicae calamitatem.</p>
+            </div>
+            <milestone n="6" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="15">
+               <p>Sex. Roscius, pater huiusce, municeps Amerinus fuit, cum genere et 
 nobilitate et pecunia non modo sui municipi
 verum etiam eius vicinitatis facile primus, tum gratia atque hospitiis 
 florens hominum nobilissimorum.  <reg>nam</reg> cum Metellis, Serviliis, 
 Scipionibus erat ei non modo hospitium verum etiam domesticus 
 usus et consuetudo, quas, ut aequum est, familias honestatis 
 amplitudinisque gratia nomino. <reg>itaque</reg>
-               <note>
-                  <app><lem>itaque</lem></app> atque <hi rend="italics">Halm</hi> (2)</note> ex suis omnibus<note>ex omnibus suis <foreign xml:lang="grc">w</foreign>
-               </note> commodis 
+                  <note>
+                     <app>
+                        <lem>itaque</lem>
+                     </app> atque <hi rend="italics">Halm</hi> (2)</note> ex suis omnibus<note>ex omnibus suis <foreign xml:lang="grc">ω</foreign>
+                  </note> commodis 
 hoc solum filio reliquit; nam patrimonium domestici praedones vi 
 ereptum possident, fama et vita innocentis ab hospitibus amicisque 
-paternis defenditur.</p></div>  
-
-<div type="textpart" subtype="section" n="16"><p>
-               <reg>hic</reg>
-               <note>
-                  <app><lem>hic</lem></app> is <hi rend="italics">Halm</hi> (2)</note> cum omni tempore nobilitatis fautor fuisset 
+paternis defenditur.</p>
+            </div>
+            <div type="textpart" subtype="section" n="16">
+               <p>
+                  <reg>hic</reg>
+                  <note>
+                     <app>
+                        <lem>hic</lem>
+                     </app> is <hi rend="italics">Halm</hi> (2)</note> cum omni tempore nobilitatis fautor fuisset 
 tum hoc tumultu proximo, cum omnium nobilium dignitas et salus in 
 discrimen veniret, praeter ceteros in ea vicinitate eam partem 
 causamque opera, studio, auctoritate defendit.  <reg>etenim</reg> rectum 
 putabat pro eorum honestate se pugnare propter quos ipse 
 honestissimus inter suos numerabatur.  <reg>postea</reg> quam victoria 
 constituta est ab armisque recessimus, cum proscriberentur homines<note>
-                  <app><lem>homines</lem></app> omnes <hi rend="italics">A. Eberhard</hi>
-               </note> 
+                     <app>
+                        <lem>homines</lem>
+                     </app> omnes <hi rend="italics">A. Eberhard</hi>
+                  </note> 
 atque ex omni regione caperentur ei qui adversarii fuisse 
 putabantur, erat ille Romae frequens atque<note>atque <hi rend="italics">om. pauci dett.</hi>
-               </note> in foro et in ore omnium 
+                  </note> in foro et in ore omnium 
 cotidie versabatur, magis ut exsultare victoria nobilitatis videretur 
-quam timere ne quid ex ea calamitatis sibi accideret.</p></div>
-
-
-               <div type="textpart" subtype="section" n="17"><p>
-               <reg>erant</reg> ei veteres inimicitiae cum duobus Rosciis Amerinis, quorum 
+quam timere ne quid ex ea calamitatis sibi accideret.</p>
+            </div>
+            <div type="textpart" subtype="section" n="17">
+               <p>
+                  <reg>erant</reg> ei veteres inimicitiae cum duobus Rosciis Amerinis, quorum 
 alterum sedere in accusatorum subselliis video, alterum tria huiusce 
 praedia possidere audio; quas inimicitias si tam cavere potuisset 
 quam metuere solebat viveret. <reg>neque</reg> enim, iudices, iniuria 
-metuebat.  <reg>nam</reg> duo isti sunt <choice><abbr>T.</abbr><expan>T<ex>iti</ex></expan></choice> Roscii, quorum alteri Capitoni 
+metuebat.  <reg>nam</reg> duo isti sunt <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>iti</ex>
+                     </expan>
+                  </choice> Roscii, quorum alteri Capitoni 
 cognomen est, iste qui adest Magnus vocatur, homines eius modi:<note>huius modi <hi rend="italics">Reisig</hi>
-               </note> 
+                  </note> 
 alter plurimarum palmarum vetus ac nobilis gladiator habetur, hic 
 autem nuper se ad eum lanistam contulit, quique<note>quique <hi rend="italics">Halm</hi>: qui <hi rend="italics">codd.</hi>: et qui <hi rend="italics">Madvig</hi>
-               </note> ante hanc pugnam 
+                  </note> ante hanc pugnam 
 tiro esset quod sciam<note>
-                  <app><lem>quod sciam</lem></app> quod scientiam <foreign xml:lang="grc">xw1</foreign>, <hi rend="italics">del. Garatoni</hi>
-               </note>, facile ipsum magistrum scelere audaciaque 
+                     <app>
+                        <lem>quod sciam</lem>
+                     </app> quod scientiam <foreign xml:lang="grc">χω1</foreign>, <hi rend="italics">del. Garatoni</hi>
+                  </note>, facile ipsum magistrum scelere audaciaque 
 superavit. 
 
 
             </p>
-         </div>
-         <milestone n="7" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="18"><p>
-               <reg>nam</reg> cum hic Sex. Roscius esset Ameriae, T. autem 
+            </div>
+            <milestone n="7" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="18">
+               <p>
+                  <reg>nam</reg> cum hic Sex. Roscius esset Ameriae, T. autem 
 iste Roscius Romae, cum hic filius<note>filius <hi rend="italics">del. Halm</hi>
-               </note> adsiduus in praediis esset 
+                  </note> adsiduus in praediis esset 
 cumque se voluntate patris rei familiari vitaeque rusticae dedisset, 
-ipse<note>ipse <hi rend="italics">A. Eberhard</hi>: iste <hi rend="italics">codd.</hi> (<hi rend="italics">cf.</hi> §17)</note> autem frequens Romae esset, occiditur ad balneas Pallacinas<note>Pallacinas <foreign xml:lang="grc">S<hi rend="italics">A</hi>psy</foreign>: Palatinas <foreign xml:lang="grc">fx</foreign>: Paluatinas <foreign xml:lang="grc">w</foreign>
-               </note> 
+ipse<note>ipse <hi rend="italics">A. Eberhard</hi>: iste <hi rend="italics">codd.</hi> (<hi rend="italics">cf.</hi> §17)</note> autem frequens Romae esset, occiditur ad balneas Pallacinas<note>Pallacinas <foreign xml:lang="grc">ς<hi rend="italics">α</hi>πσψ</foreign>: Palatinas <foreign xml:lang="grc">φχ</foreign>: Paluatinas <foreign xml:lang="grc">ω</foreign>
+                  </note> 
 rediens a cena Sex. Roscius. <reg>spero</reg> ex hoc ipso non esse obscurum ad 
 quem suspicio malefici pertineat; verum id quod adhuc est 
 suspiciosum<note>est suspiciosum adhuc <hi rend="italics">A</hi>
-               </note> nisi perspicuum res ipsa fecerit, hunc adfinem culpae 
-                  iudicatote.</p></div>
-
-
-               <div type="textpart" subtype="section" n="19"><p>
-               <reg>occiso</reg> Sex. Roscio primus Ameriam nuntiat Mallius Glaucia quidam, 
-homo tenuis, libertinus, cliens et familiaris istius <choice><abbr>T.</abbr><expan>T<ex>iti</ex></expan></choice> Rosci, et nuntiat 
-domum non fili sed <choice><abbr>T.</abbr><expan>T<ex>iti</ex></expan></choice> Capitonis inimici; et cum post horam primam 
+                  </note> nisi perspicuum res ipsa fecerit, hunc adfinem culpae 
+                  iudicatote.</p>
+            </div>
+            <div type="textpart" subtype="section" n="19">
+               <p>
+                  <reg>occiso</reg> Sex. Roscio primus Ameriam nuntiat Mallius Glaucia quidam, 
+homo tenuis, libertinus, cliens et familiaris istius <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>iti</ex>
+                     </expan>
+                  </choice> Rosci, et nuntiat 
+domum non fili sed <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>iti</ex>
+                     </expan>
+                  </choice> Capitonis inimici; et cum post horam primam 
 noctis occisus esset, primo diluculo nuntius hic Ameriam venit; 
 decem horis nocturnis sex et quinquaginta milia passuum cisiis<note>cisiis <hi rend="italics">Schol.</hi>: cissis <hi rend="italics">codd.</hi>
-               </note> pervolavit, 
+                  </note> pervolavit, 
 non modo ut exoptatum inimico nuntium primus adferret sed 
 etiam cruorem inimici quam recentissimum telumque paulo ante e 
-corpore extractum ostenderet.</p></div> 
-
-<div type="textpart" subtype="section" n="20"><p>
-               <reg>quadriduo</reg> quo haec gesta sunt res 
+corpore extractum ostenderet.</p>
+            </div>
+            <div type="textpart" subtype="section" n="20">
+               <p>
+                  <reg>quadriduo</reg> quo haec gesta sunt res 
 ad Chrysogonum in castra
-<choice><abbr>L.</abbr><expan>L<ex>ucii</ex></expan></choice> Sullae Volaterras defertur; magnitudo pecuniae demonstratur; 
+<choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucii</ex>
+                     </expan>
+                  </choice> Sullae Volaterras defertur; magnitudo pecuniae demonstratur; 
 bonitas praediorum — nam fundos decem et tris reliquit qui Tiberim 
 fere omnes tangunt — huius inopia et solitudo commemoratur; 
 demonstrant, cum pater huiusce Sex. Roscius, homo tam splendidus 
 et gratiosus, nullo negotio sit occisus, perfacile hunc hominem 
-incautum et rusticum<note>rusticum <hi rend="italics">ed. Guar.</hi>: rus (ruri <foreign xml:lang="grc">y2</foreign>) <hi rend="italics">codd.</hi>
-               </note> et Romae ignotum de medio tolli posse; ad eam 
+incautum et rusticum<note>rusticum <hi rend="italics">ed. Guar.</hi>: rus (ruri <foreign xml:lang="grc">ψ2</foreign>) <hi rend="italics">codd.</hi>
+                  </note> et Romae ignotum de medio tolli posse; ad eam 
 rem operam suam pollicentur.  
 
 </p>
-         </div>
-         <milestone n="8" unit="chapter"/><milestone unit="para"/>
-             <div type="textpart" subtype="section" n="21"><p>
-               <reg>ne</reg> diutius teneam<note>diutius vos teneam <hi rend="italics">ed. V</hi>
-               </note>, iudices, societas 
+            </div>
+            <milestone n="8" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="21">
+               <p>
+                  <reg>ne</reg> diutius teneam<note>diutius vos teneam <hi rend="italics">ed. V</hi>
+                  </note>, iudices, societas 
 coitur. <reg>cum</reg> nulla iam proscriptionis mentio fieret<note>cum nulla... fieret <hi rend="italics">Charisius</hi> (<hi rend="italics">K.</hi> i. 264) <hi rend="italics">Diomedes</hi> (<hi rend="italics">K.</hi> i. 390): cum... nulla fieret <hi rend="italics">codd.</hi>
-               </note>, cum etiam qui<note>
-                  <app><lem>qui</lem></app> omnes qui <hi rend="italics">Diomedes</hi>
-               </note> 
+                  </note>, cum etiam qui<note>
+                     <app>
+                        <lem>qui</lem>
+                     </app> omnes qui <hi rend="italics">Diomedes</hi>
+                  </note> 
 antea metuerant redirent ac iam defunctos
 sese periculis arbitrarentur, nomen refertur in tabulas Sex. Rosci<note>nomen... Rosci <hi rend="italics">Charisius et Diomedes, om. codd.</hi>
-               </note>, 
+                  </note>, 
 hominis studiosissimi nobilitatis; manceps fit Chrysogonus; tria 
 praedia vel nobilissima Capitoni propria traduntur, quae hodie 
-possidet; in reliquas omnis fortunas iste <choice><abbr>T.</abbr><expan>T<ex>itus</ex></expan></choice> Roscius nomine 
+possidet; in reliquas omnis fortunas iste <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itus</ex>
+                     </expan>
+                  </choice> Roscius nomine 
 Chrysogoni, quem ad modum ipse dicit, impetum facit.  <reg>haec</reg>
-               <note>
-                  <app><lem>facit</lem></app> haec bona emuntur sestertiorum duobus milibus nummum <hi rend="italics">add. codd.</hi> (<hi rend="italics">ex</hi> §6): <hi rend="italics">del. Kayser</hi>
-               </note> omnia, 
-iudices, imprudente <choice><abbr>L.</abbr><expan>L<ex>ucio</ex></expan></choice> Sulla facta esse certo<note>certo <hi rend="italics">s</hi>: certe <hi rend="italics">mei</hi>
-</note> scio.</p></div> 
-
-<div type="textpart" subtype="section" n="22"><p>
-               <reg>neque</reg> enim mirum, 
+                  <note>
+                     <app>
+                        <lem>facit</lem>
+                     </app> haec bona emuntur sestertiorum duobus milibus nummum <hi rend="italics">add. codd.</hi> (<hi rend="italics">ex</hi> §6): <hi rend="italics">del. Kayser</hi>
+                  </note> omnia, 
+iudices, imprudente <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucio</ex>
+                     </expan>
+                  </choice> Sulla facta esse certo<note>certo <hi rend="italics">s</hi>: certe <hi rend="italics">mei</hi>
+                  </note> scio.</p>
+            </div>
+            <div type="textpart" subtype="section" n="22">
+               <p>
+                  <reg>neque</reg> enim mirum, 
 cum eodem tempore et ea quae praeterita sunt reparet<note>reparet <hi rend="italics">cod. Lambini: om. mei</hi>: sanet <hi rend="italics">Rinkes</hi>
-               </note> et ea quae 
+                  </note> et ea quae 
 videntur instare praeparet, cum et pacis constituendae rationem et 
 belli gerendi potestatem solus habeat, cum omnes in unum spectent, 
 unus omnia gubernet, cum tot tantisque negotiis distentus sit ut 
@@ -473,178 +578,228 @@ respirare libere non possit, si aliquid non animadvertat, cum
 praesertim tam multi occupationem eius observent tempusque 
 aucupentur ut, simul atque ille despexerit, aliquid huiusce modi 
 moliantur. <reg>huc</reg> accedit quod, quamvis ille felix sit, sicut est, tamen in<note>in <hi rend="italics">del. Lambinus</hi>
-               </note> 
+                  </note> 
 tanta felicitate nemo potest esse in magna familia qui neminem 
-neque servum neque libertum improbum habeat. </p></div>
-
-<div type="textpart" subtype="section" n="23"><p>
-               <reg>interea</reg> iste T. 
+neque servum neque libertum improbum habeat. </p>
+            </div>
+            <div type="textpart" subtype="section" n="23">
+               <p>
+                  <reg>interea</reg> iste T. 
 Roscius, vir optimus, procurator Chrysogoni, Ameriam venit, in 
-praedia huius invadit, hunc miserum,  luctu perditum<note>perditum <hi rend="italics">w</hi>: praeditum (pro- <foreign xml:lang="grc">p</foreign>) <hi rend="italics">cett.</hi>
-               </note>, qui nondum 
+praedia huius invadit, hunc miserum,  luctu perditum<note>perditum <hi rend="italics">w</hi>: praeditum (pro- <foreign xml:lang="grc">π</foreign>) <hi rend="italics">cett.</hi>
+                  </note>, qui nondum 
 etiam omnia paterno funeri iusta solvisset, nudum eicit<note>eicit <hi rend="italics">ed. V, Sylvius</hi>: eiecit <hi rend="italics">codd.</hi>
-               </note> domo atque 
-focis patriis disque penatibus praecipitem, iudices, exturbat<note>iudices exturbat <foreign xml:lang="grc">pf1yw</foreign>: iudices sex (Sex. <hi rend="italics">A</hi>) turbat <foreign xml:lang="grc">S<hi rend="italics">A</hi>x</foreign>: Sex. Ro. (<hi rend="italics">om.</hi> Ro. <foreign xml:lang="grc">y2</foreign>) iud. exturbat <foreign xml:lang="grc">sy2</foreign>
-               </note>, ipse 
+                  </note> domo atque 
+focis patriis disque penatibus praecipitem, iudices, exturbat<note>iudices exturbat <foreign xml:lang="grc">πφ1ψω</foreign>: iudices sex (Sex. <hi rend="italics">A</hi>) turbat <foreign xml:lang="grc">ς<hi rend="italics">α</hi>χ</foreign>: Sex. Ro. (<hi rend="italics">om.</hi> Ro. <foreign xml:lang="grc">ψ2</foreign>) iud. exturbat <foreign xml:lang="grc">σψ2</foreign>
+                  </note>, ipse 
 amplissimae pecuniae fit dominus.  <reg>qui</reg> in sua re fuisset egentissimus, 
 erat, ut fit, insolens in aliena<note>aliena <hi rend="italics">Arusian.</hi> (<hi rend="italics">K.</hi> vii. 486): alienam <hi rend="italics">codd.</hi>
-               </note>; multa palam domum suam auferebat, 
+                  </note>; multa palam domum suam auferebat, 
 plura clam de medio removebat, non pauca suis adiutoribus large 
 effuseque donabat, reliqua constituta auctione vendebat.
 
 
 
             </p>
-         </div>
-         <milestone n="9" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="24"><p>
-               <reg>quod</reg> Amerinis usque eo visum est indignum ut urbe tota fletus 
+            </div>
+            <milestone n="9" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="24">
+               <p>
+                  <reg>quod</reg> Amerinis usque eo visum est indignum ut urbe tota fletus 
 gemitusque fieret.  <reg>etenim</reg> multa simul ante oculos versabantur, 
 mors hominis florentissimi, Sex. Rosci, crudelissima, fili autem eius 
 egestas indignissima, cui de tanto patrimonio praedo iste nefarius 
 ne iter quidem ad sepulcrum patrium reliquisset, bonorum emptio 
 flagitiosa, possessio<note>
-                  <app><lem>possessio</lem></app> flagitiosa possessio <hi rend="italics">cod. Lambini</hi>: falsa possessio <hi rend="italics">Landgraf</hi>
-               </note>, furta, rapinae, donationes.  <reg>nemo</reg> erat qui non 
+                     <app>
+                        <lem>possessio</lem>
+                     </app> flagitiosa possessio <hi rend="italics">cod. Lambini</hi>: falsa possessio <hi rend="italics">Landgraf</hi>
+                  </note>, furta, rapinae, donationes.  <reg>nemo</reg> erat qui non 
 ardere<note>
-                  <app><lem>ardere</lem></app> ardere illa <hi rend="italics">Rufinian.</hi> (<hi rend="italics">Rhet. M. p.</hi> 47)</note> omnia mallet quam videre in Sex. Rosci, viri optimi atque 
+                     <app>
+                        <lem>ardere</lem>
+                     </app> ardere illa <hi rend="italics">Rufinian.</hi> (<hi rend="italics">Rhet. M. p.</hi> 47)</note> omnia mallet quam videre in Sex. Rosci, viri optimi atque 
 honestissimi, bonis iactantem se ac dominantem
-                  <choice><abbr>T.</abbr><expan>T<ex>itum</ex></expan></choice> Roscium. </p></div>
-
-<div type="textpart" subtype="section" n="25"><p>
-               <reg>itaque</reg> decurionum decretum statim fit ut decem primi 
-proficiscantur ad <choice><abbr>L.</abbr><expan>L<ex>ucium</ex></expan></choice> Sullam doceantque eum qui vir Sex. Roscius 
+                  <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itum</ex>
+                     </expan>
+                  </choice> Roscium. </p>
+            </div>
+            <div type="textpart" subtype="section" n="25">
+               <p>
+                  <reg>itaque</reg> decurionum decretum statim fit ut decem primi 
+proficiscantur ad <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucium</ex>
+                     </expan>
+                  </choice> Sullam doceantque eum qui vir Sex. Roscius 
 fuerit, conquerantur de istorum scelere et iniuriis, orent ut et illius 
 mortui famam et fili innocentis fortunas conservatas velit.  <reg>atque</reg> 
 ipsum decretum, quaeso, cognoscite.  DECRETVM DECVRIONVM.  
 <reg>legati</reg> in castra veniunt.  <reg>intellegitur</reg>, iudices, id quod<note>id quod <hi rend="italics">Naugerius</hi>: ut quod <hi rend="italics">codd.</hi>
-               </note> iam ante dixi, 
-imprudente <choice><abbr>L.</abbr><expan>L<ex>ucio</ex></expan></choice> Sulla scelera haec et flagitia fieri.  <reg>nam</reg> statim 
-Chrysogonus et ipse ad eos accedit et homines nobilis adlegat<note>adlegat <hi rend="italics">Ernesti</hi>: allegatus <foreign xml:lang="grc">S</foreign>: allegat iis (hi <foreign xml:lang="grc">f</foreign>) <hi rend="italics">cett.</hi>: allegat ab iis <hi rend="italics">Lambinus</hi>
-               </note> qui 
+                  </note> iam ante dixi, 
+imprudente <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucio</ex>
+                     </expan>
+                  </choice> Sulla scelera haec et flagitia fieri.  <reg>nam</reg> statim 
+Chrysogonus et ipse ad eos accedit et homines nobilis adlegat<note>adlegat <hi rend="italics">Ernesti</hi>: allegatus <foreign xml:lang="grc">ς</foreign>: allegat iis (hi <foreign xml:lang="grc">φ</foreign>) <hi rend="italics">cett.</hi>: allegat ab iis <hi rend="italics">Lambinus</hi>
+                  </note> qui 
 peterent ne ad Sullam adirent, et omnia Chrysogonum quae vellent 
-esse facturum pollicerentur. </p></div> 
-
-<div type="textpart" subtype="section" n="26"><p>Vsque adeo autem<note>
-                  <app><lem>autem</lem></app> enim <hi rend="italics">coni. Müller</hi>
-               </note> ille pertimuerat ut 
+esse facturum pollicerentur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="26">
+               <p>Vsque adeo autem<note>
+                     <app>
+                        <lem>autem</lem>
+                     </app> enim <hi rend="italics">coni. Müller</hi>
+                  </note> ille pertimuerat ut 
 mori mallet quam de his rebus Sullam doceri.  <reg>homines</reg> antiqui, qui 
 ex sua natura ceteros fingerent, cum ille confirmaret sese nomen <reg>sex</reg>. 
 Rosci de tabulis exempturum, praedia vacua filio traditurum, cumque 
-id ita futurum <choice><abbr>T.</abbr><expan>T<ex>itus</ex></expan></choice> Roscius Capito qui in decem legatis erat 
-appromitteret, crediderunt; Ameriam re inorata<note>re inorata <hi rend="italics">B<foreign xml:lang="grc">py</foreign>
-                  </hi>: re morata <hi rend="italics">cett.</hi>
-               </note> reverterunt.  <reg>ac</reg> 
+id ita futurum <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itus</ex>
+                     </expan>
+                  </choice> Roscius Capito qui in decem legatis erat 
+appromitteret, crediderunt; Ameriam re inorata<note>re inorata <hi rend="italics">B<foreign xml:lang="grc">πψ</foreign>
+                     </hi>: re morata <hi rend="italics">cett.</hi>
+                  </note> reverterunt.  <reg>ac</reg> 
 primo rem differre cotidie ac procrastinare isti coeperunt, deinde 
 aliquanto lentius nihil<note>nihil <hi rend="italics">del. Halm</hi>
-               </note> agere atque deludere, postremo, id quod facile 
+                  </note> agere atque deludere, postremo, id quod facile 
 intellectum
 est, insidias vitae huiusce Sex. Rosci parare neque sese arbitrari 
 posse diutius alienam pecuniam domino incolumi obtinere.  
 
 
             </p>
-         </div>
-         <milestone n="10" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="27"><p>
-               <reg>quod</reg> hic 
+            </div>
+            <milestone n="10" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="27">
+               <p>
+                  <reg>quod</reg> hic 
 simul atque sensit, de amicorum cognatorumque sententia Romam 
 confugit et sese ad Caeciliam, Nepotis sororem, Baliarici filiam<note>Nepotis sororem, Baliarici filiam <hi rend="italics">Garatoni</hi>: Nepotis filiam <hi rend="italics">codd.: del. Passeratius</hi>
-               </note>, quam 
-honoris  causa nomino, contulit, qua<note>qua <foreign xml:lang="grc">x1y2w</foreign>: quam <hi rend="italics">cett.</hi>
-               </note> pater usus erat plurimum; in 
-qua muliere, iudices, etiam<note>etiamnum <foreign xml:lang="grc">S</foreign>
-               </note> nunc, id quod omnes semper 
+                  </note>, quam 
+honoris  causa nomino, contulit, qua<note>qua <foreign xml:lang="grc">χ1ψ2ω</foreign>: quam <hi rend="italics">cett.</hi>
+                  </note> pater usus erat plurimum; in 
+qua muliere, iudices, etiam<note>etiamnum <foreign xml:lang="grc">ς</foreign>
+                  </note> nunc, id quod omnes semper 
 existimaverunt, quasi exempli causa vestigia antiqui offici remanent.  
 <reg>ea</reg> Sex. Roscium inopem, eiectum domo atque expulsum ex suis bonis, 
 fugientem latronum tela et minas recepit domum hospitique 
 oppresso iam desperatoque ab omnibus opitulata est.  <reg>eius</reg> virtute, 
 fide, diligentia factum est ut hic potius vivus in reos quam occisus in 
-proscriptos referretur.</p></div>
-
-
-               <div type="textpart" subtype="section" n="28"><p>
-               <reg>nam</reg> postquam isti intellexerunt summa diligentia vitam Sex. Rosci 
-custodiri neque sibi ullam caedis faciendae<note>faciundae <foreign xml:lang="grc">sx2</foreign>
-               </note> potestatem dari, 
+proscriptos referretur.</p>
+            </div>
+            <div type="textpart" subtype="section" n="28">
+               <p>
+                  <reg>nam</reg> postquam isti intellexerunt summa diligentia vitam Sex. Rosci 
+custodiri neque sibi ullam caedis faciendae<note>faciundae <foreign xml:lang="grc">σχ2</foreign>
+                  </note> potestatem dari, 
 consilium ceperunt plenum sceleris et audaciae ut nomen huius de 
 parricidio deferrent, ut ad eam rem aliquem accusatorem veterem 
 compararent qui de ea re posset<note>posset <hi rend="italics">ed. Mediol.</hi>: possit <hi rend="italics">codd.</hi>
-               </note> dicere aliquid, in qua re nulla 
+                  </note> dicere aliquid, in qua re nulla 
 subesset suspicio, denique ut, quoniam crimine non poterant, tempore 
 ipso pugnarent.  <reg>ita</reg> loqui homines: 'quod iudicia tam diu facta 
 non essent, condemnari eum oportere qui primus in iudicium 
 adductus esset; huic autem patronos propter Chrysogoni gratiam 
 defuturos; de bonorum venditione et de ista societate verbum esse 
 facturum neminem; ipso nomine parricidi et atrocitate criminis fore 
-ut hic nullo negotio tolleretur, cum ab nullo defensus esset.'</p></div>  
-
-<div type="textpart" subtype="section" n="29"><p>
-               <reg>hoc</reg> consilio 
+ut hic nullo negotio tolleretur, cum ab nullo defensus esset.'</p>
+            </div>
+            <div type="textpart" subtype="section" n="29">
+               <p>
+                  <reg>hoc</reg> consilio 
 atque adeo hac amentia impulsi quem ipsi, cum cuperent, non 
 potuerunt occidere, eum iugulandum vobis tradiderunt.
-         <milestone n="11" unit="chapter"/><milestone unit="para"/>
-
-               <reg>quid</reg> primum querar aut unde potissimum, iudices, ordiar aut quod 
+         <milestone n="11" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>quid</reg> primum querar aut unde potissimum, iudices, ordiar aut quod 
 aut a quibus auxilium petam? deorumne immortalium, populine 
 Romani, vestramne qui summam potestatem habetis hoc tempore 
-fidem implorem? </p></div> 
-
-<div type="textpart" subtype="section" n="30"><p>
-               <reg>pater</reg> occisus nefarie, domus obsessa ab inimicis, 
+fidem implorem? </p>
+            </div>
+            <div type="textpart" subtype="section" n="30">
+               <p>
+                  <reg>pater</reg> occisus nefarie, domus obsessa ab inimicis, 
 bona adempta, possessa<note>possessio <hi rend="italics">Passeratius</hi>
-               </note>, direpta, fili vita infesta, saepe ferro atque 
+                  </note>, direpta, fili vita infesta, saepe ferro atque 
 insidiis appetita. <reg>quid</reg> ab his tot maleficiis sceleris abesse videtur? 
 <reg>tamen</reg> haec aliis nefariis cumulant atque adaugent, crimen 
 incredibile confingunt, testis in hunc et accusatores huiusce pecunia 
 comparant; hanc condicionem misero ferunt ut optet<note>optet <hi rend="italics">Beroaldus</hi>: optetur <hi rend="italics">codd.</hi> T. <hi rend="italics">A. Eberhard: om. codd.</hi>
-               </note> utrum malit 
-cervices <choice><abbr>T.</abbr><expan>T<ex>ito</ex></expan></choice> Roscio dare an insutus in culleum<note>
-                  <app><lem>culleum</lem></app> supplicium (-io <foreign xml:lang="grc">y</foreign>) parricidarum <hi rend="italics">add. codd.</hi>: <hi rend="italics">del. Hotoman</hi>
-               </note> per summum dedecus 
+                  </note> utrum malit 
+cervices <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>ito</ex>
+                     </expan>
+                  </choice> Roscio dare an insutus in culleum<note>
+                     <app>
+                        <lem>culleum</lem>
+                     </app> supplicium (-io <foreign xml:lang="grc">ψ</foreign>) parricidarum <hi rend="italics">add. codd.</hi>: <hi rend="italics">del. Hotoman</hi>
+                  </note> per summum dedecus 
 vitam amittere.  <reg>patronos</reg> huic defuturos putaverunt; desunt; qui 
 libere dicat, qui cum fide defendat, id quod in hac causa satis est<note>satis est <hi rend="italics">ed. Mediol.</hi>: satis <hi rend="italics">codd.</hi>: est satis <hi rend="italics">Naugerius</hi>
-               </note>
-               <note>
-                  <hi rend="italics">Post</hi> satis <hi rend="italics">add.</hi> quoniam quidem suscepi (<hi rend="italics">ex</hi> §31) <hi rend="italics">codd.</hi>: <hi rend="italics">del. Heusinger</hi>
-               </note> non 
-   deest profecto, iudices.  </p></div>
-
-<div type="textpart" subtype="section" n="31"><p>
-               <reg>et</reg> forsitan in suscipienda causa temere 
+                  </note>
+                  <note>
+                     <hi rend="italics">Post</hi> satis <hi rend="italics">add.</hi> quoniam quidem suscepi (<hi rend="italics">ex</hi> §31) <hi rend="italics">codd.</hi>: <hi rend="italics">del. Heusinger</hi>
+                  </note> non 
+   deest profecto, iudices.  </p>
+            </div>
+            <div type="textpart" subtype="section" n="31">
+               <p>
+                  <reg>et</reg> forsitan in suscipienda causa temere 
 impulsus adulescentia fecerim; quoniam quidem semel suscepi, licet 
 hercules undique omnes minae<note>
-                  <app><lem>minae</lem></app> in me <foreign xml:lang="grc">sxy</foreign>: immineant <hi rend="italics">Halm</hi> (2): mihi minae <hi rend="italics">Baiter</hi>
-               </note> terrores periculaque impendeant<note>impendeant <hi rend="italics">ed. R.</hi>: impediant <foreign xml:lang="grc">Ssx</foreign>: impendant <hi rend="italics">cett.</hi>
-               </note> 
+                     <app>
+                        <lem>minae</lem>
+                     </app> in me <foreign xml:lang="grc">σχψ</foreign>: immineant <hi rend="italics">Halm</hi> (2): mihi minae <hi rend="italics">Baiter</hi>
+                  </note> terrores periculaque impendeant<note>impendeant <hi rend="italics">ed. R.</hi>: impediant <foreign xml:lang="grc">σσχ</foreign>: impendant <hi rend="italics">cett.</hi>
+                  </note> 
 omnia, succurram ac<note>
-                  <app><lem>ac</lem></app> atque <foreign xml:lang="grc">sxy</foreign>
-               </note> subibo.  <reg>certum</reg> est deliberatumque quae ad 
+                     <app>
+                        <lem>ac</lem>
+                     </app> atque <foreign xml:lang="grc">σχψ</foreign>
+                  </note> subibo.  <reg>certum</reg> est deliberatumque quae ad 
 causam pertinere arbitror, omnia non modo dicere verum etiam 
-libenter audacter<note>audaciter <hi rend="italics">Lambinus</hi> (<hi rend="italics">cf.</hi> §104)</note> libereque dicere; nulla res tanta exsistet<note>exsistet <foreign xml:lang="grc">w</foreign>: exsistat (-it <foreign xml:lang="grc">y</foreign>) <hi rend="italics">cett.</hi>
-               </note>, iudices, 
-   ut possit vim mihi maiorem adhibere metus quam fides. </p></div>
-
-<div type="textpart" subtype="section" n="32"><p>
-               <reg>etenim</reg> quis 
+libenter audacter<note>audaciter <hi rend="italics">Lambinus</hi> (<hi rend="italics">cf.</hi> §104)</note> libereque dicere; nulla res tanta exsistet<note>exsistet <foreign xml:lang="grc">ω</foreign>: exsistat (-it <foreign xml:lang="grc">ψ</foreign>) <hi rend="italics">cett.</hi>
+                  </note>, iudices, 
+   ut possit vim mihi maiorem adhibere metus quam fides. </p>
+            </div>
+            <div type="textpart" subtype="section" n="32">
+               <p>
+                  <reg>etenim</reg> quis 
 tam dissoluto animo est qui haec cum videat tacere ac neglegere 
 possit? <reg>patrem</reg> meum, cum proscriptus non esset, iugulastis, occisum 
 in proscriptorum numerum rettulistis, me domo mea per vim 
 expulistis, patrimonium meum possidetis. <reg>quid</reg> voltis amplius? 
 etiamne ad subsellia cum ferro atque telis venistis ut hic aut 
 iuguletis aut condemnetis<note>
-                  <app><lem>condemnetis</lem></app> Sex. Roscium <hi rend="italics">add. codd.: del. Lambinus</hi>
-               </note>?
+                     <app>
+                        <lem>condemnetis</lem>
+                     </app> Sex. Roscium <hi rend="italics">add. codd.: del. Lambinus</hi>
+                  </note>?
 
 
             </p>
-         </div>
-         <milestone n="12" unit="chapter"/><milestone unit="para"/>
-
-               <div type="textpart" subtype="section" n="33"><p>
-               <reg>hominem</reg> longe audacissimum nuper habuimus in civitate C. 
+            </div>
+            <milestone n="12" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="33">
+               <p>
+                  <reg>hominem</reg> longe audacissimum nuper habuimus in civitate C. 
 Fimbriam et, quod inter omnis constat, nisi inter eos qui ipsi quoque 
-insaniunt insanissimum.  <reg>is</reg> cum curasset in funere <choice><abbr>C.</abbr><expan>G<ex>aii</ex></expan></choice> Mari ut Q. 
+insaniunt insanissimum.  <reg>is</reg> cum curasset in funere <choice>
+                     <abbr>C.</abbr>
+                     <expan>G<ex>aii</ex>
+                     </expan>
+                  </choice> Mari ut Q. 
 Scaevola volneraretur, vir sanctissimus atque ornatissimus nostrae 
 civitatis, de cuius laude neque hic locus est ut multa dicantur neque 
 plura tamen dici possunt quam populus Romanus memoria retinet, 
@@ -653,117 +808,142 @@ ab eo quaereretur quid tandem accusaturus esset eum quem pro
 dignitate ne laudare quidem quisquam satis commode posset, aiunt 
 hominem, ut erat furiosus, respondisse: 'quod non totum telum 
 corpore recepisset.'  <reg>quo</reg> populus Romanus nihil vidit indignius nisi 
-eiusdem viri mortem, quae tantum potuit ut omnis occisus<note>occisus <foreign xml:lang="grc">S</foreign>: civis suos <hi rend="italics">A<foreign xml:lang="grc">pf</foreign>
-                  </hi>: civis <foreign xml:lang="grc">sxy</foreign>
-               </note> perdiderit 
-et adflixerit; quos quia servare per compositionem<note>servare per compositionem <hi rend="italics">ed. R</hi>: servare per conservare posicionem <foreign xml:lang="grc">Sx</foreign>: servare per cos. repositionem <hi rend="italics">A<foreign xml:lang="grc">pf</foreign>
-                  </hi>: conservare per positionem <foreign xml:lang="grc">sx2</foreign>: conservare per compositionem <foreign xml:lang="grc">y</foreign>
-               </note> volebat, ipse ab 
-                  eis interemptus est. </p></div> 
-
-<div type="textpart" subtype="section" n="34"><p>
-               <reg>estne</reg> hoc illi dicto atque facto Fimbriano<note>Fimbriano <hi rend="italics">Rufinian.</hi> (<hi rend="italics">Rhet. M. p.</hi> 44): Fimbria non <foreign xml:lang="grc">S</foreign>: Fimbriae non <hi rend="italics">cett.</hi>
-               </note> 
+eiusdem viri mortem, quae tantum potuit ut omnis occisus<note>occisus <foreign xml:lang="grc">ς</foreign>: civis suos <hi rend="italics">A<foreign xml:lang="grc">πφ</foreign>
+                     </hi>: civis <foreign xml:lang="grc">σχψ</foreign>
+                  </note> perdiderit 
+et adflixerit; quos quia servare per compositionem<note>servare per compositionem <hi rend="italics">ed. R</hi>: servare per conservare posicionem <foreign xml:lang="grc">σχ</foreign>: servare per cos. repositionem <hi rend="italics">A<foreign xml:lang="grc">πφ</foreign>
+                     </hi>: conservare per positionem <foreign xml:lang="grc">σχ2</foreign>: conservare per compositionem <foreign xml:lang="grc">ψ</foreign>
+                  </note> volebat, ipse ab 
+                  eis interemptus est. </p>
+            </div>
+            <div type="textpart" subtype="section" n="34">
+               <p>
+                  <reg>estne</reg> hoc illi dicto atque facto Fimbriano<note>Fimbriano <hi rend="italics">Rufinian.</hi> (<hi rend="italics">Rhet. M. p.</hi> 44): Fimbria non <foreign xml:lang="grc">ς</foreign>: Fimbriae non <hi rend="italics">cett.</hi>
+                  </note> 
 simillimum?  <reg>accusatis</reg> Sex. Roscium. <reg>quid</reg> ita? <reg>quia</reg> de manibus 
 vestris effugit, quia se occidi passus non est.  <reg>illud</reg>, quia in Scaevola 
 factum est, magis<note>magis <hi rend="italics">transpos. ante</hi> ferendum <hi rend="italics">A. Eberhard</hi>
-               </note> indignum videtur, hoc, quia fit a Chrysogono, non<note>
-                  <app><lem>non</lem></app> num <hi rend="italics">Hotoman: del. Guarinus</hi> (<hi rend="italics">in Comment.</hi>)</note> 
+                  </note> indignum videtur, hoc, quia fit a Chrysogono, non<note>
+                     <app>
+                        <lem>non</lem>
+                     </app> num <hi rend="italics">Hotoman: del. Guarinus</hi> (<hi rend="italics">in Comment.</hi>)</note> 
 est ferendum<note>
-                  <app><lem>est ferendum</lem></app> est feferendum <foreign xml:lang="grc">S</foreign>: esset ferendum <foreign xml:lang="grc">x2</foreign>
-               </note>.  <reg>nam</reg> per deos immortalis! quid est in hac causa quod 
+                     <app>
+                        <lem>est ferendum</lem>
+                     </app> est feferendum <foreign xml:lang="grc">ς</foreign>: esset ferendum <foreign xml:lang="grc">χ2</foreign>
+                  </note>.  <reg>nam</reg> per deos immortalis! quid est in hac causa quod 
 defensionis indigeat? qui locus ingenium patroni requirit aut oratoris 
 eloquentiam magno opere desiderat? <reg>totam</reg> causam, iudices, 
 explicemus atque ante oculos expositam consideremus; ita facillime 
-quae res totum iudicium contineat et quibus de<note>de <foreign xml:lang="grc">y2</foreign>: <hi rend="italics">om. cett.</hi>
-               </note> rebus nos dicere 
+quae res totum iudicium contineat et quibus de<note>de <foreign xml:lang="grc">ψ2</foreign>: <hi rend="italics">om. cett.</hi>
+                  </note> rebus nos dicere 
 oporteat et quid vos sequi conveniat intellegetis.
 
 
             </p>
-         </div>
-         <milestone n="13" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="35"><p>
-               <reg>tres</reg> sunt res, quantum ego existimare possum, quae
+            </div>
+            <milestone n="13" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="35">
+               <p>
+                  <reg>tres</reg> sunt res, quantum ego existimare possum, quae
 obstent hoc tempore Sex. Roscio, crimen adversariorum et audacia et 
 potentia.  <reg>criminis</reg> confictionem accusator Erucius<note>
-                  <app><lem>accusator Erucius</lem></app> Erucius <hi rend="italics">del. Madvig</hi>: accusator <hi rend="italics">del. A. Eberhard</hi> (<hi rend="italics">contra Victorinum, Rhet. M. p.</hi> 210)</note> suscepit, audaciae 
+                     <app>
+                        <lem>accusator Erucius</lem>
+                     </app> Erucius <hi rend="italics">del. Madvig</hi>: accusator <hi rend="italics">del. A. Eberhard</hi> (<hi rend="italics">contra Victorinum, Rhet. M. p.</hi> 210)</note> suscepit, audaciae 
 partis Roscii sibi poposcerunt<note>depoposcerunt <hi rend="italics">Victorinus</hi>
-               </note>, Chrysogonus autem, is qui plurimum 
+                  </note>, Chrysogonus autem, is qui plurimum 
 potest, potentia pugnat.  <reg>de</reg> hisce omnibus rebus me dicere oportere 
-                  intellego.  <reg>quid</reg> igitur est? </p></div> 
-
-<div type="textpart" subtype="section" n="36"><p>
-               <reg>non</reg> eodem modo de omnibus, ideo quod 
+                  intellego.  <reg>quid</reg> igitur est? </p>
+            </div>
+            <div type="textpart" subtype="section" n="36">
+               <p>
+                  <reg>non</reg> eodem modo de omnibus, ideo quod 
 prima illa res ad meum officium pertinet, duas autem reliquas vobis 
 populus Romanus imposuit; ego crimen oportet diluam, vos et 
 audaciae resistere et hominum eius modi perniciosam atque 
 intolerandam potentiam primo quoque tempore exstinguere atque 
-opprimere debetis.</p></div>
-
-
-               <div type="textpart" subtype="section" n="37"><p>
-               <reg>occidisse</reg> patrem Sex. Roscius arguitur.  <reg>scelestum</reg>, di immortales! ac 
+opprimere debetis.</p>
+            </div>
+            <div type="textpart" subtype="section" n="37">
+               <p>
+                  <reg>occidisse</reg> patrem Sex. Roscius arguitur.  <reg>scelestum</reg>, di immortales! ac 
 nefarium facinus atque eius modi quo uno maleficio scelera omnia 
 complexa esse videantur!  <reg>etenim</reg> si, id quod praeclare a sapientibus 
 dicitur, voltu saepe laeditur pietas, quod supplicium satis acre 
 reperietur in eum qui mortem obtulerit parenti?  pro quo mori 
-ipsum, si res postularet, iura divina atque humana cogebant.</p></div>  
-
-<div type="textpart" subtype="section" n="38"><p>
-               <reg>in</reg> hoc 
+ipsum, si res postularet, iura divina atque humana cogebant.</p>
+            </div>
+            <div type="textpart" subtype="section" n="38">
+               <p>
+                  <reg>in</reg> hoc 
 tanto, tam atroci, tam singulari maleficio, quod ita raro exstitit ut, si 
 quando auditum sit<note>
-                  <app><lem>sit</lem></app> est <hi rend="italics">Halm</hi>
-               </note>, portenti ac prodigi simile numeretur, quibus 
-tandem tu, <choice><abbr>C.</abbr><expan>G<ex>aii</ex></expan></choice> Eruci<note>tu C. <hi rend="italics">Klotz</hi>: te C. (G. <foreign xml:lang="grc">S</foreign>: GN. <foreign xml:lang="grc">px1</foreign>) <hi rend="italics">codd.</hi>
-               </note>, argumentis accusatorem censes uti oportere? 
+                     <app>
+                        <lem>sit</lem>
+                     </app> est <hi rend="italics">Halm</hi>
+                  </note>, portenti ac prodigi simile numeretur, quibus 
+tandem tu, <choice>
+                     <abbr>C.</abbr>
+                     <expan>G<ex>aii</ex>
+                     </expan>
+                  </choice> Eruci<note>tu C. <hi rend="italics">Klotz</hi>: te C. (G. <foreign xml:lang="grc">ς</foreign>: GN. <foreign xml:lang="grc">πχ1</foreign>) <hi rend="italics">codd.</hi>
+                  </note>, argumentis accusatorem censes uti oportere? 
 nonne et audaciam eius qui in crimen vocetur singularem ostendere 
 et mores feros immanemque naturam et vitam vitiis flagitiisque 
 omnibus deditam, denique<note>denique <hi rend="italics">Madvig</hi>: et denique <hi rend="italics">codd.</hi>
-               </note> omnia ad perniciem profligata atque 
+                  </note> omnia ad perniciem profligata atque 
 perdita? <reg>quorum</reg> tu nihil in Sex. Roscium ne obiciendi quidem causa 
 contulisti.
 
 
             </p>
-         </div>
-         <milestone n="14" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="39"><p>
-               <reg>patrem</reg> occidit Sex. Roscius. <reg>qui</reg> homo? adulescentulus corruptus et 
+            </div>
+            <milestone n="14" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="39">
+               <p>
+                  <reg>patrem</reg> occidit Sex. Roscius. <reg>qui</reg> homo? adulescentulus corruptus et 
 ab hominibus nequam inductus<note>
-                  <app><lem>inductus</lem></app> iudicatus <foreign xml:lang="grc">y2</foreign>
-               </note>? <reg>annos</reg> natus maior<note>
-                  <app><lem>natus maior</lem></app> natu maior <hi rend="italics">Gulielmius</hi>: natus magis <hi rend="italics">Naugerius</hi> (<hi rend="italics">contra Arusian. K.</hi> vii. 495)</note> quadraginta.  
+                     <app>
+                        <lem>inductus</lem>
+                     </app> iudicatus <foreign xml:lang="grc">ψ2</foreign>
+                  </note>? <reg>annos</reg> natus maior<note>
+                     <app>
+                        <lem>natus maior</lem>
+                     </app> natu maior <hi rend="italics">Gulielmius</hi>: natus magis <hi rend="italics">Naugerius</hi> (<hi rend="italics">contra Arusian. K.</hi> vii. 495)</note> quadraginta.  
 <reg>vetus</reg> videlicet sicarius, homo audax
 et saepe in caede versatus.  <reg>at</reg> hoc ab accusatore ne dici quidem 
 audistis.  <reg>luxuries</reg> igitur hominem nimirum et aeris alieni magnitudo 
-et indomitae animi cupiditates ad hoc scelus impulerunt.  <reg>de</reg> luxuria<note>luxoriae <foreign xml:lang="grc">S</foreign>: luxurie <hi rend="italics">w, Müller</hi> (<hi rend="italics">cf.</hi> §75)</note> 
+et indomitae animi cupiditates ad hoc scelus impulerunt.  <reg>de</reg> luxuria<note>luxoriae <foreign xml:lang="grc">ς</foreign>: luxurie <hi rend="italics">w, Müller</hi> (<hi rend="italics">cf.</hi> §75)</note> 
 purgavit Erucius, cum dixit hunc ne in convivio quidem ullo fere 
 interfuisse. <reg>nihil</reg> autem umquam<note>umquam cuiquam <hi rend="italics">Bake</hi>
-               </note> debuit.   <reg>cupiditates</reg> porro quae 
+                  </note> debuit.   <reg>cupiditates</reg> porro quae 
 possunt esse in eo qui, ut ipse accusator obiecit, ruri semper habitarit 
 et in agro colendo vixerit? quae vita maxime disiuncta a<note>a <hi rend="italics">ed. Guar.: om. codd.</hi>
-               </note> cupiditate et 
-cum officio coniuncta est<note>coniuncta est <hi rend="italics">s</hi>: coniuncta <foreign xml:lang="grc">sx2y</foreign>: <hi rend="italics">om.</hi> 
-                  <foreign xml:lang="grc">S<hi rend="italics">A</hi>px1</foreign>
-</note>.</p></div>
-
-<div type="textpart" subtype="section" n="40"><p>
-               <reg>quae</reg> res igitur tantum istum furorem <reg>sex</reg>. 
-Roscio obiecit? '<reg>patri</reg>' inquit 'non placebat.'<note>patri non placebat <hi rend="italics">hab.</hi> 
-                  <foreign xml:lang="grc">S</foreign> 
-                  <hi rend="italics">in mg., om. w, del. Madvig</hi>
-               </note>  
-               <reg>patri</reg> non placebat? quam 
+                  </note> cupiditate et 
+cum officio coniuncta est<note>coniuncta est <hi rend="italics">s</hi>: coniuncta <foreign xml:lang="grc">σχ2ψ</foreign>: <hi rend="italics">om.</hi>
+                     <foreign xml:lang="grc">ς<hi rend="italics">α</hi>πχ1</foreign>
+                  </note>.</p>
+            </div>
+            <div type="textpart" subtype="section" n="40">
+               <p>
+                  <reg>quae</reg> res igitur tantum istum furorem <reg>sex</reg>. 
+Roscio obiecit? '<reg>patri</reg>' inquit 'non placebat.'<note>patri non placebat <hi rend="italics">hab.</hi>
+                     <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">in mg., om. w, del. Madvig</hi>
+                  </note>
+                  <reg>patri</reg> non placebat? quam 
 ob causam? necesse est enim eam quoque iustam et magnam et 
 perspicuam fuisse.  <reg>nam</reg> ut illud incredibile est, mortem oblatam esse 
 patri a filio sine plurimis et maximis causis, sic hoc veri simile non 
 est, odio fuisse parenti filium sine causis multis et magnis et 
-necessariis.</p></div> 
-
-<div type="textpart" subtype="section" n="41"><p>
-               <reg>rursus</reg> igitur eodem revertamur et quaeramus quae 
+necessariis.</p>
+            </div>
+            <div type="textpart" subtype="section" n="41">
+               <p>
+                  <reg>rursus</reg> igitur eodem revertamur et quaeramus quae 
 tanta vitia fuerint in unico filio qua re is patri displiceret.  <reg>at</reg> 
 perspicuum est nullum fuisse.  <reg>pater</reg> igitur amens, qui odisset eum 
 sine causa quem procrearat? <reg>at</reg> is quidem fuit omnium 
@@ -773,315 +953,344 @@ neque sceleris filio fuisse.
 
 
             </p>
-         </div>
-         <milestone n="15" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="42"><p>'<reg>nescio</reg>' inquit 'quae causa odi fuerit; fuisse odium intellego quia 
+            </div>
+            <milestone n="15" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="42">
+               <p>'<reg>nescio</reg>' inquit 'quae causa odi fuerit; fuisse odium intellego quia 
 antea, cum duos filios haberet, illum alterum qui mortuus est 
-secum omni tempore volebat esse, hunc in praedia rustica relegarat.'<note>relegavit <foreign xml:lang="grc">S</foreign>
-               </note>  
-               <reg>quod</reg> Erucio accidebat in mala nugatoriaque accusatione, idem mihi 
-usu<note>usu mihi <hi rend="italics">A<foreign xml:lang="grc">p1f</foreign>
-                  </hi>
-               </note> venit in causa optima.  <reg>ille</reg> quo modo crimen commenticium 
+secum omni tempore volebat esse, hunc in praedia rustica relegarat.'<note>relegavit <foreign xml:lang="grc">ς</foreign>
+                  </note>
+                  <reg>quod</reg> Erucio accidebat in mala nugatoriaque accusatione, idem mihi 
+usu<note>usu mihi <hi rend="italics">A<foreign xml:lang="grc">π1φ</foreign>
+                     </hi>
+                  </note> venit in causa optima.  <reg>ille</reg> quo modo crimen commenticium 
 confirmaret non inveniebat, ego res tam levis qua ratione infirmem 
-ac diluam reperire non possum. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="43"><p>
-               <reg>quid</reg> ais, Eruci? tot praedia, tam 
+ac diluam reperire non possum. </p>
+            </div>
+            <div type="textpart" subtype="section" n="43">
+               <p>
+                  <reg>quid</reg> ais, Eruci? tot praedia, tam 
 pulchra, tam fructuosa Sex. Roscius filio suo relegationis ac supplici 
-gratia colenda ac tuenda tradiderat? <reg>quid</reg>? hoc patres familiae<note>familias <foreign xml:lang="grc">x</foreign>, <hi rend="italics">ed. V</hi>
-               </note> qui 
+gratia colenda ac tuenda tradiderat? <reg>quid</reg>? hoc patres familiae<note>familias <foreign xml:lang="grc">χ</foreign>, <hi rend="italics">ed. V</hi>
+                  </note> qui 
 liberos habent, praesertim homines illius ordinis ex municipiis 
 rusticanis, nonne optatissimum sibi putant esse filios suos rei 
 familiari maxime servire et in praediis colendis operae plurimum 
-studique consumere? </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="44"><p>
-               <reg>an</reg> amandarat<note>amandarat <foreign xml:lang="grc">S<hi rend="italics">B</hi>px2y1</foreign>: mandarat (emend. <foreign xml:lang="grc">y2</foreign> 
-                  <hi rend="italics">cett.</hi>
-               </note> hunc sic ut esset in agro ac 
+studique consumere? </p>
+            </div>
+            <div type="textpart" subtype="section" n="44">
+               <p>
+                  <reg>an</reg> amandarat<note>amandarat <foreign xml:lang="grc">ς<hi rend="italics">β</hi>πχ2ψ1</foreign>: mandarat (emend. <foreign xml:lang="grc">ψ2</foreign>
+                     <hi rend="italics">cett.</hi>
+                  </note> hunc sic ut esset in agro ac 
 tantum modo aleretur ad villam, ut commodis omnibus careret? 
 <reg>quid</reg>? si constat hunc non modo colendis praediis praefuisse sed 
-certis fundis patre vivo frui solitum esse, tamenne haec a te vita eius<note>a te vita eius <hi rend="italics">Vahlen</hi>: a te vita et <foreign xml:lang="grc">y2</foreign>: attente vita et <hi rend="italics">cett.</hi>: attenta vita et <hi rend="italics">Naugerius</hi>
-               </note> 
+certis fundis patre vivo frui solitum esse, tamenne haec a te vita eius<note>a te vita eius <hi rend="italics">Vahlen</hi>: a te vita et <foreign xml:lang="grc">ψ2</foreign>: attente vita et <hi rend="italics">cett.</hi>: attenta vita et <hi rend="italics">Naugerius</hi>
+                  </note> 
 rusticana relegatio atque amandatio appellabitur? <reg>vides</reg>, Eruci, 
-quantum distet argumentatio tua ab re ipsa atque a<note>a <foreign xml:lang="grc">y</foreign>: <hi rend="italics">om. cett.</hi>
-               </note> veritate.  <reg>quod</reg> 
+quantum distet argumentatio tua ab re ipsa atque a<note>a <foreign xml:lang="grc">ψ</foreign>: <hi rend="italics">om. cett.</hi>
+                  </note> veritate.  <reg>quod</reg> 
 consuetudine patres faciunt, id quasi novum reprehendis; quod 
-benivolentia fit, id odio factum<note>factum || || <foreign xml:lang="grc">S</foreign>: <hi rend="italics">fort.</hi> factum tu</note> criminaris; quod honoris causa pater 
-   filio suo concessit, id eum supplici causa fecisse dicis. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="45"><p>
-               <reg>neque</reg> haec tu 
+benivolentia fit, id odio factum<note>factum || || <foreign xml:lang="grc">ς</foreign>: <hi rend="italics">fort.</hi> factum tu</note> criminaris; quod honoris causa pater 
+   filio suo concessit, id eum supplici causa fecisse dicis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="45">
+               <p>
+                  <reg>neque</reg> haec tu 
 non intellegis, sed usque eo quid<note>
-                  <app><lem>quid</lem></app> quod <hi rend="italics">Lambinus</hi>
-               </note> arguas non habes, ut non modo tibi 
+                     <app>
+                        <lem>quid</lem>
+                     </app> quod <hi rend="italics">Lambinus</hi>
+                  </note> arguas non habes, ut non modo tibi 
 contra nos dicendum putes verum etiam contra rerum naturam 
 contraque consuetudinem hominum contraque opiniones omnium.
 
-         <milestone n="16" unit="chapter"/><milestone unit="para"/>
-               <reg>at</reg> enim, cum duos filios haberet, alterum a se non dimittebat, 
+         <milestone n="16" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>at</reg> enim, cum duos filios haberet, alterum a se non dimittebat, 
 alterum ruri esse patiebatur.  <reg>quaeso</reg>, Eruci, ut hoc in bonam partem 
-               accipias; non enim exprobrandi causa sed commonendi gratia dicam. </p></div> 
-            
-
-<div type="textpart" subtype="section" n="46"><p>
-               <reg>si</reg> tibi fortuna non dedit ut patre certo nascerere ex quo intellegere 
+               accipias; non enim exprobrandi causa sed commonendi gratia dicam. </p>
+            </div>
+            <div type="textpart" subtype="section" n="46">
+               <p>
+                  <reg>si</reg> tibi fortuna non dedit ut patre certo nascerere ex quo intellegere 
 posses qui animus patrius in liberos esset, at natura certe dedit ut 
 humanitatis non parum haberes; eo accessit studium doctrinae ut ne 
 a litteris quidem alienus esses.  <reg>ecquid</reg>
-               <note>esses. ecquid <hi rend="italics">ed. C. Stephani</hi>: esset quid <foreign xml:lang="grc">S</foreign>: esses quid <hi rend="italics">cett.</hi>
-               </note> tandem tibi videtur, ut ad 
+                  <note>esses. ecquid <hi rend="italics">ed. C. Stephani</hi>: esset quid <foreign xml:lang="grc">ς</foreign>: esses quid <hi rend="italics">cett.</hi>
+                  </note> tandem tibi videtur, ut ad 
 fabulas veniamus, senex ille Caecilianus minoris facere
 Eutychum, filium rusticum, quam illum alterum, Chaerestratum? — 
 nam, ut opinor, hoc nomine est — alterum in urbe secum honoris causa 
-habere, alterum rus supplici causa relegasse? </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="47"><p>'<reg>quid</reg> ad istas ineptias 
+habere, alterum rus supplici causa relegasse? </p>
+            </div>
+            <div type="textpart" subtype="section" n="47">
+               <p>'<reg>quid</reg> ad istas ineptias 
 abis?' inquies.  <reg>quasi</reg> vero mihi difficile sit quamvis multos 
 nominatim proferre, ne longius abeam, vel tribulis vel vicinos meos 
-qui suos liberos quos plurimi faciunt agricolas<note>agricolas <foreign xml:lang="grc">y2</foreign>: agriculos (agricos <foreign xml:lang="grc">y1</foreign>) <hi rend="italics">cett.</hi>
-               </note> adsiduos esse cupiunt. 
+qui suos liberos quos plurimi faciunt agricolas<note>agricolas <foreign xml:lang="grc">ψ2</foreign>: agriculos (agricos <foreign xml:lang="grc">ψ1</foreign>) <hi rend="italics">cett.</hi>
+                  </note> adsiduos esse cupiunt. 
 <reg>verum</reg> homines notos sumere odiosum est, cum et illud incertum sit 
-velintne ei sese nominari, et<note>ii <foreign xml:lang="grc">sx</foreign>, <hi rend="italics">Halm</hi>: hi <hi rend="italics">cett.</hi>
-               </note> nemo vobis magis notus futurus sit 
-quam est hic Eutychus, et certe ad rem nihil intersit utrum hunc<note>hunc <hi rend="italics">om.</hi> 
-                  <foreign xml:lang="grc">sf</foreign>
-               </note> ego 
-comicum adulescentem an aliquem ex agro Veienti<note>Veienti <hi rend="italics">Fleckeisen</hi> (<hi rend="italics">cf. Zielinski p.</hi> 191): Veiente <foreign xml:lang="grc">y2</foreign>: veientem <foreign xml:lang="grc">S</foreign>
-                  <hi rend="italics">A</hi>: venientem <hi rend="italics">cett.</hi>
-               </note> nominem.  <reg>etenim</reg> 
+velintne ei sese nominari, et<note>ii <foreign xml:lang="grc">σχ</foreign>, <hi rend="italics">Halm</hi>: hi <hi rend="italics">cett.</hi>
+                  </note> nemo vobis magis notus futurus sit 
+quam est hic Eutychus, et certe ad rem nihil intersit utrum hunc<note>hunc <hi rend="italics">om.</hi>
+                     <foreign xml:lang="grc">σφ</foreign>
+                  </note> ego 
+comicum adulescentem an aliquem ex agro Veienti<note>Veienti <hi rend="italics">Fleckeisen</hi> (<hi rend="italics">cf. Zielinski p.</hi> 191): Veiente <foreign xml:lang="grc">ψ2</foreign>: veientem <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">A</hi>: venientem <hi rend="italics">cett.</hi>
+                  </note> nominem.  <reg>etenim</reg> 
 haec conficta arbitror esse a poetis<note>a poetis esse <hi rend="italics">ed. R</hi>
-               </note> ut effictos nostros mores in alienis 
+                  </note> ut effictos nostros mores in alienis 
 personis expressamque imaginem<note>
-                  <app><lem>imaginem</lem></app> nostram (nostrae <hi rend="italics">Hotoman</hi>) <hi rend="italics">add. codd., del. Madvig</hi>
-               </note> vitae cotidianae videremus<note>videremus <hi rend="italics">A, ed. Guar.</hi>: viderimus <hi rend="italics">cett.</hi>
-               </note>. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="48"><p>
-               <reg>age</reg> 
+                     <app>
+                        <lem>imaginem</lem>
+                     </app> nostram (nostrae <hi rend="italics">Hotoman</hi>) <hi rend="italics">add. codd., del. Madvig</hi>
+                  </note> vitae cotidianae videremus<note>videremus <hi rend="italics">A, ed. Guar.</hi>: viderimus <hi rend="italics">cett.</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="48">
+               <p>
+                  <reg>age</reg> 
 nunc, refer animum sis ad veritatem et considera non modo in 
 Umbria atque in ea vicinitate sed in his veteribus municipiis quae 
 studia a patribus familias<note>familias <hi rend="italics">ed. Guar.</hi>: familiis <hi rend="italics">codd.</hi>
-               </note> maxime laudentur; iam profecto te 
+                  </note> maxime laudentur; iam profecto te 
 intelleges inopia criminum summam laudem Sex. Roscio vitio et 
 culpae dedisse.  
-         <milestone n="17" unit="chapter"/><milestone unit="para"/>
-               <reg>ac</reg>
-               <note>
-                  <app><lem>ac</lem></app> at <foreign xml:lang="grc">fy</foreign>
-               </note> non modo hoc patrum voluntate liberi faciunt sed 
+         <milestone n="17" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>ac</reg>
+                  <note>
+                     <app>
+                        <lem>ac</lem>
+                     </app> at <foreign xml:lang="grc">φψ</foreign>
+                  </note> non modo hoc patrum voluntate liberi faciunt sed 
 permultos et ego novi et, nisi me fallit animus, unus quisque vestrum 
-qui et ipsi incensi sunt studio quod ad<note>quod ad <foreign xml:lang="grc">w</foreign>, <hi rend="italics">Angelius</hi>: quod <foreign xml:lang="grc">Sf</foreign>: quo ad <hi rend="italics">cett.</hi>
-               </note> agrum colendum attinet, 
+qui et ipsi incensi sunt studio quod ad<note>quod ad <foreign xml:lang="grc">ω</foreign>, <hi rend="italics">Angelius</hi>: quod <foreign xml:lang="grc">σφ</foreign>: quo ad <hi rend="italics">cett.</hi>
+                  </note> agrum colendum attinet, 
 vitamque hanc rusticam, quam tu probro et crimini putas esse 
-oportere, et honestissimam et suavissimam esse arbitrantur. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="49"><p>
-               <reg>quid</reg> 
+oportere, et honestissimam et suavissimam esse arbitrantur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="49">
+               <p>
+                  <reg>quid</reg> 
 censes hunc ipsum Sex. Roscium quo studio et qua intellegentia esse 
 in rusticis rebus?  Vt ex his propinquis eius, hominibus honestissimis, 
 audio, non tu in isto artificio accusatorio callidior es quam hic in suo. 
 <reg>verum</reg>, ut opinor,
 quoniam ita Chrysogono videtur qui huic nullum praedium reliquit, 
 et artificium obliviscatur et studium deponat licebit. <reg>quod</reg> tametsi 
-miserum et indignum est, feret<note>feret <foreign xml:lang="grc">x1</foreign>: ferret (-re <foreign xml:lang="grc">sf</foreign>) <hi rend="italics">cett.</hi>
-               </note> tamen aequo animo, iudices, si per 
+miserum et indignum est, feret<note>feret <foreign xml:lang="grc">χ1</foreign>: ferret (-re <foreign xml:lang="grc">σφ</foreign>) <hi rend="italics">cett.</hi>
+                  </note> tamen aequo animo, iudices, si per 
 vos vitam et famam potest obtinere; hoc vero est quod ferri<note>ferre <hi rend="italics">Puteanus</hi>
-               </note> non 
+                  </note> non 
 potest, si et in hanc calamitatem venit propter praediorum bonitatem 
-et multitudinem et quod ea studiose coluit, id erit ei maxime<note>maximae <foreign xml:lang="grc">S</foreign>
-               </note> fraudi, 
+et multitudinem et quod ea studiose coluit, id erit ei maxime<note>maximae <foreign xml:lang="grc">ς</foreign>
+                  </note> fraudi, 
 ut parum miseriae sit quod aliis coluit non sibi, nisi etiam quod 
 omnino coluit crimini fuerit.
 
 </p>
-         </div>
-         <milestone n="18" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="50"><p>
-               <reg>ne</reg> tu, Eruci, accusator esses ridiculus, si illis temporibus natus esses<note>natus |||| esses <foreign xml:lang="grc">S</foreign>
-               </note> 
+            </div>
+            <milestone n="18" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="50">
+               <p>
+                  <reg>ne</reg> tu, Eruci, accusator esses ridiculus, si illis temporibus natus esses<note>natus |||| esses <foreign xml:lang="grc">ς</foreign>
+                  </note> 
 cum ab aratro arcessebantur qui consules fierent. <reg>etenim</reg> qui 
 praeesse agro colendo flagitium putes, profecto illum Atilium quem 
 sua manu spargentem semen qui missi erant convenerunt hominem 
 turpissimum atque inhonestissimum iudicares.  <reg>at</reg> hercule maiores 
 nostri longe aliter et de illo et de ceteris talibus viris existimabant 
 itaque ex minima tenuissimaque re publica<note>rem publicam <hi rend="italics">Pluygers</hi>
-               </note> maximam et florentissimam 
+                  </note> maximam et florentissimam 
 nobis reliquerunt.  <reg>suos</reg> enim agros studiose colebant, non 
 alienos cupide appetebant; quibus rebus et agris et urbibus et 
 nationibus rem publicam atque hoc imperium et populi Romani 
-nomen auxerunt.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="51"><p>
-               <reg>neque</reg> ego haec eo profero quo conferenda sint 
+nomen auxerunt.</p>
+            </div>
+            <div type="textpart" subtype="section" n="51">
+               <p>
+                  <reg>neque</reg> ego haec eo profero quo conferenda sint 
 cum hisce de quibus nunc quaerimus, sed ut illud intellegatur<note>
-                  <app><lem>intellegatur</lem></app> intellegant <hi rend="italics">A</hi>: intellegas <foreign xml:lang="grc">sx2</foreign>
-               </note>, cum 
+                     <app>
+                        <lem>intellegatur</lem>
+                     </app> intellegant <hi rend="italics">A</hi>: intellegas <foreign xml:lang="grc">σχ2</foreign>
+                  </note>, cum 
 apud maiores nostros summi viri clarissimique homines qui omni 
 tempore ad gubernacula rei publicae sedere debebant tamen in agris 
 quoque colendis aliquantum operae temporisque consumpserint<note>consumpserint <hi rend="italics">Beroaldus</hi>: consumpserunt <hi rend="italics">codd.</hi>
-               </note>, 
+                  </note>, 
 ignosci oportere ei homini qui se fateatur esse rusticum, cum ruri<note>
-                  <app><lem>cum ruri</lem></app> qui ruri <hi rend="italics">Vrsinus</hi> assiduos <foreign xml:lang="grc">S<hi rend="italics">A</hi>
-                  </foreign>: assiduo <hi rend="italics">Gulielmius</hi>
-               </note> 
+                     <app>
+                        <lem>cum ruri</lem>
+                     </app> qui ruri <hi rend="italics">Vrsinus</hi> assiduos <foreign xml:lang="grc">ς<hi rend="italics">α</hi>
+                     </foreign>: assiduo <hi rend="italics">Gulielmius</hi>
+                  </note> 
 adsiduus semper vixerit, cum praesertim nihil esset quod aut patri 
 gratius aut sibi iucundius aut re
-vera honestius facere posset.	</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="52"><p>
-               <reg>odium</reg> igitur acerrimum patris in filium ex hoc, opinor, ostenditur, 
+vera honestius facere posset.	</p>
+            </div>
+            <div type="textpart" subtype="section" n="52">
+               <p>
+                  <reg>odium</reg> igitur acerrimum patris in filium ex hoc, opinor, ostenditur, 
 Eruci, quod hunc ruri esse patiebatur. <reg>numquid</reg> est aliud? '<reg>immo</reg> 
 vero' inquit 'est; nam istum exheredare in animo habebat.'  <reg>audio</reg>; 
 nunc dicis aliquid quod ad rem pertineat; nam illa, opinor, tu quoque 
 concedis levia esse atque inepta: '<reg>convivia</reg> cum patre non inibat.' 
 <reg>quippe</reg>, qui ne in oppidum quidem nisi perraro veniret<note>
-                  <app><lem>perraro</lem></app> errario <foreign xml:lang="grc">S</foreign>: raro <foreign xml:lang="grc">sxy2</foreign>
-               </note>. '<reg>domum</reg> 
+                     <app>
+                        <lem>perraro</lem>
+                     </app> errario <foreign xml:lang="grc">ς</foreign>: raro <foreign xml:lang="grc">σχψ2</foreign>
+                  </note>. '<reg>domum</reg> 
 suam istum non fere quisquam vocabat.'  <reg>nec</reg> mirum, qui neque in 
 urbe viveret neque revocaturus esset. 
 
 </p>
-         </div>
-
-<milestone n="19" unit="chapter"/><milestone unit="para"/>
-<div type="textpart" subtype="section" n="53"><p>
-               <reg>verum</reg> haec tu quoque<note>haec quoque tu <hi rend="italics">ed. R</hi>
-               </note> 
+            </div>
+            <milestone n="19" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="53">
+               <p>
+                  <reg>verum</reg> haec tu quoque<note>haec quoque tu <hi rend="italics">ed. R</hi>
+                  </note> 
 intellegis esse nugatoria; illud quod coepimus videamus, quo certius 
 argumentum odi reperiri nullo modo potest. '<reg>exheredare</reg> pater filium 
 cogitabat.' Mitto quaerere qua de causa; quaero qui scias; tametsi te 
 dicere atque enumerare causas omnis oportebat, et id erat certi<note>certe <hi rend="italics">Pluygers</hi>
-               </note> 
+                  </note> 
 accusatoris officium qui tanti sceleris argueret explicare omnia vitia 
 ac peccata fili quibus incensus parens potuerit animum inducere ut 
 naturam ipsam vinceret, ut amorem illum penitus insitum eiceret ex 
 animo<note>ex animo <hi rend="italics">del. May</hi>
-               </note>, ut denique patrem esse. sese oblivisceretur; quae sine magnis 
-huiusce<note>huiusce |||| <foreign xml:lang="grc">S</foreign>
-</note> peccatis accidere potuisse non arbitror. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="54"><p>
-               <reg>verum</reg> concedo tibi 
+                  </note>, ut denique patrem esse. sese oblivisceretur; quae sine magnis 
+huiusce<note>huiusce |||| <foreign xml:lang="grc">ς</foreign>
+                  </note> peccatis accidere potuisse non arbitror. </p>
+            </div>
+            <div type="textpart" subtype="section" n="54">
+               <p>
+                  <reg>verum</reg> concedo tibi 
 ut ea praetereas quae, cum taces, nulla esse concedis; illud<note>illud <hi rend="italics">Gulielmius</hi>: illum <hi rend="italics">codd.</hi>
-               </note> quidem, 
+                  </note> quidem, 
 voluisse exheredare, certe tu planum facere debes. <reg>quid</reg> ergo adfers 
-qua re id factum putemus?  <reg>vere</reg> nihil potes dicere<note>potes se dicere <foreign xml:lang="grc">S</foreign>: potes edicere <hi rend="italics">Gulielmius: fort.</hi> potes elicere</note>; finge aliquid 
+qua re id factum putemus?  <reg>vere</reg> nihil potes dicere<note>potes se dicere <foreign xml:lang="grc">ς</foreign>: potes edicere <hi rend="italics">Gulielmius: fort.</hi> potes elicere</note>; finge aliquid 
 saltem commode ut ne plane videaris id facere quod aperte facis, 
 huius miseri fortunis et horum virorum talium dignitati inludere. 
 <reg>exheredare</reg> filium voluit.  <reg>quam</reg> ob causam? '<reg>nescio</reg>.'  
 <reg>exheredavitne</reg>? '<reg>non</reg>.' <reg>quis</reg> prohibuit? '<reg>cogitabat</reg>.' <reg>cogitabat</reg>
-               <note>
-                  <hi rend="italics">alterum</hi> cogitabat <hi rend="italics">om. w, del. Madvig</hi>
-               </note>? cui dixit? 
+                  <note>
+                     <hi rend="italics">alterum</hi> cogitabat <hi rend="italics">om. w, del. Madvig</hi>
+                  </note>? cui dixit? 
 '<reg>nemini</reg>.'  <reg>quid</reg> est aliud iudicio ac legibus ac maiestate vestra abuti 
 ad quaestum atque ad<note>
-                  <app><lem>atque ad</lem></app> atque <hi rend="italics">A<foreign xml:lang="grc">x1</foreign>
-                  </hi>
-               </note> libidinem nisi hoc modo  accusare atque id 
+                     <app>
+                        <lem>atque ad</lem>
+                     </app> atque <hi rend="italics">A<foreign xml:lang="grc">χ1</foreign>
+                     </hi>
+                  </note> libidinem nisi hoc modo  accusare atque id 
 obicere quod planum facere non modo
-non possis verum ne coneris quidem? </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="55"><p>
-               <reg>nemo</reg> nostrum est, Eruci, 
+non possis verum ne coneris quidem? </p>
+            </div>
+            <div type="textpart" subtype="section" n="55">
+               <p>
+                  <reg>nemo</reg> nostrum est, Eruci, 
 quin sciat tibi inimicitias cum Sex. Roscio nullas esse; vident omnes 
 qua de causa huic<note>huic <hi rend="italics">Beroaldus</hi>: huc <hi rend="italics">codd.</hi>
-               </note> inimicus venias; sciunt huiusce pecunia te 
+                  </note> inimicus venias; sciunt huiusce pecunia te 
 adductum esse  <reg>quid</reg> ergo est? <reg>ita</reg> tamen quaestus te cupidum esse 
 oportebat ut horum existimationem et legem Remmiam<note>
-                  <app><lem>Remmiam</lem></app> rem miram <hi rend="italics">A</hi>: Eruci iam <foreign xml:lang="grc">y</foreign> 
-                  <hi rend="italics">mg.</hi>
-               </note> putares 
+                     <app>
+                        <lem>Remmiam</lem>
+                     </app> rem miram <hi rend="italics">A</hi>: Eruci iam <foreign xml:lang="grc">ψ</foreign>
+                     <hi rend="italics">mg.</hi>
+                  </note> putares 
 aliquid valere oportere.
 
 
             </p>
-         </div>
-         <milestone n="20" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="56"><p>
-               <reg>accusatores</reg> multos esse in civitate utile est ut metu contineatur 
+            </div>
+            <milestone n="20" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="56">
+               <p>
+                  <reg>accusatores</reg> multos esse in civitate utile est ut metu contineatur 
 audacia; verum tamen hoc ita est utile ut ne plane inludamur ab 
 accusatoribus. <reg>innocens</reg> est quispiam, verum tamen, quamquam 
 abest a culpa, suspicione tamen non caret<note>
-                  <hi rend="italics">alterum</hi> tamen <hi rend="italics">del. Novák</hi>
-               </note>; tametsi miserum est, 
+                     <hi rend="italics">alterum</hi> tamen <hi rend="italics">del. Novák</hi>
+                  </note>; tametsi miserum est, 
 tamen ei qui hunc accuset possim<note>possum <hi rend="italics">w</hi>
-               </note> aliquo modo ignoscere.  <reg>cum</reg> enim 
+                  </note> aliquo modo ignoscere.  <reg>cum</reg> enim 
 aliquid habeat quod possit<note>possit <hi rend="italics">Angelius</hi>: possim <hi rend="italics">codd.</hi>
-               </note> criminose ac suspiciose dicere, aperte 
+                  </note> criminose ac suspiciose dicere, aperte 
 ludificari et calumniari sciens non videatur.  <reg>qua</reg> re facile omnes 
 patimur esse quam plurimos accusatores, quod innocens, si accusatus 
 sit<note>
-                  <app><lem>sit</lem></app> est <hi rend="italics">Halm</hi> (2)</note>, absolvi potest, nocens, nisi accusatus fuerit, condemnari non 
+                     <app>
+                        <lem>sit</lem>
+                     </app> est <hi rend="italics">Halm</hi> (2)</note>, absolvi potest, nocens, nisi accusatus fuerit, condemnari non 
 potest; utilius est autem absolvi innocentem quam nocentem causam 
 non dicere. Anseribus cibaria publice locantur et canes aluntur in 
 Capitolio ut significent si fures venerint. <reg>at</reg> fures internoscere non 
 possunt, significant tamen si qui noctu in Capitolium venerint<note>venerut <hi rend="italics">Madvig</hi>
-               </note> et, quia 
+                  </note> et, quia 
 id est suspiciosum, tametsi bestiae sunt, tamen in eam partem potius 
-peccant quae est cautior.  <reg>quod</reg> si luce quoque canes latrent cum deos<note>does <foreign xml:lang="grc">sxy1</foreign>: deo (eo <foreign xml:lang="grc">y2</foreign>) <hi rend="italics">cett.</hi>
-               </note> 
+peccant quae est cautior.  <reg>quod</reg> si luce quoque canes latrent cum deos<note>does <foreign xml:lang="grc">σχψ1</foreign>: deo (eo <foreign xml:lang="grc">ψ2</foreign>) <hi rend="italics">cett.</hi>
+                  </note> 
 salutatum aliqui venerint, opinor, eis crura suffringantur, quod acres 
-sint etiam tum cum suspicio nulla sit. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="57"><p>
-               <reg>simillima</reg> est accusatorum 
+sint etiam tum cum suspicio nulla sit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="57">
+               <p>
+                  <reg>simillima</reg> est accusatorum 
 ratio.  Alii vestrum anseres sunt qui tantum modo clamant, nocere 
 non possunt, alii canes qui et latrare et mordere possunt.  <reg>cibaria</reg> 
 vobis praeberi videmus; vos autem maxime debetis in eos impetum 
 facere qui merentur.  <reg>hoc</reg> populo gratissimum est. <reg>deinde</reg>, si 
 voletis, etiam tum cum veri simile erit aliquem<note>aliquem aliquid <hi rend="italics">Hotoman</hi>
-               </note> commisisse, in 
+                  </note> commisisse, in 
 suspicione latratote; id quoque concedi potest.  <reg>sin</reg> autem sic agetis 
 ut arguatis aliquem patrem occidisse neque dicere possitis aut qua re 
 aut quo modo, ac tantum modo sine suspicione latrabitis, crura 
 quidem vobis nemo suffringet, sed, si ego hos bene novi, litteram 
-illam cui vos usque eo inimici estis ut etiam Kal. omnis<note>Kal. omnis <hi rend="italics">Pighius</hi>: calomnis <foreign xml:lang="grc">S<hi rend="italics">A</hi>pfx</foreign>: calonis <foreign xml:lang="grc">s</foreign>: calomniis <foreign xml:lang="grc">y</foreign>: calumpniis <foreign xml:lang="grc">w</foreign>
-               </note> oderitis ita 
-vehementer ad caput adfigent<note>adfigent <foreign xml:lang="grc">y2</foreign>, <hi rend="italics">ed. R</hi>: adfingent (-entur <foreign xml:lang="grc">w</foreign>) <hi rend="italics">cett.</hi>
-               </note> ut postea neminem alium nisi fortunas 
+illam cui vos usque eo inimici estis ut etiam Kal. omnis<note>Kal. omnis <hi rend="italics">Pighius</hi>: calomnis <foreign xml:lang="grc">ς<hi rend="italics">α</hi>πφχ</foreign>: calonis <foreign xml:lang="grc">ς</foreign>: calomniis <foreign xml:lang="grc">ψ</foreign>: calumpniis <foreign xml:lang="grc">ω</foreign>
+                  </note> oderitis ita 
+vehementer ad caput adfigent<note>adfigent <foreign xml:lang="grc">ψ2</foreign>, <hi rend="italics">ed. R</hi>: adfingent (-entur <foreign xml:lang="grc">ω</foreign>) <hi rend="italics">cett.</hi>
+                  </note> ut postea neminem alium nisi fortunas 
 vestras accusare possitis.</p>
-         </div>
-         
-                  <milestone n="21" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="58"><p>
-               <reg>quid</reg> mihi ad defendendum dedisti, bone accusator? quid hisce autem 
+            </div>
+            <milestone n="21" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="58">
+               <p>
+                  <reg>quid</reg> mihi ad defendendum dedisti, bone accusator? quid hisce autem 
 ad suspicandum? '<reg>ne</reg>
-               <note>
-                  <app><lem>ne</lem></app> neque <foreign xml:lang="grc">S</foreign>
-               </note> exheredaretur veritus est.'  <reg>audio</reg>, sed qua de 
+                  <note>
+                     <app>
+                        <lem>ne</lem>
+                     </app> neque <foreign xml:lang="grc">ς</foreign>
+                  </note> exheredaretur veritus est.'  <reg>audio</reg>, sed qua de 
 causa vereri debuerit nemo dicit. '<reg>habebat</reg> pater in animo.'  <reg>planum</reg> 
-fac. <reg>nihil</reg> est; non quicum deliberaverit<note>deliberaverit <foreign xml:lang="grc">sx</foreign>: deliberavit <hi rend="italics">cett.</hi>: deliberarit <hi rend="italics">ed. V</hi>
-               </note>, quem certiorem fecerit, 
+fac. <reg>nihil</reg> est; non quicum deliberaverit<note>deliberaverit <foreign xml:lang="grc">σχ</foreign>: deliberavit <hi rend="italics">cett.</hi>: deliberarit <hi rend="italics">ed. V</hi>
+                  </note>, quem certiorem fecerit, 
 unde istud vobis suspicari in mentem venerit. <reg>cum</reg> hoc modo accusas, 
 Eruci, nonne hoc palam dicis: '<reg>ego</reg> quid acceperim scio, quid dicam 
-nescio; unum illud<note>illud <foreign xml:lang="grc">sxy</foreign>: illum <hi rend="italics">cett.</hi>
-               </note> spectavi quod Chrysogonus aiebat neminem isti 
+nescio; unum illud<note>illud <foreign xml:lang="grc">σχψ</foreign>: illum <hi rend="italics">cett.</hi>
+                  </note> spectavi quod Chrysogonus aiebat neminem isti 
 patronum futurum; de bonorum emptione deque ea societate 
 neminem esse qui verbum facere auderet hoc tempore'<note>hoc tempore auderet <hi rend="italics">ed. Mediol.</hi>
-               </note>? <reg>haec</reg> te 
+                  </note>? <reg>haec</reg> te 
 opinio falsa in istam fraudem impulit; non me hercules verbum 
-fecisses, si tibi quemquam responsurum putasses.</p></div> 
-                  
-
-
-               <div type="textpart" subtype="section" n="59"><p>
-               <reg>operae</reg> pretium erat, si animadvertistis, iudices, neglegentiam eius in 
+fecisses, si tibi quemquam responsurum putasses.</p>
+            </div>
+            <div type="textpart" subtype="section" n="59">
+               <p>
+                  <reg>operae</reg> pretium erat, si animadvertistis, iudices, neglegentiam eius in 
 accusando considerare.  <reg>credo</reg>, cum vidisset qui homines in hisce 
 subselliis sederent, quaesisse<note>quaesisse <hi rend="italics">ed. R</hi>: quaesisset <hi rend="italics">codd.</hi>
-               </note> num ille aut ille defensurus esset; de 
+                  </note> num ille aut ille defensurus esset; de 
 me ne suspicatum quidem esse, quod antea causam publicam nullam 
 dixerim.  <reg>postea</reg> quam invenit neminem eorum qui possunt et solent 
 ita neglegens esse coepit ut, eum in mentem veniret ei, resideret, 
@@ -1091,42 +1300,45 @@ imperaret, prorsus ut vestro consessu et hoc conventu pro summa
 solitudine abuteretur. <reg>peroravit</reg> aliquando, adsedit; surrexi ego.  
 
 </p>
-         </div>
-         
- <milestone n="22" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="60"><p>
-               <reg>respirare</reg> visus est quod non alius potius diceret.  <reg>coepi</reg> dicere.  
+            </div>
+            <milestone n="22" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="60">
+               <p>
+                  <reg>respirare</reg> visus est quod non alius potius diceret.  <reg>coepi</reg> dicere.  
 Vsque eo animadverti, iudices, eum iocari atque alias res agere ante 
 quam Chrysogonum nominavi; quem simul atque attigi, statim homo 
 se erexit, mirari visus est.  <reg>intellexi</reg> quid cum pepugisset<note>
-                  <app><lem>pepugisset</lem></app> pupugisset <foreign xml:lang="grc">xy2</foreign> (<hi rend="italics">cf. Gellium</hi> vi. 9. 15)</note>. <reg>iterum</reg> ac 
+                     <app>
+                        <lem>pepugisset</lem>
+                     </app> pupugisset <foreign xml:lang="grc">χψ2</foreign> (<hi rend="italics">cf. Gellium</hi> vi. 9. 15)</note>. <reg>iterum</reg> ac 
 tertio nominavi.  <reg>postea</reg> homines cursare ultro et citro non 
 destiterunt, credo, qui Chrysogono nuntiarent esse<note>esse <hi rend="italics">om. w</hi>: aliquem esse <hi rend="italics">ed. V</hi>
-               </note> aliquem in civitate<note>civitatem <foreign xml:lang="grc">Ssx</foreign>
-               </note> 
+                  </note> aliquem in civitate<note>civitatem <foreign xml:lang="grc">σσχ</foreign>
+                  </note> 
 qui contra voluntatem eius dicere auderet; aliter causam agi atque 
 ille existimaret, aperiri bonorum emptionem, vexari pessime 
 societatem, gratiam potentiamque eius neglegi, iudices diligenter 
-attendere, populo rem indignam videri. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="61"><p>
-               <reg>quae</reg> quoniam te fefellerunt<note>fefellerunt <hi rend="italics">ed. V</hi>: fefellerint <hi rend="italics">codd.</hi>
-               </note>, 
+attendere, populo rem indignam videri. </p>
+            </div>
+            <div type="textpart" subtype="section" n="61">
+               <p>
+                  <reg>quae</reg> quoniam te fefellerunt<note>fefellerunt <hi rend="italics">ed. V</hi>: fefellerint <hi rend="italics">codd.</hi>
+                  </note>, 
 Eruci, quoniamque vides versa esse omnia, causam pro Sex. Roscio, si 
 non commode, at libere dici, quem dedi putabas defendi intellegis, 
 quos tradituros sperabas vides iudicare, restitue nobis aliquando 
 veterem tuam illam calliditatem atque prudentiam, confitere<note>aut confitere te <hi rend="italics">Hotoman</hi>
-               </note> huc ea 
+                  </note> huc ea 
 spe venisse quod putares hic latrocinium, non iudicium futurum.
 
 
                <reg>de</reg> parricidio causa dicitur; ratio ab accusatore reddita non est quam 
-   ob causam patrem filius occiderit.  </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="62"><p>
-               <reg>quod</reg> in minimis noxiis et in his 
+   ob causam patrem filius occiderit.  </p>
+            </div>
+            <div type="textpart" subtype="section" n="62">
+               <p>
+                  <reg>quod</reg> in minimis noxiis et in his 
 levioribus peccatis quae magis crebra et iam prope cotidiana sunt vel<note>vel <hi rend="italics">Eberhard</hi>: id <hi rend="italics">codd.</hi>: et <hi rend="italics">Klotz: del. Ascens.</hi> (3)</note> 
 maxime et primum quaeritur, quae causa malefici fuerit, id Erucius in 
 parricidio quaeri non putat oportere.  <reg>in</reg> quo scelere, iudices, etiam 
@@ -1139,10 +1351,10 @@ audacia ostendatur necesse est, neque audacia solum sed summus
 furor atque amentia.  <reg>haec</reg> cum sint omnia, tamen exstent oportet 
 expressa sceleris vestigia, ubi, qua ratione, per quos, quo tempore 
 maleficium sit admissum. <reg>quae</reg> nisi multa et manifesta sunt, 
-   profecto res tam scelesta, tam atrox, tam nefaria credi non potest. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="63"><p>Magna est enim vis humanitatis; multum valet communio sanguinis; 
+   profecto res tam scelesta, tam atrox, tam nefaria credi non potest. </p>
+            </div>
+            <div type="textpart" subtype="section" n="63">
+               <p>Magna est enim vis humanitatis; multum valet communio sanguinis; 
 reclamitat istius modi suspicionibus ipsa natura; portentum atque 
 monstrum certissimum est esse aliquem humana specie et figura qui 
 tantum immanitate bestias vicerit ut, propter quos hanc suavissimam 
@@ -1152,105 +1364,120 @@ sese partus atque educatio et natura ipsa conciliet.
 
 
             </p>
-         </div>
-         <milestone n="23" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="64"><p>
-               <reg>non</reg> ita multis ante annis aiunt <choice><abbr>T.</abbr><expan>T<ex>itum</ex></expan></choice> Caelium<note>Caelium <hi rend="italics">Valerius Max.</hi> viii. 1. 13: Colelium (Cold- <foreign xml:lang="grc">fy</foreign>) <hi rend="italics">codd.</hi>
-               </note> quendam Terracinensem<note>Terracinensem <foreign xml:lang="grc">Spw</foreign>, <hi rend="italics">Schol.</hi>: Tarracinensem <hi rend="italics">cett., Valerius Max.</hi> (<hi rend="italics">cf. Schuchardt</hi> iii. 103)</note>, 
+            </div>
+            <milestone n="23" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="64">
+               <p>
+                  <reg>non</reg> ita multis ante annis aiunt <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itum</ex>
+                     </expan>
+                  </choice> Caelium<note>Caelium <hi rend="italics">Valerius Max.</hi> viii. 1. 13: Colelium (Cold- <foreign xml:lang="grc">φψ</foreign>) <hi rend="italics">codd.</hi>
+                  </note> quendam Terracinensem<note>Terracinensem <foreign xml:lang="grc">σπω</foreign>, <hi rend="italics">Schol.</hi>: Tarracinensem <hi rend="italics">cett., Valerius Max.</hi> (<hi rend="italics">cf. Schuchardt</hi> iii. 103)</note>, 
 hominem non obscurum, cum cenatus cubitum in idem conclave cum 
 duobus adulescentibus filiis isset, inventum esse mane iugulatum.  
 <reg>cum</reg> neque servus quisquam reperiretur<note>reperiretur <hi rend="italics">Angelius</hi>: reperiebatur <hi rend="italics">codd.</hi>
-               </note> neque liber ad quem ea 
+                  </note> neque liber ad quem ea 
 suspicio pertineret, id aetatis autem duo filii propter cubantes ne 
 sensisse quidem se dicerent, nomina filiorum de parricidio delata 
-sunt. <reg>quid</reg> poterat tam esse<note>tam esse <hi rend="italics">Gruter</hi>: sa est <foreign xml:lang="grc">S</foreign>: sane <hi rend="italics">A<foreign xml:lang="grc">pfw</foreign>
-                  </hi>: satis est <foreign xml:lang="grc">sxy</foreign> suspiciosum <hi rend="italics">Madvig</hi>: suspiciosum autem <hi rend="italics">codd.</hi>: suspiciosum. Suspiciosum autem <hi rend="italics">coni. Halm</hi>
-               </note> suspiciosum? neutrumne sensisse? 
+sunt. <reg>quid</reg> poterat tam esse<note>tam esse <hi rend="italics">Gruter</hi>: sa est <foreign xml:lang="grc">ς</foreign>: sane <hi rend="italics">A<foreign xml:lang="grc">πφω</foreign>
+                     </hi>: satis est <foreign xml:lang="grc">σχψ</foreign> suspiciosum <hi rend="italics">Madvig</hi>: suspiciosum autem <hi rend="italics">codd.</hi>: suspiciosum. Suspiciosum autem <hi rend="italics">coni. Halm</hi>
+                  </note> suspiciosum? neutrumne sensisse? 
 ausum autem esse quemquam se in id conclave committere eo 
 potissimum tempore cum ibidem essent duo adulescentes filii qui et 
 sentire et defendere facile possent? <reg>erat</reg> porro nemo in quem ea 
-                  suspicio conveniret. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="65"><p>
-               <reg>tamen</reg>, cum planum iudicibus esset factum 
+                  suspicio conveniret. </p>
+            </div>
+            <div type="textpart" subtype="section" n="65">
+               <p>
+                  <reg>tamen</reg>, cum planum iudicibus esset factum 
 aperto ostio dormientis eos repertos esse, iudicio absoluti 
 adulescentes et suspicione omni liberati sunt.  <reg>nemo</reg> enim putabat 
 quemquam esse qui, cum omnia
 divina atque humana iura scelere nefario polluisset, somnum statim 
-capere potuisset<note>potuisset <hi rend="italics">edd. VR</hi>: potuisse (-se || <foreign xml:lang="grc">S</foreign>) <hi rend="italics">codd.</hi>: posset <hi rend="italics">Ernesti</hi>
-               </note>, propterea quod qui tantum facinus commiserunt 
+capere potuisset<note>potuisset <hi rend="italics">edd. VR</hi>: potuisse (-se || <foreign xml:lang="grc">ς</foreign>) <hi rend="italics">codd.</hi>: posset <hi rend="italics">Ernesti</hi>
+                  </note>, propterea quod qui tantum facinus commiserunt 
 non modo sine cura quiescere sed ne spirare quidem sine metu 
 possunt.
 
 
             </p>
-         </div>
-         <milestone n="24" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="66"><p>
-               <reg>videtisne</reg> quos<note>
-                  <app><lem>quos</lem></app> quod <foreign xml:lang="grc">x2y2</foreign>
-               </note> nobis poetae tradiderunt patris ulciscendi causa 
+            </div>
+            <milestone n="24" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="66">
+               <p>
+                  <reg>videtisne</reg> quos<note>
+                     <app>
+                        <lem>quos</lem>
+                     </app> quod <foreign xml:lang="grc">χ2ψ2</foreign>
+                  </note> nobis poetae tradiderunt patris ulciscendi causa 
 supplicium de matre sumpsisse, cum praesertim deorum 
 immortalium iussis atque oraculis id fecisse dicantur, tamen ut eos 
 agitent Furiae neque consistere umquam<note>usquam <hi rend="italics">A</hi>
-               </note> patiantur, quod ne pii 
+                  </note> patiantur, quod ne pii 
 quidem sine scelere esse potuerunt? <reg>sic</reg> se res habet, iudices: 
 magnam vim, magnam necessitatem, magnam possidet religionem 
 paternus maternusque sanguis; ex quo si qua macula concepta est, 
-non modo elui<note>elui <hi rend="italics">Victorius</hi>: leui <foreign xml:lang="grc">S<hi rend="italics">A</hi>pf</foreign>: leni <foreign xml:lang="grc">xy</foreign>: lui <foreign xml:lang="grc">w</foreign>: <hi rend="italics">om.</hi> 
-                  <foreign xml:lang="grc">s</foreign> 
-                  <hi rend="italics">in lac.</hi>
-               </note> non potest verum usque eo permanat ad animum ut 
-                  summus furor atque amentia consequatur. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="67"><p>
-               <reg>nolite</reg> enim putare, quem 
+non modo elui<note>elui <hi rend="italics">Victorius</hi>: leui <foreign xml:lang="grc">ς<hi rend="italics">α</hi>πφ</foreign>: leni <foreign xml:lang="grc">χψ</foreign>: lui <foreign xml:lang="grc">ω</foreign>: <hi rend="italics">om.</hi>
+                     <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">in lac.</hi>
+                  </note> non potest verum usque eo permanat ad animum ut 
+                  summus furor atque amentia consequatur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="67">
+               <p>
+                  <reg>nolite</reg> enim putare, quem 
 ad modum in fabulis saepenumero videtis, eos qui aliquid impie 
 scelerateque commiserint<note>commiserint <hi rend="italics">ed. R</hi>: commiserunt <hi rend="italics">codd.</hi>
-               </note> agitari et perterreri Furiarum taedis 
+                  </note> agitari et perterreri Furiarum taedis 
 ardentibus. Sua quemque fraus et suus terror maxime vexat, suum 
 quemque scelus agitat amentiaque adficit, suae malae cogitationes 
 conscientiaeque animi terrent; hae<note>
-                  <app><lem>hae</lem></app> haec <hi rend="italics">w, Schol. Lucan.</hi> vii. 784 (<hi rend="italics">cf. Deiot.</hi> 26)</note> sunt impiis adsiduae 
-domesticaeque Furiae quae dies noctesque parentium<note>parentium <foreign xml:lang="grc">S<hi rend="italics">A</hi>p</foreign>: parentum <hi rend="italics">cett.</hi> (<hi rend="italics">cf. Neue</hi> i. 404)</note> poenas a 
-   consceleratissimis filiis repetant.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="68"><p>
-               <reg>haec</reg> magnitudo malefici facit ut, 
+                     <app>
+                        <lem>hae</lem>
+                     </app> haec <hi rend="italics">w, Schol. Lucan.</hi> vii. 784 (<hi rend="italics">cf. Deiot.</hi> 26)</note> sunt impiis adsiduae 
+domesticaeque Furiae quae dies noctesque parentium<note>parentium <foreign xml:lang="grc">ς<hi rend="italics">α</hi>π</foreign>: parentum <hi rend="italics">cett.</hi> (<hi rend="italics">cf. Neue</hi> i. 404)</note> poenas a 
+   consceleratissimis filiis repetant.</p>
+            </div>
+            <div type="textpart" subtype="section" n="68">
+               <p>
+                  <reg>haec</reg> magnitudo malefici facit ut, 
 nisi paene manifestum parricidium proferatur, credibile non sit, nisi 
 turpis adulescentia, nisi omnibus flagitiis vita inquinata, nisi sumptus 
-effusi cum probro atque dedecore, nisi prorupta<note>praerupta <foreign xml:lang="grc">w</foreign>
-               </note> audacia, nisi 
+effusi cum probro atque dedecore, nisi prorupta<note>praerupta <foreign xml:lang="grc">ω</foreign>
+                  </note> audacia, nisi 
 tanta temeritas ut non procul abhorreat ab insania. <reg>accedat</reg> huc 
-oportet odium parentis, animadversionis<note>animumadversionis <foreign xml:lang="grc">S</foreign>
-               </note> paternae metus, amici 
+oportet odium parentis, animadversionis<note>animumadversionis <foreign xml:lang="grc">ς</foreign>
+                  </note> paternae metus, amici 
 improbi, servi conscii, tempus idoneum, locus opportune captus ad 
 eam rem; paene dicam, respersas
 manus sanguine paterno iudices videant oportet, si tantum facinus, 
-tam immane, tam acerbum credituri sunt. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="69"><p>
-               <reg>qua</reg> re hoc quo minus est 
+tam immane, tam acerbum credituri sunt. </p>
+            </div>
+            <div type="textpart" subtype="section" n="69">
+               <p>
+                  <reg>qua</reg> re hoc quo minus est 
 credibile, nisi ostenditur, eo magis est, si convincitur, vindicandum.
-         <milestone n="25" unit="chapter"/><milestone unit="para"/>
-               <reg>itaque</reg> cum multis ex rebus intellegi potest maiores nostros non modo 
+         <milestone n="25" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>itaque</reg> cum multis ex rebus intellegi potest maiores nostros non modo 
 armis plus quam ceteras nationes verum etiam consilio sapientiaque 
 potuisse, tum ex hac re vel maxime quod in impios singulare 
-supplicium invenerunt. <reg>qua</reg> in re quantum prudentia praestiterint<note>praestiterint (-it <foreign xml:lang="grc">s</foreign>) <foreign xml:lang="grc">sxy</foreign>: praestiterunt <hi rend="italics">cett</hi>.</note> eis 
-   qui apud ceteros sapientissimi fuisse dicuntur considerate. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="70"><p>
-               <reg>prudentissima</reg> 
+supplicium invenerunt. <reg>qua</reg> in re quantum prudentia praestiterint<note>praestiterint (-it <foreign xml:lang="grc">ς</foreign>) <foreign xml:lang="grc">σχψ</foreign>: praestiterunt <hi rend="italics">cett</hi>.</note> eis 
+   qui apud ceteros sapientissimi fuisse dicuntur considerate. </p>
+            </div>
+            <div type="textpart" subtype="section" n="70">
+               <p>
+                  <reg>prudentissima</reg> 
 civitas Atheniensium, dum ea rerum potita est, fuisse 
 traditur; eius porro civitatis sapientissimum Solonem dicunt fuisse, 
 eum qui leges quibus hodie quoque utuntur scripserit<note>
-                  <app><lem>scripserit</lem></app> scripsit <hi rend="italics">Halm</hi>
-               </note>. <reg>is</reg> cum 
+                     <app>
+                        <lem>scripserit</lem>
+                     </app> scripsit <hi rend="italics">Halm</hi>
+                  </note>. <reg>is</reg> cum 
 interrogaretur cur nullum supplicium constituisset in eum qui 
 parentem necasset, respondit se id neminem facturum putasse.  
 <reg>sapienter</reg> fecisse dicitur, cum de eo nihil sanxerit quod antea 
@@ -1258,388 +1485,442 @@ commissum non erat, ne non tam prohibere quam admonere
 videretur. <reg>quanto</reg> nostri maiores sapientius! qui cum intellegerent 
 nihil esse tam sanctum quod non aliquando violaret audacia, 
 supplicium in parricidas singulare excogitaverunt ut, quos natura 
-ipsa retinere in officio non potuisset, ei<note>ii <hi rend="italics">Naugerius</hi> (2): in <foreign xml:lang="grc">S</foreign>: <hi rend="italics">om. cett.</hi>
-               </note> magnitudine poenae a<note>a <hi rend="italics">s, Wesenberg: om. mei</hi>
-               </note> 
+ipsa retinere in officio non potuisset, ei<note>ii <hi rend="italics">Naugerius</hi> (2): in <foreign xml:lang="grc">ς</foreign>: <hi rend="italics">om. cett.</hi>
+                  </note> magnitudine poenae a<note>a <hi rend="italics">s, Wesenberg: om. mei</hi>
+                  </note> 
 maleficio summoverentur.  <reg>insui</reg> voluerunt in culleum vivos atque ita<note>ita <hi rend="italics">om. w, del. Kayser</hi>
-               </note> 
+                  </note> 
 in flumen deici.</p>
-         </div>
-
-         <milestone n="26" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="71"><p>O singularem sapientiam, iudices! <reg>nonne</reg> videntur hunc hominem 
+            </div>
+            <milestone n="26" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="71">
+               <p>O singularem sapientiam, iudices! <reg>nonne</reg> videntur hunc hominem 
 ex rerum natura sustulisse et eripuisse cui repente caelum, solem, 
 aquam terramque ademerint ut, qui eum necasset unde ipse natus 
-esset<note>esset <hi rend="italics">Angelius</hi>: est (esset <foreign xml:lang="grc">sxy</foreign>) et <hi rend="italics">codd.</hi>
-               </note>, careret eis rebus omnibus ex quibus omnia nata esse dicuntur? 
+esset<note>esset <hi rend="italics">Angelius</hi>: est (esset <foreign xml:lang="grc">σχψ</foreign>) et <hi rend="italics">codd.</hi>
+                  </note>, careret eis rebus omnibus ex quibus omnia nata esse dicuntur? 
 <reg>noluerunt</reg> feris corpus obicere ne bestiis quoque quae tantum scelus 
 attigissent
 immanioribus uteremur; non sic nudos in flumen deicere ne, cum 
 delati essent in mare, ipsum<note>mare, mare ipsum <hi rend="italics">Richter</hi>
-               </note> polluerent quo cetera quae violata sunt 
+                  </note> polluerent quo cetera quae violata sunt 
 expiari putantur; denique nihil tam vile neque tam volgare est cuius 
-partem ullam reliquerint. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="72"><p>
-               <reg>etenim</reg> quid tam est<note>
-                  <app><lem>tam est</lem></app> est tam <foreign xml:lang="grc">x</foreign>, <hi rend="italics">Lambinus</hi> (quid enim tam commune <hi rend="italics">cit. Cicero Orat.</hi> 107; <hi rend="italics">Quintil.</hi> xii. 6. 4)</note> commune quam 
+partem ullam reliquerint. </p>
+            </div>
+            <div type="textpart" subtype="section" n="72">
+               <p>
+                  <reg>etenim</reg> quid tam est<note>
+                     <app>
+                        <lem>tam est</lem>
+                     </app> est tam <foreign xml:lang="grc">χ</foreign>, <hi rend="italics">Lambinus</hi> (quid enim tam commune <hi rend="italics">cit. Cicero Orat.</hi> 107; <hi rend="italics">Quintil.</hi> xii. 6. 4)</note> commune quam 
 spiritus vivis, terra  mortuis, mare fluctuantibus, litus eiectis?  <reg>ita</reg> 
-vivunt, dum possunt, ut ducere animam<note>animam <foreign xml:lang="grc">Sxy</foreign>, <hi rend="italics">Cic. l. c.</hi>: animum <hi rend="italics">cett.</hi>
-               </note> de caelo non queant, ita 
+vivunt, dum possunt, ut ducere animam<note>animam <foreign xml:lang="grc">σχψ</foreign>, <hi rend="italics">Cic. l. c.</hi>: animum <hi rend="italics">cett.</hi>
+                  </note> de caelo non queant, ita 
 moriuntur ut eorum ossa terra non tangat<note>terram non tangant <hi rend="italics">Cic. l. c.</hi>
-               </note>, ita iactantur fluctibus ut 
+                  </note>, ita iactantur fluctibus ut 
 numquam adluantur<note>adluantur <hi rend="italics">Cic. l. c., Sylvius</hi>: abluantur <hi rend="italics">codd.</hi>
-               </note>, ita postremo eiciuntur ut ne ad saxa quidem 
+                  </note>, ita postremo eiciuntur ut ne ad saxa quidem 
 mortui conquiescant.  <reg>tanti</reg> malefici crimen, cui maleficio tam insigne 
 supplicium est constitutum, probare te, Eruci, censes posse talibus 
 viris, si ne causam quidem malefici protuleris?  si hunc apud 
 bonorum emptores ipsos accusares eique iudicio Chrysogonus 
-praeesset, tamen diligentius paratiusque venisses.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="73"><p>Vtrum quid agatur 
+praeesset, tamen diligentius paratiusque venisses.</p>
+            </div>
+            <div type="textpart" subtype="section" n="73">
+               <p>Vtrum quid agatur 
 non vides, an apud quos agatur?  <reg>agitur</reg> de parricidio quod sine 
 multis causis suscipi non potest; apud homines autem prudentissimos 
 agitur qui intellegunt neminem ne minimum quidem 
 maleficium sine causa admittere.
-<milestone n="27" unit="chapter"/><milestone unit="para"/>
-               <reg>esto</reg>, causam proferre non potes.  <reg>tametsi</reg> statim vicisse debeo, 
+<milestone n="27" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>esto</reg>, causam proferre non potes.  <reg>tametsi</reg> statim vicisse debeo, 
 tamen de meo<note>meo <hi rend="italics">Madvig</hi>: in eo <hi rend="italics">codd.</hi> (<hi rend="italics">cf. Clu.</hi> 65)</note> iure decedam et tibi quod in alia causa non 
 concederem in hac concedam fretus huius innocentia.  <reg>non</reg> quaero 
 abs te qua re patrem Sex. Roscius occiderit, quaero quo modo 
-occiderit.  <reg>ita</reg> quaero abs te, <choice><abbr>C.</abbr><expan>G<ex>ai</ex></expan></choice> Eruci: quo modo, et <reg>sic</reg> tecum agam ut 
+occiderit.  <reg>ita</reg> quaero abs te, <choice>
+                     <abbr>C.</abbr>
+                     <expan>G<ex>ai</ex>
+                     </expan>
+                  </choice> Eruci: quo modo, et <reg>sic</reg> tecum agam ut 
 meo loco vel respondendi vel interpellandi tibi potestatem faciam vel 
-etiam, <reg>si</reg> quid voles, interrogandi.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="74"><p>
-               <reg>quo</reg> modo occidit? ipse percussit 
+etiam, <reg>si</reg> quid voles, interrogandi.</p>
+            </div>
+            <div type="textpart" subtype="section" n="74">
+               <p>
+                  <reg>quo</reg> modo occidit? ipse percussit 
 an aliis occidendum dedit? si ipsum arguis, Romae non fuit; si per 
-alios fecisse dicis, quaero quos<note>quos <foreign xml:lang="grc">S</foreign>, <hi rend="italics">Richter: om. cett.</hi>
-               </note>?
+alios fecisse dicis, quaero quos<note>quos <foreign xml:lang="grc">ς</foreign>, <hi rend="italics">Richter: om. cett.</hi>
+                  </note>?
 <reg>servosne</reg> an liberos? si liberos<note>si liberos <hi rend="italics">Madvig: om. codd.</hi>
-               </note>, quos homines? indidemne Ameria an 
-hosce ex urbe <reg>sicarios</reg>? si Ameria<note>si Ameria <foreign xml:lang="grc">sxy</foreign>: si Ameriae <hi rend="italics">cett.</hi>
-               </note>, qui sunt ei<note>ii <foreign xml:lang="grc">w</foreign> 
-                  <hi rend="italics">Halm</hi>: hi <hi rend="italics">cett.</hi>
-               </note>? cur<note>
-                  <app><lem>cur</lem></app> quur <foreign xml:lang="grc">Spy1</foreign>: quine <foreign xml:lang="grc">x</foreign>: <hi rend="italics">om.</hi> 
-                  <foreign xml:lang="grc">s</foreign> 
-                  <hi rend="italics">in lac.</hi> (<hi rend="italics">cf.</hi> §108)</note> non nominantur? 
+                  </note>, quos homines? indidemne Ameria an 
+hosce ex urbe <reg>sicarios</reg>? si Ameria<note>si Ameria <foreign xml:lang="grc">σχψ</foreign>: si Ameriae <hi rend="italics">cett.</hi>
+                  </note>, qui sunt ei<note>ii <foreign xml:lang="grc">ω</foreign>
+                     <hi rend="italics">Halm</hi>: hi <hi rend="italics">cett.</hi>
+                  </note>? cur<note>
+                     <app>
+                        <lem>cur</lem>
+                     </app> quur <foreign xml:lang="grc">σπψ1</foreign>: quine <foreign xml:lang="grc">χ</foreign>: <hi rend="italics">om.</hi>
+                     <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">in lac.</hi> (<hi rend="italics">cf.</hi> §108)</note> non nominantur? 
 si Roma<note>Roma <hi rend="italics">ed. R. Stephani</hi>: Romae <hi rend="italics">codd.</hi>
-               </note>, unde eos noverat Roscius qui Romam multis annis non venit 
+                  </note>, unde eos noverat Roscius qui Romam multis annis non venit 
 neque umquam plus triduo fuit? ubi eos convenit? qui conlocutus<note>qui conlocutus <hi rend="italics">G. Krüger</hi>: quicum locutus <hi rend="italics">codd.</hi>
-               </note> 
+                  </note> 
 est? quo modo persuasit? '<reg>pretium</reg> dedit'; cui dedit? per quem 
 dedit?  unde aut quantum dedit?  <reg>nonne</reg> his vestigiis ad caput 
 malefici perveniri solet?  <reg>et</reg> simul tibi in mentem veniat facito quem 
 ad modum vitam huiusce depinxeris; hunc hominem ferum atque 
 agrestem fuisse, numquam cum homine quoquam conlocutum esse, 
-numquam in oppido constitisse.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="75"><p>
-               <reg>qua</reg> in re praetereo illud quod mihi 
+numquam in oppido constitisse.</p>
+            </div>
+            <div type="textpart" subtype="section" n="75">
+               <p>
+                  <reg>qua</reg> in re praetereo illud quod mihi 
 maximo argumento ad huius innocentiam poterat esse, in rusticis 
 moribus, in victu arido, in hac horrida incultaque vita istius modi 
 maleficia gigni non solere.  Vt non omnem frugem neque arborem in 
 omni agro reperire possis, sic non omne facinus in omni vita nascitur.  
 <reg>in</reg> urbe luxuries creatur, ex luxuria<note>
-                  <app><lem>luxuria</lem></app> luxoriae <foreign xml:lang="grc">S</foreign>: luxurie <hi rend="italics">w</hi>
-               </note> exsistat avaritia necesse est, ex 
+                     <app>
+                        <lem>luxuria</lem>
+                     </app> luxoriae <foreign xml:lang="grc">ς</foreign>: luxurie <hi rend="italics">w</hi>
+                  </note> exsistat avaritia necesse est, ex 
 avaritia erumpat audacia, inde omnia scelera ac<note>
-                  <app><lem>ac</lem></app> atque <foreign xml:lang="grc">sx</foreign>: et <hi rend="italics">A</hi>
-               </note> maleficia gignuntur; 
+                     <app>
+                        <lem>ac</lem>
+                     </app> atque <foreign xml:lang="grc">σχ</foreign>: et <hi rend="italics">A</hi>
+                  </note> maleficia gignuntur; 
 vita autem haec rustica quam tu agrestem vocas parsimoniae, 
 diligentiae, iustitiae magistra est.</p>
-         </div>
-         
-                  <milestone n="28" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="76"><p>
-               <reg>verum</reg> haec missa facio; illud quaero, is homo qui<note>qui <foreign xml:lang="grc">y2</foreign>: <hi rend="italics">om. cett.</hi>
-               </note> ut tute dicis, 
+            </div>
+            <milestone n="28" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="76">
+               <p>
+                  <reg>verum</reg> haec missa facio; illud quaero, is homo qui<note>qui <foreign xml:lang="grc">ψ2</foreign>: <hi rend="italics">om. cett.</hi>
+                  </note> ut tute dicis, 
 numquam  inter homines fuerit<note>fuit <hi rend="italics">A</hi>
-               </note>, per quos homines hoc tantum 
+                  </note>, per quos homines hoc tantum 
 facinus, tam occultum<note>occulte <hi rend="italics">Kayser</hi>
-               </note>, absens praesertim, conficere potuerit.  <reg>multa</reg> 
+                  </note>, absens praesertim, conficere potuerit.  <reg>multa</reg> 
 sunt falsa, iudices, quae tamen argui suspiciose possunt; in his rebus 
 si suspicio reperta erit, culpam inesse concedam. Romae Sex. Roscius 
 occiditur, cum in agro Amerino esset filius. Litteras, credo, misit 
 alicui sicario qui Romae noverat neminem.  <reg>arcessivit</reg>
-               <note>
-                  <app><lem>arcessivit</lem></app> arcessi vita <foreign xml:lang="grc">S</foreign>: arcessunt <hi rend="italics">A</hi>
-                  <foreign xml:lang="grc">f</foreign>
-               </note> 
+                  <note>
+                     <app>
+                        <lem>arcessivit</lem>
+                     </app> arcessi vita <foreign xml:lang="grc">ς</foreign>: arcessunt <hi rend="italics">A</hi>
+                     <foreign xml:lang="grc">φ</foreign>
+                  </note> 
 aliquem<note>aliquem.</note>.  <reg>quem</reg>
-               <note>Quem <hi rend="italics">Priscian.</hi> (<hi rend="italics">K.</hi> iii. 534): aliquem <hi rend="italics">codd.</hi>
-               </note> aut<note>aut <foreign xml:lang="grc">S</foreign>: at (ac <foreign xml:lang="grc">w</foreign>) <hi rend="italics">cett.</hi>
-               </note> quando?  <reg>nuntium</reg> misit.  <reg>quem</reg> aut ad quem? 
+                  <note>Quem <hi rend="italics">Priscian.</hi> (<hi rend="italics">K.</hi> iii. 534): aliquem <hi rend="italics">codd.</hi>
+                  </note> aut<note>aut <foreign xml:lang="grc">ς</foreign>: at (ac <foreign xml:lang="grc">ω</foreign>) <hi rend="italics">cett.</hi>
+                  </note> quando?  <reg>nuntium</reg> misit.  <reg>quem</reg> aut ad quem? 
 <reg>pretio</reg>, gratia, spe, promissis induxit aliquem. <reg>nihil</reg> horum ne confingi 
-                  quidem potest; et tamen causa de parricidio dicitur.</p></div> 
-                  
-
-
-               <div type="textpart" subtype="section" n="77"><p>
-               <reg>reliquum</reg> est ut per servos id admiserit.  O, di immortales, rem 
+                  quidem potest; et tamen causa de parricidio dicitur.</p>
+            </div>
+            <div type="textpart" subtype="section" n="77">
+               <p>
+                  <reg>reliquum</reg> est ut per servos id admiserit.  O, di immortales, rem 
 miseram et calamitosam! <reg>quid</reg>
-               <note>quid <hi rend="italics">scripsi</hi>: quod <hi rend="italics">codd.</hi>
-               </note>? <reg>in</reg> tali crimine quod innocenti<note>
-                  <app><lem>quod innocenti</lem></app> quod innocentibus <hi rend="italics">Halm</hi> (2): innocenti <hi rend="italics">w</hi>
-               </note> saluti 
+                  <note>quid <hi rend="italics">scripsi</hi>: quod <hi rend="italics">codd.</hi>
+                  </note>? <reg>in</reg> tali crimine quod innocenti<note>
+                     <app>
+                        <lem>quod innocenti</lem>
+                     </app> quod innocentibus <hi rend="italics">Halm</hi> (2): innocenti <hi rend="italics">w</hi>
+                  </note> saluti 
 solet esse ut servos in quaestionem polliceatur<note>polliceatur <hi rend="italics">mg. Sylvii</hi>: polliceantur <hi rend="italics">codd.</hi>
-               </note>, id Sex. Roscio facere 
+                  </note>, id Sex. Roscio facere 
 non licet? <reg>vos</reg> qui hunc accusatis omnis eius servos habetis; unus 
-puer victus cotidiani administer<note>minister <foreign xml:lang="grc">w</foreign>
-               </note> ex tanta familia Sex. Roscio relictus 
-non est. <reg>te</reg> nunc appello, <choice><abbr>P.</abbr><expan>P<ex>ubli</ex></expan></choice> Scipio, te, <choice><abbr>M.</abbr><expan>M<ex>arce</ex></expan></choice> Metelle<note>M. <hi rend="italics">Krause</hi>: Q. <foreign xml:lang="grc">x</foreign>: <hi rend="italics">om. cett.</hi>
-               </note>; vobis advocatis, 
+puer victus cotidiani administer<note>minister <foreign xml:lang="grc">ω</foreign>
+                  </note> ex tanta familia Sex. Roscio relictus 
+non est. <reg>te</reg> nunc appello, <choice>
+                     <abbr>P.</abbr>
+                     <expan>P<ex>ubli</ex>
+                     </expan>
+                  </choice> Scipio, te, <choice>
+                     <abbr>M.</abbr>
+                     <expan>M<ex>arce</ex>
+                     </expan>
+                  </choice> Metelle<note>M. <hi rend="italics">Krause</hi>: Q. <foreign xml:lang="grc">χ</foreign>: <hi rend="italics">om. cett.</hi>
+                  </note>; vobis advocatis, 
 vobis agentibus aliquotiens duos servos paternos in quaestionem ab 
-adversariis Sex. Roscius postulavit; meministisne <choice><abbr>T.</abbr><expan>T<ex>itum</ex></expan></choice> Roscium<note>meministisne T. Roscium <hi rend="italics">ed. R. Stephani</hi>: meministine T. Rosci <hi rend="italics">codd.</hi>
-               </note> 
+adversariis Sex. Roscius postulavit; meministisne <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itum</ex>
+                     </expan>
+                  </choice> Roscium<note>meministisne T. Roscium <hi rend="italics">ed. R. Stephani</hi>: meministine T. Rosci <hi rend="italics">codd.</hi>
+                  </note> 
 recusare?  <reg>quid</reg>? ei servi ubi sunt? Chrysogonum, iudices, sectantur; 
-apud eum sunt in honore et<note>iis <foreign xml:lang="grc">Sx</foreign>, <hi rend="italics">Madvig</hi>: his <hi rend="italics">cett.</hi>
-               </note> in pretio.  <reg>etiam</reg> nunc ut ex eis quaeratur 
-                  ego postulo, hic orat atque obsecrat.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="78"><p>
-               <reg>quid</reg> facitis? cur recusatis?  
+apud eum sunt in honore et<note>iis <foreign xml:lang="grc">σχ</foreign>, <hi rend="italics">Madvig</hi>: his <hi rend="italics">cett.</hi>
+                  </note> in pretio.  <reg>etiam</reg> nunc ut ex eis quaeratur 
+                  ego postulo, hic orat atque obsecrat.</p>
+            </div>
+            <div type="textpart" subtype="section" n="78">
+               <p>
+                  <reg>quid</reg> facitis? cur recusatis?  
 <reg>dubitate</reg> etiam nunc, iudices, si potestis, a quo sit Sex. Roscius 
-occisus, ab eone qui propter illius mortem in egestate et in<note>et in <foreign xml:lang="grc">xw</foreign>, <hi rend="italics">Halm</hi>: et <hi rend="italics">cett.</hi>
-               </note> insidiis 
+occisus, ab eone qui propter illius mortem in egestate et in<note>et in <foreign xml:lang="grc">χω</foreign>, <hi rend="italics">Halm</hi>: et <hi rend="italics">cett.</hi>
+                  </note> insidiis 
 versatur, cui ne quaerendi quidem de morte patris potestas 
 permittitur, an ab eis qui quaestionem fugitant, bona possident, in 
 caede atque ex caede vivunt. <reg>omnia</reg>, iudices, in hac causa sunt misera 
 atque indigna; tamen hoc nihil neque acerbius neque iniquius 
 proferri potest: mortis paternae de servis paternis quaestionem 
 habere filio non licet!  <reg>ne</reg> tam diu quidem dominus erit in suos dum 
-ex eis de patris morte quaeratur? <reg>veniam</reg>, neque ita multo postea<note>postea <hi rend="italics">scripsi</hi>: post.. <foreign xml:lang="grc">S</foreign>: post <hi rend="italics">cett.</hi>
-               </note>, ad 
+ex eis de patris morte quaeratur? <reg>veniam</reg>, neque ita multo postea<note>postea <hi rend="italics">scripsi</hi>: post.. <foreign xml:lang="grc">ς</foreign>: post <hi rend="italics">cett.</hi>
+                  </note>, ad 
 hunc locum; nam hoc totum
 ad Roscios pertinet, de quorum audacia tum me dicturum pollicitus 
 sum, cum Eruci crimina diluissem.
 
 
             </p>
-         </div>
-         <milestone n="29" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="79"><p>
-               <reg>nunc</reg>, Eruci, ad te venio.  <reg>conveniat</reg> mihi tecum necesse est, si ad 
+            </div>
+            <milestone n="29" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="79">
+               <p>
+                  <reg>nunc</reg>, Eruci, ad te venio.  <reg>conveniat</reg> mihi tecum necesse est, si ad 
 hunc maleficium istud pertinet, aut ipsum sua manu fecisse, id quod 
 negas, aut per aliquos liberos aut servos.  <reg>liberosne</reg>? quos neque ut 
-convenire<note>convenire <hi rend="italics">ed. Guar.</hi>: conveniret (-em <foreign xml:lang="grc">w</foreign>) <hi rend="italics">codd.</hi>
-               </note> potuerit neque qua ratione inducere neque ubi neque per 
+convenire<note>convenire <hi rend="italics">ed. Guar.</hi>: conveniret (-em <foreign xml:lang="grc">ω</foreign>) <hi rend="italics">codd.</hi>
+                  </note> potuerit neque qua ratione inducere neque ubi neque per 
 quos neque qua spe aut quo pretio potes ostendere. <reg>ego</reg> contra 
 ostendo non modo nihil eorum fecisse Sex. Roscium sed ne potuisse 
 quidem facere, quod neque Romae multis annis fuerit neque de 
 praediis umquam temere discesserit.  <reg>restare</reg> tibi videbatur 
 servorum nomen, quo quasi in portum reiectus a ceteris 
 suspicionibus confugere posses; ubi scopulum offendis '<reg>eius</reg> modi ut 
-non modo ab hoc crimen<note>crimine <foreign xml:lang="grc">sfw</foreign>
-               </note> resilire videas verum omnem suspicionem 
-                  in vosmet ipsos recidere intellegas.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="80"><p>
-               <reg>quid</reg> ergo est<note>quid est ergo <foreign xml:lang="grc">y</foreign>
-               </note> quo tamen<note>tamen <foreign xml:lang="grc">S</foreign>: tandem <hi rend="italics">cett.</hi>
-               </note> 
+non modo ab hoc crimen<note>crimine <foreign xml:lang="grc">σφω</foreign>
+                  </note> resilire videas verum omnem suspicionem 
+                  in vosmet ipsos recidere intellegas.</p>
+            </div>
+            <div type="textpart" subtype="section" n="80">
+               <p>
+                  <reg>quid</reg> ergo est<note>quid est ergo <foreign xml:lang="grc">ψ</foreign>
+                  </note> quo tamen<note>tamen <foreign xml:lang="grc">ς</foreign>: tandem <hi rend="italics">cett.</hi>
+                  </note> 
 accusator inopia argumentorum confugerit<note>confugit <hi rend="italics">Madvig</hi>
-               </note>?   <reg>eius</reg> modi tempus erat' 
+                  </note>?   <reg>eius</reg> modi tempus erat' 
 inquit 'ut homines volgo impune occiderentur; qua re hoc tu propter 
 multitudinem sicariorum nullo negotio facere potuisti.'  <reg>interdum</reg>
-               <note>interdum <hi rend="italics">cod.</hi> (?) <hi rend="italics">Vrsini</hi>: interim <hi rend="italics">mei</hi>
-               </note> 
+                  <note>interdum <hi rend="italics">cod.</hi> (?) <hi rend="italics">Vrsini</hi>: interim <hi rend="italics">mei</hi>
+                  </note> 
 mihi videris, Eruci, una mercede duas res adsequi velle, nos iudicio 
 perfundere<note>
-                  <app><lem>perfundere</lem></app> pessundare <hi rend="italics">Trojel</hi>: pervertere <hi rend="italics">Halm</hi> (<hi rend="italics">cf. Suet. Domit.</hi> 8 perfusoriis assertionibus)</note>, accusare autem eos ipsos a quibus mercedem accepisti. 
+                     <app>
+                        <lem>perfundere</lem>
+                     </app> pessundare <hi rend="italics">Trojel</hi>: pervertere <hi rend="italics">Halm</hi> (<hi rend="italics">cf. Suet. Domit.</hi> 8 perfusoriis assertionibus)</note>, accusare autem eos ipsos a quibus mercedem accepisti. 
 <reg>quid</reg> ais? volgo occidebantur? <reg>per</reg> quos et a quibus? <reg>nonne</reg>
-               <note>
-                  <app><lem>nonne</lem></app> non <hi rend="italics">Ernesti</hi>
-               </note> cogitas te 
+                  <note>
+                     <app>
+                        <lem>nonne</lem>
+                     </app> non <hi rend="italics">Ernesti</hi>
+                  </note> cogitas te 
 a sectoribus huc adductum esse? <reg>quid</reg> postea? <reg>nescimus</reg> per ista 
-   tempora eosdem fere sectores fuisse collorum et bonorum?</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="81"><p>
-               <reg>ei</reg> denique qui tum armati dies noctesque concursabant<note>
-                  <app><lem>concursabant</lem></app> concurabant <foreign xml:lang="grc">S</foreign>: circumcursabant (cucurs. <foreign xml:lang="grc">y1</foreign>) <foreign xml:lang="grc">y2</foreign>
-               </note>, qui Romae erant 
-adsidui, qui omni tempore in praeda et in<note>et in <foreign xml:lang="grc">w</foreign>: et <hi rend="italics">cett.</hi>
-               </note> sanguine versabantur, <reg>sex</reg>. 
+   tempora eosdem fere sectores fuisse collorum et bonorum?</p>
+            </div>
+            <div type="textpart" subtype="section" n="81">
+               <p>
+                  <reg>ei</reg> denique qui tum armati dies noctesque concursabant<note>
+                     <app>
+                        <lem>concursabant</lem>
+                     </app> concurabant <foreign xml:lang="grc">ς</foreign>: circumcursabant (cucurs. <foreign xml:lang="grc">ψ1</foreign>) <foreign xml:lang="grc">ψ2</foreign>
+                  </note>, qui Romae erant 
+adsidui, qui omni tempore in praeda et in<note>et in <foreign xml:lang="grc">ω</foreign>: et <hi rend="italics">cett.</hi>
+                  </note> sanguine versabantur, <reg>sex</reg>. 
 Roscio temporis illius acerbitatem iniquitatemque obicient et illam 
 sicariorum multitudinem in qua
 ipsi duces ac principes erant huic crimini putabunt fore? qui non 
 modo Romae non fuit sed omnino quid Romae ageretur nescivit<note>nescivit <hi rend="italics">Madvig</hi>: nesciret <hi rend="italics">codd.</hi>
-               </note>, 
-   propterea quod ruri adsiduus, quem ad modum tute confiteris, fuit.</p></div> 
-                  
-
-
-
-               <div type="textpart" subtype="section" n="82"><p>
-               <reg>vereor</reg> ne aut molestus sim vobis, iudices, aut ne ingeniis vestris 
+                  </note>, 
+   propterea quod ruri adsiduus, quem ad modum tute confiteris, fuit.</p>
+            </div>
+            <div type="textpart" subtype="section" n="82">
+               <p>
+                  <reg>vereor</reg> ne aut molestus sim vobis, iudices, aut ne ingeniis vestris 
 videar diffidere, si de tam perspicuis rebus diutius disseram.  Eruci 
 criminatio tota, ut arbitror, dissoluta est; nisi forte exspectatis ut illa 
 diluam quae de peculatu ac de eius modi rebus commenticiis inaudita 
 nobis ante hoc tempus ac nova obiecit; quae mihi iste visus est ex 
 alia<note>
-                  <app><lem>alia</lem></app> aliena <hi rend="italics">Passeratius</hi>: aliqua <hi rend="italics">A. Eberhard</hi>
-               </note> oratione declamare quam in alium reum commentaretur; ita 
+                     <app>
+                        <lem>alia</lem>
+                     </app> aliena <hi rend="italics">Passeratius</hi>: aliqua <hi rend="italics">A. Eberhard</hi>
+                  </note> oratione declamare quam in alium reum commentaretur; ita 
 neque ad crimen parricidi neque ad eum qui causam dicit 
 pertinebant<note>pertinebant <hi rend="italics">Naugerius</hi> (2): pertinebat <hi rend="italics">codd.</hi>
-               </note>; de quibus quoniam<note>quoniam (quõ <foreign xml:lang="grc">S</foreign>: qm <foreign xml:lang="grc">S</foreign> 
-                  <hi rend="italics">mg</hi>) <foreign xml:lang="grc">Ssx</foreign>: cum <hi rend="italics">A</hi>
-                  <foreign xml:lang="grc">w</foreign>: quomodo <foreign xml:lang="grc">py</foreign>: uno <foreign xml:lang="grc">f</foreign>
-               </note> verbo arguit, verbo satis est negare.  
-<reg>si</reg> quid est quod ad testis reservet, ibi quoque nos<note>ibi quoque nos <foreign xml:lang="grc">Ssx</foreign>, <hi rend="italics">Madvig</hi>: ibi nos quoque <hi rend="italics">cett.</hi>
-               </note>, ut in ipsa causa, 
+                  </note>; de quibus quoniam<note>quoniam (quõ <foreign xml:lang="grc">ς</foreign>: qm <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">mg</hi>) <foreign xml:lang="grc">σσχ</foreign>: cum <hi rend="italics">A</hi>
+                     <foreign xml:lang="grc">ω</foreign>: quomodo <foreign xml:lang="grc">πψ</foreign>: uno <foreign xml:lang="grc">φ</foreign>
+                  </note> verbo arguit, verbo satis est negare.  
+<reg>si</reg> quid est quod ad testis reservet, ibi quoque nos<note>ibi quoque nos <foreign xml:lang="grc">σσχ</foreign>, <hi rend="italics">Madvig</hi>: ibi nos quoque <hi rend="italics">cett.</hi>
+                  </note>, ut in ipsa causa, 
 paratiores reperiet quam putabat.
 
 
 
             </p>
-         </div>
-         <milestone n="30" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="83"><p>
-               <reg>venio</reg> nunc eo quo me non cupiditas ducit sed fides. <reg>nam</reg> si mihi 
+            </div>
+            <milestone n="30" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="83">
+               <p>
+                  <reg>venio</reg> nunc eo quo me non cupiditas ducit sed fides. <reg>nam</reg> si mihi 
 liberet accusare, accusarem alios potius ex quibus possem crescere; 
 quod certum est non facere, dum utrumvis licebit.  <reg>is</reg> enim mihi 
 videtur amplissimus qui sua virtute in altiorem locum pervenit, non 
 qui ascendit per alterius incommodum et calamitatem. <reg>desinamus</reg> 
-aliquando ea scrutari quae sunt inania; quaeramus ibi<note>ibi <foreign xml:lang="grc">s2</foreign>, <hi rend="italics">Steinmetz</hi>: ubi <hi rend="italics">cett.</hi> (<hi rend="italics">cf. Clu.</hi> 37)</note> maleficium 
+aliquando ea scrutari quae sunt inania; quaeramus ibi<note>ibi <foreign xml:lang="grc">ς2</foreign>, <hi rend="italics">Steinmetz</hi>: ubi <hi rend="italics">cett.</hi> (<hi rend="italics">cf. Clu.</hi> 37)</note> maleficium 
 ubi et est et inveniri potest; iam intelleges, Eruci, certum crimen 
 quam multis suspicionibus coarguatur<note>arguatur <hi rend="italics">A</hi>
-               </note>, tametsi neque omnia dicam et 
+                  </note>, tametsi neque omnia dicam et 
 leviter unum quidque<note>quidque <hi rend="italics">Wesenberg</hi>: quodque <hi rend="italics">codd.</hi>
-               </note> tangam.  <reg>neque</reg> enim id facerem, nisi necesse 
+                  </note> tangam.  <reg>neque</reg> enim id facerem, nisi necesse 
 esset, et id erit signi me invitum facere, quod non persequar<note>persequar <hi rend="italics">Lambinus</hi>: prosequar <hi rend="italics">codd.</hi>
-               </note> longius 
-                  quam salus huius et mea fides postulabit.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="84"><p>
-               <reg>causam</reg> tu nullam reperiebas in Sex. Roscio; at ego in T. 
-Roscio reperio.  <reg>tecum</reg> enim mihi res est, <choice><abbr>T.</abbr><expan>T<ex>iti</ex></expan></choice> Rosci, quoniam 
-istic sedes ac te palam adversarium esse<note>esse |||| <foreign xml:lang="grc">S</foreign>
-               </note> profiteris<note>profiteris <hi rend="italics">edd. VR</hi>: profitearis <hi rend="italics">codd.</hi>
-               </note>. <reg>de</reg> 
+                  </note> longius 
+                  quam salus huius et mea fides postulabit.</p>
+            </div>
+            <div type="textpart" subtype="section" n="84">
+               <p>
+                  <reg>causam</reg> tu nullam reperiebas in Sex. Roscio; at ego in T. 
+Roscio reperio.  <reg>tecum</reg> enim mihi res est, <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>iti</ex>
+                     </expan>
+                  </choice> Rosci, quoniam 
+istic sedes ac te palam adversarium esse<note>esse |||| <foreign xml:lang="grc">ς</foreign>
+                  </note> profiteris<note>profiteris <hi rend="italics">edd. VR</hi>: profitearis <hi rend="italics">codd.</hi>
+                  </note>. <reg>de</reg> 
 Capitone post viderimus, si, quem ad modum paratum esse 
 audio, testis prodierit; tum alias quoque suas palmas 
 cognoscet de quibus me ne audisse quidem suspicatur.
-<choice><abbr>L.</abbr><expan>L<ex>ucius</ex></expan></choice> Cassius ille quem populus Romanus verissimum<note>severissimum <hi rend="italics">mg. Lambini</hi>
-               </note> et 
+<choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucius</ex>
+                     </expan>
+                  </choice> Cassius ille quem populus Romanus verissimum<note>severissimum <hi rend="italics">mg. Lambini</hi>
+                  </note> et 
 sapientissimum iudicem putabat identidem in causis quaerere 
 solebat 'cui bono' fuisset.  <reg>sic</reg> vita hominum est ut ad 
-   maleficium nemo conetur sine spe atque emolumento accedere. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="85"><p>
-               <reg>hunc</reg> quaesitorem ac iudicem fugiebant atque horrebant<note>abhorrebant <hi rend="italics">A</hi>
-               </note> 
+   maleficium nemo conetur sine spe atque emolumento accedere. </p>
+            </div>
+            <div type="textpart" subtype="section" n="85">
+               <p>
+                  <reg>hunc</reg> quaesitorem ac iudicem fugiebant atque horrebant<note>abhorrebant <hi rend="italics">A</hi>
+                  </note> 
 ei quibus periculum creabatur ideo quod, tametsi veritatis 
 erat amicus, tamen natura non tam propensus ad misericordiam 
 quam applicatus<note>applicatus <hi rend="italics">Novák</hi> (<hi rend="italics">cf. Fin.</hi> vi. 34): implicatus <hi rend="italics">codd.</hi>: implacatus <hi rend="italics">Gravius</hi>: inclinatus <hi rend="italics">Manutius</hi>
-               </note> ad severitatem videbatur. <reg>ego</reg>, quamquam 
+                  </note> ad severitatem videbatur. <reg>ego</reg>, quamquam 
 praeest huic quaestioni vir et contra audaciam fortissimus 
 et ab innocentia clementissimus, tamen facile me paterer vel 
 illo ipso acerrimo iudice quaerente vel apud Cassianos 
-iudices, quorum etiam nunc ei<note>nunc ii <hi rend="italics">Naugerius</hi>: nuncii <foreign xml:lang="grc">Spw</foreign>: nuntii <hi rend="italics">cett.</hi>
-               </note> quibus causa dicenda est nomen 
+iudices, quorum etiam nunc ei<note>nunc ii <hi rend="italics">Naugerius</hi>: nuncii <foreign xml:lang="grc">σπω</foreign>: nuntii <hi rend="italics">cett.</hi>
+                  </note> quibus causa dicenda est nomen 
 ipsum reformidant, pro Sex. Roscio dicere.
 
 </p>
-         </div>
-         <milestone n="31" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="86"><p>
-               <reg>in</reg> hac enim causa cum viderent illos amplissimam 
+            </div>
+            <milestone n="31" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="86">
+               <p>
+                  <reg>in</reg> hac enim causa cum viderent illos amplissimam 
 pecuniam possidere, hunc in summa mendicitate esse, illud 
 quidem non quaererent, cui bono fuisset, sed eo perspicuo<note>perspicuo <hi rend="italics">Puteanus</hi>: perspicuum <hi rend="italics">codd.</hi>
-               </note> 
+                  </note> 
 crimen et suspicionem potius ad praedam adiungerent quam ad 
 egestatem. <reg>quid</reg> si accedit eodem ut tenuis antea fueris? 
 quid si ut avarus? quid si ut audax? quid si ut illius qui 
-occisus est inimicissimus? num quaerenda causa<note>cause <foreign xml:lang="grc">w<hi rend="italics">w</hi>
-                  </foreign>: <hi rend="italics">om. cett.</hi>
-               </note> quae te ad 
-tantum facinus adduxerit<note>adduxerunt (edux. <foreign xml:lang="grc">s</foreign>) <foreign xml:lang="grc">sxy</foreign>
-               </note>? <reg>quid</reg> ergo horum negari potest? 
+occisus est inimicissimus? num quaerenda causa<note>cause <foreign xml:lang="grc">ω<hi rend="italics">ω</hi>
+                     </foreign>: <hi rend="italics">om. cett.</hi>
+                  </note> quae te ad 
+tantum facinus adduxerit<note>adduxerunt (edux. <foreign xml:lang="grc">ς</foreign>) <foreign xml:lang="grc">σχψ</foreign>
+                  </note>? <reg>quid</reg> ergo horum negari potest? 
 <reg>tenuitas</reg> hominis eius modi est ut dissimulari non queat 
 atque eo
 magis eluceat<note>elucet <hi rend="italics">Heumann</hi>
-</note> quo magis occultatur.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="87"><p>
-               <reg>avaritiam</reg> praefers  qui
+                  </note> quo magis occultatur.</p>
+            </div>
+            <div type="textpart" subtype="section" n="87">
+               <p>
+                  <reg>avaritiam</reg> praefers  qui
 societatem coieris de municipis cognatique fortunis cum 
 alienissimo. <reg>quam</reg> sis audax, ut alia obliviscar, hinc omnes 
 intellegere potuerunt quod ex tota societate, hoc est ex tot 
 sicariis, solus tu inventus es qui cum accusatoribus sederes 
 atque os tuum non modo ostenderes sed etiam offerres. 
 <reg>inimicitias</reg> tibi fuisse cum Sex. Roscio et magnas rei familiaris 
-   controversias concedas necesse est. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="88"><p>
-               <reg>restat</reg>, iudices, 
+   controversias concedas necesse est. </p>
+            </div>
+            <div type="textpart" subtype="section" n="88">
+               <p>
+                  <reg>restat</reg>, iudices, 
 ut hoc dubitemus, uter potius Sex. Roscium occiderit, is  ad
 quem morte eius divitiae venerint, an is ad quem mendicitas, 
-is<note>mendicitas is <foreign xml:lang="grc">y</foreign>: mendicitatis <foreign xml:lang="grc">Spfw</foreign>: mendicitas <hi rend="italics">A</hi>
-                  <foreign xml:lang="grc">sx</foreign>
-               </note> qui antea tenuis fuerit, an is qui postea factus sit egentissimus, 
+is<note>mendicitas is <foreign xml:lang="grc">ψ</foreign>: mendicitatis <foreign xml:lang="grc">σπφω</foreign>: mendicitas <hi rend="italics">A</hi>
+                     <foreign xml:lang="grc">σχ</foreign>
+                  </note> qui antea tenuis fuerit, an is qui postea factus sit egentissimus, 
 is qui ardens avaritia feratur infestus in suos, an 
 is qui semper ita vixerit ut quaestum nosset nullum, fructum 
 autem eum solum quem labore peperisset, is qui omnium 
 sectorum audacissimus sit, an is qui propter fori iudiciorumque 
 insolentiam non modo subsellia verum etiam urbem ipsam 
 reformidet<note>reformidet <hi rend="italics">Lambinus</hi>: reformidat <hi rend="italics">codd.</hi>
-               </note>, postremo, iudices, id quod ad rem mea sententia 
+                  </note>, postremo, iudices, id quod ad rem mea sententia 
 maxime pertinet, utrum inimicus potius an filius.
 
 
             </p>
-         </div>
-         <milestone n="32" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="89"><p>
-               <reg>haec</reg> tu, Eruci, tot et tanta si nanctus<note>nanctus <foreign xml:lang="grc">Sp</foreign>, <hi rend="italics">Halm</hi>: nactus <hi rend="italics">cett.</hi>
-               </note> esses in reo, quam 
+            </div>
+            <milestone n="32" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="89">
+               <p>
+                  <reg>haec</reg> tu, Eruci, tot et tanta si nanctus<note>nanctus <foreign xml:lang="grc">σπ</foreign>, <hi rend="italics">Halm</hi>: nactus <hi rend="italics">cett.</hi>
+                  </note> esses in reo, quam 
 diu diceres! quo te modo iactares! tempus hercule te 
 citius quam oratio deficeret.  <reg>etenim</reg> in singulis rebus 
 eius modi
 materies est ut dies singulos possis<note>posses <hi rend="italics">Wesenberg</hi>
-               </note> consumere.  <reg>neque</reg> ego 
+                  </note> consumere.  <reg>neque</reg> ego 
 non possum; non enim tantum mihi derogo, tametsi nihil 
 adrogo, ut te copiosius quam me putem posse dicere. <reg>verum</reg> ego 
 forsitan propter multitudinem patronorum<note>
-                  <app><lem>patronorum</lem></app> paternorum <foreign xml:lang="grc">S<hi rend="italics">A</hi>fw</foreign>
-               </note> in grege<note>grege <foreign xml:lang="grc">y</foreign>: gregem <hi rend="italics">cett.</hi>
-               </note> adnumerer, 
+                     <app>
+                        <lem>patronorum</lem>
+                     </app> paternorum <foreign xml:lang="grc">ς<hi rend="italics">α</hi>φω</foreign>
+                  </note> in grege<note>grege <foreign xml:lang="grc">ψ</foreign>: gregem <hi rend="italics">cett.</hi>
+                  </note> adnumerer, 
 te pugna Cannensis accusatorem<note>accusatorum <hi rend="italics">Buttmann</hi>
-               </note> sat bonum fecit.  <reg>multos</reg> 
-caesos non ad Trasumennum<note>Trasumennum <hi rend="italics">Fleckeisen</hi>: Trahasymennum <foreign xml:lang="grc">S</foreign>: Trasimennum <foreign xml:lang="grc">p</foreign>: Trasimenum <hi rend="italics">A<foreign xml:lang="grc">sy</foreign>
-                  </hi>
-</note> lacum, sed ad Servilium vidimus.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="90"><p>
-               <quote>
-                  <reg>quis</reg> ibi non est volneratus ferro Phrygio?</quote>
-               <reg>non</reg> necesse est omnis commemorare Curtios, Marios, denique 
+                  </note> sat bonum fecit.  <reg>multos</reg> 
+caesos non ad Trasumennum<note>Trasumennum <hi rend="italics">Fleckeisen</hi>: Trahasymennum <foreign xml:lang="grc">ς</foreign>: Trasimennum <foreign xml:lang="grc">π</foreign>: Trasimenum <hi rend="italics">A<foreign xml:lang="grc">σψ</foreign>
+                     </hi>
+                  </note> lacum, sed ad Servilium vidimus.</p>
+            </div>
+            <div type="textpart" subtype="section" n="90">
+               <p>
+                  <quote>
+                     <reg>quis</reg> ibi non est volneratus ferro Phrygio?</quote>
+                  <reg>non</reg> necesse est omnis commemorare Curtios, Marios, denique 
 Memmios<note>Memmios <hi rend="italics">Vrsinus</hi>: Mammeos <hi rend="italics">codd.</hi>
-               </note> quos iam aetas a proeliis avocabat, postremo Priamum 
+                  </note> quos iam aetas a proeliis avocabat, postremo Priamum 
 ipsum senem<note>senem <hi rend="italics">del. Madvig</hi> 11 rei p. <hi rend="italics">ed. R</hi>: re p. <hi rend="italics">codd.</hi>
-               </note>, Antistium quem non modo aetas sed etiam leges 
+                  </note>, Antistium quem non modo aetas sed etiam leges 
 pugnare prohibebant.  <reg>iam</reg> quos nemo propter ignobilitatem 
 nominat, sescenti sunt qui inter sicarios et de veneficiis accusabant; 
 qui omnes, quod ad me attinet, vellem viverent.  <reg>nihil</reg> enim mali est 
 canes ibi quam plurimos esse ubi permulti observandi multaque 
-servanda sunt.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="91"><p>
-               <reg>verum</reg>, ut fit, multa saepe imprudentibus imperatoribus vis 
+servanda sunt.</p>
+            </div>
+            <div type="textpart" subtype="section" n="91">
+               <p>
+                  <reg>verum</reg>, ut fit, multa saepe imprudentibus imperatoribus vis 
 belli ac turba molitur. <reg>dum</reg> is in aliis rebus erat occupatus qui 
 summam rerum administrabat, erant interea qui suis volneribus 
 mederentur; qui, tamquam si offusa rei publicae sempiterna nox 
@@ -1656,26 +1937,34 @@ omnes intellegant me non studio accusare sed officio defendere.
 
 
             </p>
-         </div>
-         <milestone n="33" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="92"><p>
-               <reg>video</reg> igitur causas esse permultas quae istum impellerent; 
+            </div>
+            <milestone n="33" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="92">
+               <p>
+                  <reg>video</reg> igitur causas esse permultas quae istum impellerent; 
 videamus nunc ecquae<note>ecquae <hi rend="italics">Naugerius</hi>: et quae <hi rend="italics">codd.</hi>
-               </note> facultas suscipiendi malefici 
-fuerit.  Vbi occisus est Sex. Roscius? —  Romae.  —  <reg>quid</reg>? tu, <choice><abbr>T.</abbr><expan>T<ex>iti</ex></expan></choice> Rosci<note>tu T. <hi rend="italics">w</hi>: ut <foreign xml:lang="grc">S</foreign>: tu <hi rend="italics">cett.</hi>
-               </note>, 
+                  </note> facultas suscipiendi malefici 
+fuerit.  Vbi occisus est Sex. Roscius? —  Romae.  —  <reg>quid</reg>? tu, <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>iti</ex>
+                     </expan>
+                  </choice> Rosci<note>tu T. <hi rend="italics">w</hi>: ut <foreign xml:lang="grc">ς</foreign>: tu <hi rend="italics">cett.</hi>
+                  </note>, 
 ubi tunc eras?  —  Romae.  <reg>verum</reg> quid ad rem? et alii multi.  —  <reg>quasi</reg> 
 nunc<note>
-                  <app><lem>nunc</lem></app> non <foreign xml:lang="grc">Sy2</foreign>
-               </note> id agatur quis ex tanta multitudine occiderit, ac non hoc 
+                     <app>
+                        <lem>nunc</lem>
+                     </app> non <foreign xml:lang="grc">σψ2</foreign>
+                  </note> id agatur quis ex tanta multitudine occiderit, ac non hoc 
 quaeratur, eum qui Romae sit occisus utrum veri similius sit ab eo 
 esse occisum qui adsiduus eo tempore Romae fuerit, an ab eo qui 
 multis
-annis Romam omnino non accesserit. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="93"><p>
-               <reg>age</reg> nunc ceteras quoque 
+annis Romam omnino non accesserit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="93">
+               <p>
+                  <reg>age</reg> nunc ceteras quoque 
 facultates<note>quoque facultates <hi rend="italics">edd. VR. Garatoni</hi>: facultates quoque <hi rend="italics">codd.</hi> (<hi rend="italics">cf.</hi> §83)</note> consideremus.  <reg>erat</reg> tum multitudo sicariorum, id quod 
 commemoravit Erucius, et homines impune occidebantur.  <reg>quid</reg>? ea 
 multitudo quae erat? <reg>opinor</reg>, aut eorum qui in bonis erant occupati, 
@@ -1685,11 +1974,11 @@ dives es; sin eos quos qui leviore nomine appellant percussores
 vocant, quaere in cuius fide sint et clientela; mihi crede, aliquem de 
 societate tua reperies; et, quicquid tu contra dixeris, id cum 
 defensione nostra contendito; ita facillime causa Sex. Rosci cum tua 
-conferetur.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="94"><p>
-               <reg>dices</reg>: '<reg>quid</reg> postea, si Romae adsiduus fui?'  
+conferetur.</p>
+            </div>
+            <div type="textpart" subtype="section" n="94">
+               <p>
+                  <reg>dices</reg>: '<reg>quid</reg> postea, si Romae adsiduus fui?'  
 <reg>respondebo</reg>: '<reg>at</reg> ego omnino non fui.'  — <reg>fateor</reg> me sectorem esse, 
 verum et alii multi.  —  <reg>at</reg> ego, ut tute arguis, agricola et rusticus.  — 
 <reg>non</reg> continuo, si me in gregem sicariorum contuli, sum sicarius.
@@ -1703,153 +1992,187 @@ vereor ne ad pluris oratio mea pertinere videatur.
 
 
             </p>
-         </div>
-         <milestone n="34" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="95"><p>
-               <reg>videamus</reg> nunc strictim, sicut cetera, quae post mortem Sex. Rosci 
-abs te, <choice><abbr>T.</abbr><expan>T<ex>ite</ex></expan></choice> Rosci, facta sunt<note>
-                  <app><lem>sunt</lem></app> sint <hi rend="italics">Halm</hi>
-               </note>; quae ita aperta et manifesta sunt ut 
-medius fidius, iudices, invitus ea dicam. <reg>vereor</reg> enim, cuicuimodi<note>cuicuimodi <hi rend="italics">Priscian.</hi> (<hi rend="italics">K.</hi> iii. 7): quiquimodi (quin cuiusmodi <foreign xml:lang="grc">p</foreign> 
-                  <hi rend="italics">mg.</hi>) <hi rend="italics">codd.</hi>
-               </note> es, 
-<choice><abbr>T.</abbr><expan>T<ex>ite</ex></expan></choice> Rosci<note>es T. <hi rend="italics">duo dett.</hi>: est <hi rend="italics">mei, codd. Prisciani</hi>
-               </note>, ne ita hunc videar voluisse servare ut tibi omnino non 
+            </div>
+            <milestone n="34" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="95">
+               <p>
+                  <reg>videamus</reg> nunc strictim, sicut cetera, quae post mortem Sex. Rosci 
+abs te, <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>ite</ex>
+                     </expan>
+                  </choice> Rosci, facta sunt<note>
+                     <app>
+                        <lem>sunt</lem>
+                     </app> sint <hi rend="italics">Halm</hi>
+                  </note>; quae ita aperta et manifesta sunt ut 
+medius fidius, iudices, invitus ea dicam. <reg>vereor</reg> enim, cuicuimodi<note>cuicuimodi <hi rend="italics">Priscian.</hi> (<hi rend="italics">K.</hi> iii. 7): quiquimodi (quin cuiusmodi <foreign xml:lang="grc">π</foreign>
+                     <hi rend="italics">mg.</hi>) <hi rend="italics">codd.</hi>
+                  </note> es, 
+<choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>ite</ex>
+                     </expan>
+                  </choice> Rosci<note>es T. <hi rend="italics">duo dett.</hi>: est <hi rend="italics">mei, codd. Prisciani</hi>
+                  </note>, ne ita hunc videar voluisse servare ut tibi omnino non 
 pepercerim.  <reg>cum</reg> hoc vereor et cupio tibi aliqua ex parte quod salva 
 fide possim
 parcere, rursus immuto voluntatem meam; venit enim mihi in 
-mentem oris tui.  Tene<note>tene (-es <foreign xml:lang="grc">y2</foreign>) cum <hi rend="italics">A</hi>
-                  <foreign xml:lang="grc">y2</foreign>: tene quin <foreign xml:lang="grc">S</foreign>: tenes quin <hi rend="italics">cett.</hi>
-               </note>, cum ceteri socii tui fugerent ac se occultarent, 
+mentem oris tui.  Tene<note>tene (-es <foreign xml:lang="grc">ψ2</foreign>) cum <hi rend="italics">A</hi>
+                     <foreign xml:lang="grc">ψ2</foreign>: tene quin <foreign xml:lang="grc">ς</foreign>: tenes quin <hi rend="italics">cett.</hi>
+                  </note>, cum ceteri socii tui fugerent ac se occultarent, 
 ut hoc iudicium non de illorum praeda sed de huius maleficio fieri 
 videretur, potissimum tibi partis istas depoposcisse ut in iudicio 
 versarere et sederes cum accusatore? <reg>qua</reg> in<note>
-                  <app><lem>in</lem></app> tu <hi rend="italics">Ernesti</hi>
-               </note> re nihil aliud adsequeris 
+                     <app>
+                        <lem>in</lem>
+                     </app> tu <hi rend="italics">Ernesti</hi>
+                  </note> re nihil aliud adsequeris 
 nisi ut ab omnibus
-mortalibus audacia tua cognoscatur et impudentia<note>impudentia <hi rend="italics">A<foreign xml:lang="grc">xy</foreign>
-                  </hi>: imprudentia <hi rend="italics">cett.</hi>
-</note>.</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="96"><p>
-               <reg>occiso</reg> 
-               <reg>sex</reg>. 
+mortalibus audacia tua cognoscatur et impudentia<note>impudentia <hi rend="italics">A<foreign xml:lang="grc">χψ</foreign>
+                     </hi>: imprudentia <hi rend="italics">cett.</hi>
+                  </note>.</p>
+            </div>
+            <div type="textpart" subtype="section" n="96">
+               <p>
+                  <reg>occiso</reg>
+                  <reg>sex</reg>. 
 Roscio quis primus Ameriam nuntiat? Mallius Glaucia, quem iam 
 antea nominavi, tuus cliens et familiaris.  <reg>quid</reg> attinuit eum 
 potissimum nuntiare quod, si nullum iam ante consilium de morte ac 
 de bonis eius inieras nullamque societatem neque sceleris neque 
 praemi cum homine ullo coieras, ad te minime omnium pertinebat? 
  —  Sua sponte Mallius nuntiat.  —  <reg>quid</reg>, quaeso<note>quaeso <hi rend="italics">Angelius</hi>: quasi <hi rend="italics">codd.</hi>
-               </note>, eius intererat? <reg>an</reg>, 
+                  </note>, eius intererat? <reg>an</reg>, 
 cum Ameriam non huiusce rei causa venisset, casu accidit ut id quod 
 Romae audierat primus nuntiaret? <reg>cuius</reg> rei causa venerat Ameriam? 
 '<reg>non</reg> possum' inquit 'divinare.' <reg>eo</reg> rem iam adducam ut nihil 
-divinatione opus sit.  <reg>qua</reg> ratione <choice><abbr>T.</abbr><expan>T<ex>ito</ex></expan></choice> Roscio Capitoni<note>T. Roscio <hi rend="italics">Richter</hi>:.. Roscio <foreign xml:lang="grc">S</foreign>: Roscio <hi rend="italics">cett.</hi>
-               </note> primo<note>primo <hi rend="italics">Büchner</hi>: primum <hi rend="italics">codd.</hi> (<hi rend="italics">fort.</hi> prim. <hi rend="italics">in archetypo erat, cf.</hi> §125, <hi rend="italics">Cael.</hi> 67)</note> nuntiavit? 
+divinatione opus sit.  <reg>qua</reg> ratione <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>ito</ex>
+                     </expan>
+                  </choice> Roscio Capitoni<note>T. Roscio <hi rend="italics">Richter</hi>:.. Roscio <foreign xml:lang="grc">ς</foreign>: Roscio <hi rend="italics">cett.</hi>
+                  </note> primo<note>primo <hi rend="italics">Büchner</hi>: primum <hi rend="italics">codd.</hi> (<hi rend="italics">fort.</hi> prim. <hi rend="italics">in archetypo erat, cf.</hi> §125, <hi rend="italics">Cael.</hi> 67)</note> nuntiavit? 
 <reg>cum</reg> Ameriae Sex. Rosci domus uxor liberique essent, cum tot 
 propinqui cognatique optime convenientes, qua ratione factum est ut 
-iste tuus cliens, sceleris tui nuntius, <choice><abbr>T.</abbr><expan>T<ex>ito</ex></expan></choice> Roscio Capitoni potissimum
-   nuntiaret?</p></div> 
-                  
-
-<div type="textpart" subtype="section" n="97"><p>
-               <reg>occisus</reg> est a cena rediens; nondum lucebat cum 
+iste tuus cliens, sceleris tui nuntius, <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>ito</ex>
+                     </expan>
+                  </choice> Roscio Capitoni potissimum
+   nuntiaret?</p>
+            </div>
+            <div type="textpart" subtype="section" n="97">
+               <p>
+                  <reg>occisus</reg> est a cena rediens; nondum lucebat cum 
 Ameriae scitum est. <reg>quid</reg> hic incredibilis cursus, quid haec tanta 
 celeritas festinatioque significat? <reg>non</reg> quaero quis percusserit; nihil 
 est, Glaucia, quod metuas; non excutio te, si quid forte ferri habuisti, 
 non scrutor; nihil ad me arbitror pertinere; quoniam cuius consilio 
 occisus sit invenio, cuius manu sit percussus non laboro.  Vnum hoc
 sumo quod mihi apertum tuum scelus resque manifesta dat: Vbi aut 
-unde audivit Glaucia? qui tam cito scivit? <reg>fac</reg> audisse<note>audisse <hi rend="italics">A<foreign xml:lang="grc">pyw</foreign>
-                  </hi>: audisset <hi rend="italics">cett.</hi>
-               </note> statim; quae 
+unde audivit Glaucia? qui tam cito scivit? <reg>fac</reg> audisse<note>audisse <hi rend="italics">A<foreign xml:lang="grc">πψω</foreign>
+                     </hi>: audisset <hi rend="italics">cett.</hi>
+                  </note> statim; quae 
 res eum nocte una tantum itineris contendere coegit? quae necessitas 
 eum tanta premebat ut, si sua sponte iter Ameriam faceret, id 
 temporis Roma proficisceretur, nullam partem noctis requiesceret?
 
 
             </p>
-         </div>
-         <milestone n="35" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="98"><p>
-               <reg>etiamne</reg> in tam perspicuis rebus argumentatio quaerenda aut 
+            </div>
+            <milestone n="35" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="98">
+               <p>
+                  <reg>etiamne</reg> in tam perspicuis rebus argumentatio quaerenda aut 
 coniectura capienda est<note>est <hi rend="italics">Madvig</hi>: sit <hi rend="italics">codd.</hi>
-               </note>?  <reg>nonne</reg> vobis haec quae
+                  </note>?  <reg>nonne</reg> vobis haec quae
 
 audistis cernere oculis videmini, iudices?  non illum miserum, 
 ignarum casus sui, redeuntem a cena videtis, non positas insidias, 
 non impetum repentinum? non versatur ante oculos vobis in caede 
-Glaucia? non adest iste <choice><abbr>T.</abbr><expan>T<ex>itus</ex></expan></choice> Roscius? non suis manibus in curru conlocat 
+Glaucia? non adest iste <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itus</ex>
+                     </expan>
+                  </choice> Roscius? non suis manibus in curru conlocat 
 Automedontem illum, sui sceleris acerbissimi nefariaeque victoriae 
 nuntium? non orat ut eam noctem pervigilet, ut honoris sui causa 
-laboret, ut Capitoni quam primum nuntiet? </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="99"><p>
-               <reg>quid</reg> erat quod 
+laboret, ut Capitoni quam primum nuntiet? </p>
+            </div>
+            <div type="textpart" subtype="section" n="99">
+               <p>
+                  <reg>quid</reg> erat quod 
 Capitonem primum scire vellet<note>vellet <hi rend="italics">Ernesti</hi>: voluerit <hi rend="italics">codd.</hi>: voluit <hi rend="italics">Müller</hi> (<hi rend="italics">cf. Zielinski p.</hi> 191)</note>?  <reg>nescio</reg>, nisi
 hoc video, Capitonem in his bonis esse socium; de tribus et decem 
-fundis tris nobilissimos fundos eum video possidere. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="100"><p>
-               <reg>audio</reg> praeterea 
+fundis tris nobilissimos fundos eum video possidere. </p>
+            </div>
+            <div type="textpart" subtype="section" n="100">
+               <p>
+                  <reg>audio</reg> praeterea 
 non hanc suspicionem nunc primum in Capitonem conferri; 
-multas esse infamis eius<note>infames eius <hi rend="italics">Gruter</hi>: infamius (-is <foreign xml:lang="grc">y</foreign>) <hi rend="italics">codd.</hi>
-               </note> palmas, hanc primam esse tamen 
+multas esse infamis eius<note>infames eius <hi rend="italics">Gruter</hi>: infamius (-is <foreign xml:lang="grc">ψ</foreign>) <hi rend="italics">codd.</hi>
+                  </note> palmas, hanc primam esse tamen 
 lemniscatam quae Roma ei<note>Roma ei <hi rend="italics">Ernesti</hi>: Romae <hi rend="italics">codd</hi>.</note> deferatur; nullum modum esse hominis 
 occidendi quo ille non aliquot occiderit, multos ferro, multos veneno.  
 <reg>habeo</reg> etiam dicere quem contra morem maiorum minorem annis lx 
 de ponte in Tiberim deiecerit.  <reg>quae</reg>
-               <note>quae <hi rend="italics">Naugerius</hi>: qui <hi rend="italics">codd.</hi>
-               </note>, si prodierit atque adeo cum 
+                  <note>quae <hi rend="italics">Naugerius</hi>: qui <hi rend="italics">codd.</hi>
+                  </note>, si prodierit atque adeo cum 
 prodierit — scio enim proditurum esse — audiet. <reg>veniat</reg> modo, explicet 
-   suum volumen illud quod ei planum </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="101"><p>facere possum Erucium 
-conscripsisse; quod aiunt illum Sex. Roscio intentasse et minitatum<note>minitatum <hi rend="italics">Hotoman</hi>: mentatum <foreign xml:lang="grc">S</foreign>: meditatum <hi rend="italics">cett.</hi>
-               </note> 
+   suum volumen illud quod ei planum </p>
+            </div>
+            <div type="textpart" subtype="section" n="101">
+               <p>facere possum Erucium 
+conscripsisse; quod aiunt illum Sex. Roscio intentasse et minitatum<note>minitatum <hi rend="italics">Hotoman</hi>: mentatum <foreign xml:lang="grc">ς</foreign>: meditatum <hi rend="italics">cett.</hi>
+                  </note> 
 esse se omnia illa pro
 testimonio esse dicturum.  O praeclarum testem, iudices! o 
-gravitatem dignam exspectatione! o vitam<note>vitam <foreign xml:lang="grc">Ssx</foreign>: iustam <hi rend="italics">cett.</hi>
-               </note> honestam atque eius modi 
+gravitatem dignam exspectatione! o vitam<note>vitam <foreign xml:lang="grc">σσχ</foreign>: iustam <hi rend="italics">cett.</hi>
+                  </note> honestam atque eius modi 
 ut libentibus animis ad eius<note>
-                  <app><lem>animis</lem></app> ad eiusmodi ut libentius animis <hi rend="italics">add.</hi> 
-                  <foreign xml:lang="grc">S</foreign> 
-                  <hi rend="italics">mg.</hi>
-               </note> testimonium vestrum ius iurandum 
-accommodetis!  <reg>profecto</reg> non tam perspicue nos istorum<note>nos istorum <foreign xml:lang="grc">y2</foreign>: nonistorum <foreign xml:lang="grc">S</foreign>: istorum <hi rend="italics">cett.</hi>
-               </note> maleficia 
+                     <app>
+                        <lem>animis</lem>
+                     </app> ad eiusmodi ut libentius animis <hi rend="italics">add.</hi>
+                     <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">mg.</hi>
+                  </note> testimonium vestrum ius iurandum 
+accommodetis!  <reg>profecto</reg> non tam perspicue nos istorum<note>nos istorum <foreign xml:lang="grc">ψ2</foreign>: nonistorum <foreign xml:lang="grc">ς</foreign>: istorum <hi rend="italics">cett.</hi>
+                  </note> maleficia 
 videremus, nisi ipsos caecos redderet cupiditas et avaritia et audacia.
 
 
             </p>
-         </div>
-         <milestone n="36" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="102"><p>
-               <reg>alter</reg> ex ipsa caede volucrem nuntium Ameriam ad
+            </div>
+            <milestone n="36" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="102">
+               <p>
+                  <reg>alter</reg> ex ipsa caede volucrem nuntium Ameriam ad
 
 
-socium atque adeo<note>adeo <hi rend="italics">A.</hi> 
-                  <hi rend="italics">Eberhard</hi>: ad <hi rend="italics">codd.</hi>
-               </note> magistrum suum misit ut, si dissimulare omnes 
+socium atque adeo<note>adeo <hi rend="italics">A.</hi>
+                     <hi rend="italics">Eberhard</hi>: ad <hi rend="italics">codd.</hi>
+                  </note> magistrum suum misit ut, si dissimulare omnes 
 cuperent se scire ad quem maleficium pertineret, tamen ipse 
 apertum suum scelus ante omnium oculos poneret.  <reg>alter</reg>, si dis 
 immortalibus placet, testimonium etiam in Sex. Roscium dicturus est; 
-quasi vero id nunc agatur, utrum is quod dixerit credendum, ac non<note>id nunc... ac non <hi rend="italics">Jeep</hi> (<hi rend="italics">cf.</hi> §92): id nunc... an (aut <foreign xml:lang="grc">y</foreign>) <hi rend="italics">codd.</hi>: non id nunc... an <hi rend="italics">Madvig</hi>
-               </note> 
+quasi vero id nunc agatur, utrum is quod dixerit credendum, ac non<note>id nunc... ac non <hi rend="italics">Jeep</hi> (<hi rend="italics">cf.</hi> §92): id nunc... an (aut <foreign xml:lang="grc">ψ</foreign>) <hi rend="italics">codd.</hi>: non id nunc... an <hi rend="italics">Madvig</hi>
+                  </note> 
 quod fecerit vindicandum sit. <reg>itaque</reg>
-               <note>ita <hi rend="italics">Schol.</hi>
-               </note> more maiorum comparatum est 
+                  <note>ita <hi rend="italics">Schol.</hi>
+                  </note> more maiorum comparatum est 
 ut<note>
-                  <app><lem>ut</lem></app> ut vel <hi rend="italics">Halm</hi>
-               </note> in minimis rebus homines amplissimi testimonium de
-                  sua re non dicerent. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="103"><p>Africanus qui suo cognomine declarat 
+                     <app>
+                        <lem>ut</lem>
+                     </app> ut vel <hi rend="italics">Halm</hi>
+                  </note> in minimis rebus homines amplissimi testimonium de
+                  sua re non dicerent. </p>
+            </div>
+            <div type="textpart" subtype="section" n="103">
+               <p>Africanus qui suo cognomine declarat 
 tertiam partem orbis terrarum se subegisse tamen, si sua res 
 ageretur, testimonium non diceret; nam illud in talem virum non 
 audeo dicere: <reg>si</reg> diceret, non crederetur. <reg>videte</reg> nunc quam versa et 
@@ -1857,360 +2180,417 @@ mutata in peiorem partem sint omnia. <reg>cum</reg> de bonis et de caede
 agatur, testimonium dicturus est is qui et sector est et sicarius, hoc 
 est qui et illorum ipsorum bonorum de quibus agitur emptor atque 
 possessor est et eum hominem occidendum curavit de cuius morte 
-quaeritur. </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="104"><p>
-               <reg>quid</reg>? tu, vir optime, ecquid<note>quid tu vir <q>omptume</q> ecquid <foreign xml:lang="grc">S</foreign>: etquid tu vir optime <hi rend="italics">A</hi>
-               </note> habes quod dicas? mihi 
+quaeritur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="104">
+               <p>
+                  <reg>quid</reg>? tu, vir optime, ecquid<note>quid tu vir <q>omptume</q> ecquid <foreign xml:lang="grc">ς</foreign>: etquid tu vir optime <hi rend="italics">A</hi>
+                  </note> habes quod dicas? mihi 
 ausculta: vide ne tibi desis; tua quoque res permagna agitur.  <reg>multa</reg> 
 scelerate, multa audaciter<note>audaciter <hi rend="italics">Priscian.</hi> (<hi rend="italics">K.</hi> iii. 28): audacter <hi rend="italics">codd.</hi> (<hi rend="italics">cf. Cael.</hi>. 13)</note>, multa improbe fecisti, unum stultissime, 
 profecto tua sponte non de Eruci
 sententia: nihil opus fuit te istic sedere<note>istic sedere <hi rend="italics">Hotoman</hi>: isti credere <hi rend="italics">codd.</hi>
-               </note>.  <reg>neque</reg> enim accusatore muto 
+                  </note>.  <reg>neque</reg> enim accusatore muto 
 neque teste quisquam utitur eo qui de accusatoris subsellio surgit. 
 <reg>huc</reg> accedit quod paulo tamen occultior atque tectior vestra ista 
 cupiditas esset.  <reg>nunc</reg> quid<note>numquid <hi rend="italics">Pascal</hi>
-               </note> est quod quisquam ex vobis audire 
-desideret, eum quae facitis eius modi sint ut ea dedita opera a nobis<note>nobis <foreign xml:lang="grc">S</foreign>
-                  <hi rend="italics">B, Lambinus</hi>: vobis <hi rend="italics">cett.</hi>
-               </note> 
+                  </note> est quod quisquam ex vobis audire 
+desideret, eum quae facitis eius modi sint ut ea dedita opera a nobis<note>nobis <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">B, Lambinus</hi>: vobis <hi rend="italics">cett.</hi>
+                  </note> 
 contra vosmet ipsos facere videamini?
-   <reg>age</reg> nunc illa videamus, iudices, quae statim consecuta sunt.  </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="105"><p>
-               <reg>ad</reg> 
-Volaterras in castra <choice><abbr>L.</abbr><expan>L<ex>ucii</ex></expan></choice> Sullae mors Sex. Rosci
+   <reg>age</reg> nunc illa videamus, iudices, quae statim consecuta sunt.  </p>
+            </div>
+            <div type="textpart" subtype="section" n="105">
+               <p>
+                  <reg>ad</reg> 
+Volaterras in castra <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucii</ex>
+                     </expan>
+                  </choice> Sullae mors Sex. Rosci
 quadriduo quo is occisus est Chrysogono nuntiatur.  
-         <milestone n="37" unit="chapter"/><milestone unit="para"/>
-               <reg>quaeritur</reg> 
+         <milestone n="37" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>quaeritur</reg> 
 etiam nunc quis cum nuntium miserit? nonne perspicuum est 
-eundem qui Ameriam? <reg>curat</reg> Chrysogonus ut eius bona veneant<note>veneant <foreign xml:lang="grc">xy</foreign>: veniant <hi rend="italics">cett.</hi>
-               </note> 
+eundem qui Ameriam? <reg>curat</reg> Chrysogonus ut eius bona veneant<note>veneant <foreign xml:lang="grc">χψ</foreign>: veniant <hi rend="italics">cett.</hi>
+                  </note> 
 statim; qui non norat hominem aut rem.  <reg>at</reg> qui<note>
-                  <app><lem>at qui</lem></app> atque <foreign xml:lang="grc">sx</foreign>
-               </note> ei venit in mentem 
+                     <app>
+                        <lem>at qui</lem>
+                     </app> atque <foreign xml:lang="grc">σχ</foreign>
+                  </note> ei venit in mentem 
 praedia concupiscere hominis ignoti quem omnino numquam 
-viderat? Soletis, cum aliquid huiusce modi audistis<note>audistis <foreign xml:lang="grc">S</foreign>: auditis <hi rend="italics">cett.</hi>
-               </note>, iudices, continuo 
+viderat? Soletis, cum aliquid huiusce modi audistis<note>audistis <foreign xml:lang="grc">ς</foreign>: auditis <hi rend="italics">cett.</hi>
+                  </note>, iudices, continuo 
 dicere: '<reg>necesse</reg> est aliquem dixisse municipem aut vicinum; ei 
 plerumque indicant, per eos plerique produntur.'  <reg>hic</reg> nihil est quod 
 suspicione occupetis<note>suspicione occupetis <hi rend="italics">Madvig</hi>: suspicionem hoc putetis <hi rend="italics">codd.</hi>: suspicionem hanc putetis <hi rend="italics">Sylvius</hi>
-</note>.  </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="106"><p>
-               <reg>non</reg> enim ego ita disputabo: '<reg>veri</reg> simile 
-est Roscios<note>Roscios <foreign xml:lang="grc">S</foreign>: Roscium <hi rend="italics">cett.</hi>
-               </note> istam rem ad Chrysogonum detulisse; erat enim eis cum 
+                  </note>.  </p>
+            </div>
+            <div type="textpart" subtype="section" n="106">
+               <p>
+                  <reg>non</reg> enim ego ita disputabo: '<reg>veri</reg> simile 
+est Roscios<note>Roscios <foreign xml:lang="grc">ς</foreign>: Roscium <hi rend="italics">cett.</hi>
+                  </note> istam rem ad Chrysogonum detulisse; erat enim eis cum 
 Chrysogono iam antea amicitia; nam cum multos veteres a maioribus 
 Roscii patronos hospitesque haberent, omnis eos colere atque 
 observare destiterunt ac se in Chrysogoni fidem et clientelam 
 contulerunt.<note>ac... contulerunt <hi rend="italics">om. A</hi>
-</note>'  </p></div> 
-                  
-
-<div type="textpart" subtype="section" n="107"><p>
-               <reg>haec</reg> possum omnia vere dicere, sed in hac causa 
+                  </note>'  </p>
+            </div>
+            <div type="textpart" subtype="section" n="107">
+               <p>
+                  <reg>haec</reg> possum omnia vere dicere, sed in hac causa 
 coniectura nihil opus est; ipsos certo scio non negare ad haec bona 
-Chrysogonum accessisse impulsu suo.  <reg>si</reg> eum qui indici causa<note>indici causa <hi rend="italics">scripsi</hi>: iudiciuae <foreign xml:lang="grc">S</foreign>: indiciue <hi rend="italics">A</hi>: iudicine <foreign xml:lang="grc">f</foreign>: iudici ut <foreign xml:lang="grc">w</foreign>: indicii <hi rend="italics">cett.</hi>
-               </note> partem 
+Chrysogonum accessisse impulsu suo.  <reg>si</reg> eum qui indici causa<note>indici causa <hi rend="italics">scripsi</hi>: iudiciuae <foreign xml:lang="grc">ς</foreign>: indiciue <hi rend="italics">A</hi>: iudicine <foreign xml:lang="grc">φ</foreign>: iudici ut <foreign xml:lang="grc">ω</foreign>: indicii <hi rend="italics">cett.</hi>
+                  </note> partem 
 acceperit oculis cernetis<note>
-                  <app><lem>cernetis</lem></app> cernentes <foreign xml:lang="grc">S</foreign>: cernitis <hi rend="italics">A</hi>
-                  <foreign xml:lang="grc">y</foreign>
-               </note>, poteritisne dubitare, iudices,
+                     <app>
+                        <lem>cernetis</lem>
+                     </app> cernentes <foreign xml:lang="grc">ς</foreign>: cernitis <hi rend="italics">A</hi>
+                     <foreign xml:lang="grc">ψ</foreign>
+                  </note>, poteritisne dubitare, iudices,
 qui<note>
-                  <app><lem>qui</lem></app> quis <hi rend="italics">Halm</hi> (<hi rend="italics">cf. Zielinski p.</hi> 191)</note> indicarit?  <reg>qui</reg> sunt igitur in istis bonis quibus partem 
+                     <app>
+                        <lem>qui</lem>
+                     </app> quis <hi rend="italics">Halm</hi> (<hi rend="italics">cf. Zielinski p.</hi> 191)</note> indicarit?  <reg>qui</reg> sunt igitur in istis bonis quibus partem 
 Chrysogonus dederit?  <reg>duo</reg> Roscii.  <reg>num</reg> quisnam praeterea? <reg>nemo</reg> 
 est, iudices.  <reg>num</reg> ergo dubium est quin ei obtulerint hanc praedam 
-   Chrysogono qui ab eo partem praedae tulerunt?</p></div> 
-                  
-
-
-               <div type="textpart" subtype="section" n="108"><p>
-               <reg>age</reg> nunc ex ipsius Chrysogoni iudicio Rosciorum factum 
+   Chrysogono qui ab eo partem praedae tulerunt?</p>
+            </div>
+            <div type="textpart" subtype="section" n="108">
+               <p>
+                  <reg>age</reg> nunc ex ipsius Chrysogoni iudicio Rosciorum factum 
 consideremus.  si nihil in ista pugna Roscii quod operae pretium esset 
 fecerant, quam ob causam a<note>a <hi rend="italics">Ascens.</hi> (1): <hi rend="italics">om. mei</hi>
-               </note> Chrysogono tantis praemiis donabantur? 
-si nihil aliud fecerunt nisi rem detulerunt, nonne satis fuit eis<note>iis (is <foreign xml:lang="grc">w</foreign>) <foreign xml:lang="grc">Spsxw</foreign>, <hi rend="italics">Madvig</hi>: his <hi rend="italics">A</hi>
-                  <foreign xml:lang="grc">fy</foreign>
-               </note> gratias 
+                  </note> Chrysogono tantis praemiis donabantur? 
+si nihil aliud fecerunt nisi rem detulerunt, nonne satis fuit eis<note>iis (is <foreign xml:lang="grc">ω</foreign>) <foreign xml:lang="grc">σπσχω</foreign>, <hi rend="italics">Madvig</hi>: his <hi rend="italics">A</hi>
+                     <foreign xml:lang="grc">φψ</foreign>
+                  </note> gratias 
 agi, denique, ut perliberaliter ageretur, honoris aliquid haberi?  <reg>cur</reg>
-               <note>cur <foreign xml:lang="grc">Sy</foreign>: quur <hi rend="italics">A</hi>: qur (qui <foreign xml:lang="grc">f</foreign>) <hi rend="italics">cett.</hi> (<hi rend="italics">cf.</hi> §74)</note> 
+                  <note>cur <foreign xml:lang="grc">σψ</foreign>: quur <hi rend="italics">A</hi>: qur (qui <foreign xml:lang="grc">φ</foreign>) <hi rend="italics">cett.</hi> (<hi rend="italics">cf.</hi> §74)</note> 
 tria praedia tantae pecuniae statim Capitoni dantur? cur quae reliqua 
-sunt iste <choice><abbr>T.</abbr><expan>T<ex>itus</ex></expan></choice> Roscius<note>T. <hi rend="italics">Richter</hi>: <hi rend="italics">om. codd.</hi>
-               </note> omnia cum Chrysogono communiter possidet?  
+sunt iste <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itus</ex>
+                     </expan>
+                  </choice> Roscius<note>T. <hi rend="italics">Richter</hi>: <hi rend="italics">om. codd.</hi>
+                  </note> omnia cum Chrysogono communiter possidet?  
 <reg>nonne</reg> perspicuum est, iudices, has manubias Rosciis Chrysogonum re 
 cognita concessisse?
 
 
             </p>
-         </div>
-         <milestone n="38" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="109"><p>
-               <reg>venit</reg> in decem primis legatus in castra Capito.  <reg>vos</reg>
-               <note>Capito. Vos <hi rend="italics">scripsi</hi>: Capito || || <foreign xml:lang="grc">S</foreign>: Capito <hi rend="italics">cett.</hi>
-               </note>
+            </div>
+            <milestone n="38" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="109">
+               <p>
+                  <reg>venit</reg> in decem primis legatus in castra Capito.  <reg>vos</reg>
+                  <note>Capito. Vos <hi rend="italics">scripsi</hi>: Capito || || <foreign xml:lang="grc">ς</foreign>: Capito <hi rend="italics">cett.</hi>
+                  </note>
 totam vitam naturam moresque hominis ex ipsa legatione
 
 cognoscite.  Nisi intellexeritis, iudices, nullum esse officium, nullum 
 ius tam sanctum atque integrum quod non eius scelus<note>eius scelus <hi rend="italics">ed. R. Stephani</hi>: eiusce vis <hi rend="italics">codd.</hi>
-               </note> atque perfidia 
+                  </note> atque perfidia 
 violarit et imminuerit, virum optimum 
-esse eum iudicatote. </p></div> 
-
-<div type="textpart" subtype="section" n="110"><p>
-               <reg>impedimento</reg> est<note>est <hi rend="italics">om. A</hi>
-                  <foreign xml:lang="grc">y1</foreign>
-               </note> quo minus de his rebus 
+esse eum iudicatote. </p>
+            </div>
+            <div type="textpart" subtype="section" n="110">
+               <p>
+                  <reg>impedimento</reg> est<note>est <hi rend="italics">om. A</hi>
+                     <foreign xml:lang="grc">ψ1</foreign>
+                  </note> quo minus de his rebus 
 Sulla doceatur, ceterorum legatorum consilia et voluntatem 
 Chrysogono enuntiat, monet ut provideat ne palam res agatur, 
 ostendit, si sublata sit venditio bonorum, illum pecuniam grandem 
-amissurum, sese capitis periculum aditurum; illum acuere<note>acuere <foreign xml:lang="grc">sxy</foreign>: ac vere <hi rend="italics">cett.</hi>
-               </note>, hos 
+amissurum, sese capitis periculum aditurum; illum acuere<note>acuere <foreign xml:lang="grc">σχψ</foreign>: ac vere <hi rend="italics">cett.</hi>
+                  </note>, hos 
 qui simul erant missi fallere, illum identidem monere ut caveret, 
 hisce insidiose spem falsam ostendere, eum illo contra hos inire 
 consilia, horum consilia illi enuntiare, cum illo partem suam 
-depecisci<note>depacisci <foreign xml:lang="grc">xy2w</foreign>
-               </note>, hisce
-aliqua fretus mora<note>fretus mora <hi rend="italics">w</hi>: fretumora <foreign xml:lang="grc">S</foreign>: fretum ora (hora <foreign xml:lang="grc">p2sx</foreign>) <hi rend="italics">cett.</hi>: ficta mora <hi rend="italics">Gronovius</hi>
-               </note> semper omnis aditus ad Sullam intercludere.  
+depecisci<note>depacisci <foreign xml:lang="grc">χψ2ω</foreign>
+                  </note>, hisce
+aliqua fretus mora<note>fretus mora <hi rend="italics">w</hi>: fretumora <foreign xml:lang="grc">ς</foreign>: fretum ora (hora <foreign xml:lang="grc">π2σχ</foreign>) <hi rend="italics">cett.</hi>: ficta mora <hi rend="italics">Gronovius</hi>
+                  </note> semper omnis aditus ad Sullam intercludere.  
 <reg>postremo</reg> isto hortatore, auctore, intercessore ad Sullam legati non 
 adierunt; istius fide ac potius perfidia decepti, id quod ex ipsis 
 cognoscere poteritis, si accusator voluerit testimonium eis 
 denuntiare, pro re certa spem falsam
-domum rettulerunt.  <reg>in</reg> privatis rebus si qui rem mandatam </p></div> 
-
-<div type="textpart" subtype="section" n="111"><p>non 
+domum rettulerunt.  <reg>in</reg> privatis rebus si qui rem mandatam </p>
+            </div>
+            <div type="textpart" subtype="section" n="111">
+               <p>non 
 modo malitiosius gessisset sui quaestus aut commodi
 causa verum etiam neglegentius, cum maiores summum admisisse 
-dedecus existimabant.  <reg>itaque</reg> mandati constitutum<note>constitutum <foreign xml:lang="grc">S</foreign>
-               </note> est iudicium non 
+dedecus existimabant.  <reg>itaque</reg> mandati constitutum<note>constitutum <foreign xml:lang="grc">ς</foreign>
+                  </note> est iudicium non 
 minus turpe quam furti, credo, propterea quod quibus in rebus ipsi 
-interesse non possumus, in eis<note>in his <hi rend="italics">A<foreign xml:lang="grc">fy</foreign>
-                  </hi>
-               </note> operae nostrae vicaria fides amicorum 
+interesse non possumus, in eis<note>in his <hi rend="italics">A<foreign xml:lang="grc">φψ</foreign>
+                     </hi>
+                  </note> operae nostrae vicaria fides amicorum 
 supponitur; quam qui laedit, oppugnat omnium commune 
 praesidium et, quantum in ipso est, disturbat vitae societatem. <reg>non</reg> 
 enim possumus omnia per nos agere; alius in alia est re magis utilis.  
 <reg>idcirco</reg> amicitiae comparantur ut commune commodum mutuis
-   officiis gubernetur.  </p></div> 
-
-<div type="textpart" subtype="section" n="112"><p>
-               <reg>quid</reg> recipis mandatum, si aut neglecturus 
+   officiis gubernetur.  </p>
+            </div>
+            <div type="textpart" subtype="section" n="112">
+               <p>
+                  <reg>quid</reg> recipis mandatum, si aut neglecturus 
 aut ad tuum commodum conversurus es? cur mihi te
 offers ac meis commodis officio simulato officis et obstas? <reg>recede</reg> de 
 medio; per alium transigam.  <reg>suscipis</reg> onus offici quod te putas 
 sustinere posse; quod maxime<note>maxime <hi rend="italics">Dobree</hi>: minime <hi rend="italics">codd.</hi>
-               </note> videtur
+                  </note> videtur
 grave eis qui minime ipsi leves sunt.  
-         <milestone n="39" unit="chapter"/><milestone unit="para"/>
-         
-               <reg>ergo</reg> idcirco turpis haec 
+         <milestone n="39" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>ergo</reg> idcirco turpis haec 
 culpa est, quod duas res sanctissimas violat, amicitiam
 et fidem.  <reg>nam</reg> neque mandat quisquam fere nisi amico neque credit 
 nisi ei quem fidelem putat.  <reg>perditissimi</reg> est igitur hominis simul et 
 amicitiam dissolvere et fallere eum
-qui laesus non esset, nisi credidisset. </p></div> 
-
-<div type="textpart" subtype="section" n="113"><p>
-               <reg>itane</reg> est? in minimis rebus 
+qui laesus non esset, nisi credidisset. </p>
+            </div>
+            <div type="textpart" subtype="section" n="113">
+               <p>
+                  <reg>itane</reg> est? in minimis rebus 
 qui mandatum neglexerit, turpissimo iudicio condemnetur necesse 
 est, in re tanta cum is cui fama mortui, fortunae vivi commendatae 
 sunt atque concreditae, ignominia mortuum, inopia vivum<note>inopia vivum <hi rend="italics">Halm</hi>: egestate vivum <hi rend="italics">cod. lannoctii</hi>: <hi rend="italics">om. mei: lac.Sylvius</hi>
-               </note> adfecerit, 
+                  </note> adfecerit, 
 is inter honestos homines
 atque adeo inter vivos numerabitur? <reg>in</reg> minimis privatisque rebus 
 etiam neglegentia in crimen mandati<note>in crimen mandati <hi rend="italics">mei</hi>: mandati in crimen <hi rend="italics">s, Puteanus</hi>
-               </note> iudiciumque infamiae<note>infamiae <hi rend="italics">Puteanus</hi>: infamia (in fama <foreign xml:lang="grc">Ss</foreign>) <hi rend="italics">codd.</hi>: infame <hi rend="italics">Lambinus</hi>
-               </note> vocatur<note>vocatur <hi rend="italics">Lambinus</hi>: revocatur <hi rend="italics">codd.</hi>
-               </note>, 
+                  </note> iudiciumque infamiae<note>infamiae <hi rend="italics">Puteanus</hi>: infamia (in fama <foreign xml:lang="grc">σς</foreign>) <hi rend="italics">codd.</hi>: infame <hi rend="italics">Lambinus</hi>
+                  </note> vocatur<note>vocatur <hi rend="italics">Lambinus</hi>: revocatur <hi rend="italics">codd.</hi>
+                  </note>, 
 propterea quod, si recte<note>
-                  <app><lem>recte</lem></app> ratione 2 <hi rend="italics">dett.</hi>
-               </note> fiat, illum neglegere oporteat qui mandarit 
+                     <app>
+                        <lem>recte</lem>
+                     </app> ratione 2 <hi rend="italics">dett.</hi>
+                  </note> fiat, illum neglegere oporteat qui mandarit 
 non illum qui mandatum receperit; in re tanta quae publice gesta 
 atque commissa sit qui non neglegentia privatum aliquod commodum 
 laeserit sed perfidia legationis ipsius caerimoniam polluerit 
 maculaque adfecerit<note>
-                  <app><lem>adfecerit</lem></app> asperserit <hi rend="italics">Lambinus</hi>
-               </note>, qua is tandem poena adficietur aut quo iudicio
-   damnabitur?</p></div> 
-
-<div type="textpart" subtype="section" n="114"><p>si hanc ei rem privatim Sex. Roscius mandavisset 
+                     <app>
+                        <lem>adfecerit</lem>
+                     </app> asperserit <hi rend="italics">Lambinus</hi>
+                  </note>, qua is tandem poena adficietur aut quo iudicio
+   damnabitur?</p>
+            </div>
+            <div type="textpart" subtype="section" n="114">
+               <p>si hanc ei rem privatim Sex. Roscius mandavisset 
 ut cum Chrysogono transigeret atque decideret, inque eam rem fidem 
 suam, si quid opus esse putaret, interponeret, ille qui<note>
-                  <app><lem>ille qui</lem></app> illeque <hi rend="italics">Madvig</hi>
-               </note> sese facturum 
+                     <app>
+                        <lem>ille qui</lem>
+                     </app> illeque <hi rend="italics">Madvig</hi>
+                  </note> sese facturum 
 recepisset, nonne, si ex eo negotio tantulum in rem suam 
 convertisset, damnatus per arbitrum et rem restitueret et 
-honestatem omnem amitteret?</p></div> 
-
-<div type="textpart" subtype="section" n="115"><p>
-               <reg>nunc</reg> non hanc ei rem Sex. Roscius mandavit sed, id quod multo 
+honestatem omnem amitteret?</p>
+            </div>
+            <div type="textpart" subtype="section" n="115">
+               <p>
+                  <reg>nunc</reg> non hanc ei rem Sex. Roscius mandavit sed, id quod multo 
 gravius est, ipse Sex. Roscius cum fama vita bonisque omnibus a 
-decurionibus publice <choice><abbr>T.</abbr><expan>T<ex>ito</ex></expan></choice> Roscio<note>T. Roscio <hi rend="italics">Schütz</hi>: Roscio <hi rend="italics">codd.: del. Hotoman</hi>
-               </note> mandatus est; et ex eo <choice><abbr>T.</abbr><expan>T<ex>itus</ex></expan></choice> Roscius non 
-paululum<note>paululum <foreign xml:lang="grc">S<hi rend="italics">A</hi>pfw</foreign>: paulum <foreign xml:lang="grc">sxy</foreign>
-               </note> nescio quid in rem suam convertit sed hunc funditus<note>depactus <foreign xml:lang="grc">y2</foreign> (<hi rend="italics">cf.</hi> §110)</note> 
+decurionibus publice <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>ito</ex>
+                     </expan>
+                  </choice> Roscio<note>T. Roscio <hi rend="italics">Schütz</hi>: Roscio <hi rend="italics">codd.: del. Hotoman</hi>
+                  </note> mandatus est; et ex eo <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itus</ex>
+                     </expan>
+                  </choice> Roscius non 
+paululum<note>paululum <foreign xml:lang="grc">ς<hi rend="italics">α</hi>πφω</foreign>: paulum <foreign xml:lang="grc">σχψ</foreign>
+                  </note> nescio quid in rem suam convertit sed hunc funditus<note>depactus <foreign xml:lang="grc">ψ2</foreign> (<hi rend="italics">cf.</hi> §110)</note> 
 evertit bonis, ipse tria praedia sibi depectus est, voluntatem 
 decurionum ac municipum omnium tantidem quanti fidem suam 
 fecit.
 
 
             </p>
-         </div>
-         <milestone n="40" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="116"><p>
-               <reg>videte</reg> iam porro cetera, iudices, ut intellegatis fingi maleficium 
+            </div>
+            <milestone n="40" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="116">
+               <p>
+                  <reg>videte</reg> iam porro cetera, iudices, ut intellegatis fingi maleficium 
 nullum<note>maleficum nullum fingi <hi rend="italics">s, Halm</hi>
-               </note> posse quo iste sese non contaminarit.  <reg>in</reg> rebus minoribus 
+                  </note> posse quo iste sese non contaminarit.  <reg>in</reg> rebus minoribus 
 socium fallere turpissimum est aequeque turpe atque illud de quo 
 ante dixi; neque iniuria, propterea quod auxilium sibi se putat 
 adiunxisse qui eum altero rem communicavit.  <reg>ad</reg> cuius igitur fidem 
 confugiet, cum per eius fidem laeditur cui se commiserit? <reg>atque</reg>
-               <note>atqui <foreign xml:lang="grc">sxy</foreign>
-               </note> ea 
+                  <note>atqui <foreign xml:lang="grc">σχψ</foreign>
+                  </note> ea 
 sunt animadvertenda 
 peccata maxime quae difficillime praecaventur. <reg>tecti</reg> 
 esse ad alienos possumus, intimi<note>intumi (-temi <hi rend="italics">A</hi>) <hi rend="italics">mei</hi>
-               </note> multa apertiora videant necesse est; 
+                  </note> multa apertiora videant necesse est; 
 socium cavere qui possumus? quem etiam si metuimus, ius offici 
 laedimus. <reg>recte</reg> igitur maiores cum qui socium fefellisset in virorum 
 bonorum numero non
-putarunt haberi oportere.  </p></div> 
-
-<div type="textpart" subtype="section" n="117"><p>
-               <reg>at</reg> vero <choice><abbr>T.</abbr><expan>T<ex>itus</ex></expan></choice> Roscius non unum rei 
+putarunt haberi oportere.  </p>
+            </div>
+            <div type="textpart" subtype="section" n="117">
+               <p>
+                  <reg>at</reg> vero <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>itus</ex>
+                     </expan>
+                  </choice> Roscius non unum rei 
 pecuniariae socium fefellit, quod, tametsi grave est, tamen
 aliquo modo posse ferri videtur, verum novem homines 
 honestissimos<note>
-                  <app><lem>honestissimos</lem></app> fortissimos <hi rend="italics">ed. V</hi>
-               </note>, eiusdem muneris, legationis, offici mandatorumque 
+                     <app>
+                        <lem>honestissimos</lem>
+                     </app> fortissimos <hi rend="italics">ed. V</hi>
+                  </note>, eiusdem muneris, legationis, offici mandatorumque 
 socios, induxit, decepit, destituit, adversariis tradidit, omni fraude et 
-perfidia fefellit; qui de scelere suspicari eius<note>de scelere suspicari eius <hi rend="italics">scripsi</hi>: de eius scelere suspicari eius <foreign xml:lang="grc">S</foreign>: de eius scelere suspicari <foreign xml:lang="grc">p</foreign>: de eius scelere suspicari <hi rend="italics">cett.</hi>
-               </note> nihil potuerunt, socium 
+perfidia fefellit; qui de scelere suspicari eius<note>de scelere suspicari eius <hi rend="italics">scripsi</hi>: de eius scelere suspicari eius <foreign xml:lang="grc">ς</foreign>: de eius scelere suspicari <foreign xml:lang="grc">π</foreign>: de eius scelere suspicari <hi rend="italics">cett.</hi>
+                  </note> nihil potuerunt, socium 
 offici metuere non debuerunt, eius malitiam non viderunt, orationi 
 vanae crediderunt. <reg>itaque</reg> nunc illi homines honestissimi propter 
 istius insidias parum putantur cauti providique fuisse; iste qui initio 
 proditor fuit, deinde perfuga, qui primo sociorum consilia adversariis 
-enuntiavit, deinde societatem cum ipsis adversariis coiit<note>coiit <foreign xml:lang="grc">sxw</foreign>: coit <hi rend="italics">cett.</hi> (<hi rend="italics">cf. Mur.</hi> 20)</note>, terret etiam 
-nos ac minatur<note>ac || minatur <foreign xml:lang="grc">S</foreign>: <hi rend="italics">fort.</hi> ac dominatur (<hi rend="italics">cf.</hi> §24)</note> tribus praediis, hoc est praemiis sceleris, ornatus.  <reg>in</reg> 
+enuntiavit, deinde societatem cum ipsis adversariis coiit<note>coiit <foreign xml:lang="grc">σχω</foreign>: coit <hi rend="italics">cett.</hi> (<hi rend="italics">cf. Mur.</hi> 20)</note>, terret etiam 
+nos ac minatur<note>ac || minatur <foreign xml:lang="grc">ς</foreign>: <hi rend="italics">fort.</hi> ac dominatur (<hi rend="italics">cf.</hi> §24)</note> tribus praediis, hoc est praemiis sceleris, ornatus.  <reg>in</reg> 
 eius modi vita, iudices, in his tot tantisque flagitiis hoc quoque 
 maleficium de quo iudicium est
-reperietis. </p></div> 
-
-<div type="textpart" subtype="section" n="118"><p>
-               <reg>etenim</reg> quaerere ita debetis: ubi multa avare, multa 
+reperietis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="118">
+               <p>
+                  <reg>etenim</reg> quaerere ita debetis: ubi multa avare, multa 
 audacter<note>audaciter <hi rend="italics">Sylvius</hi>
-               </note>, multa improbe, multa perfidiose facta videbitis, ibi scelus 
+                  </note>, multa improbe, multa perfidiose facta videbitis, ibi scelus 
 quoque latere inter illa tot flagitia putatote. <reg>tametsi</reg> hoc quidem 
 minime latet quod ita promptum et propositum est ut non ex illis 
 maleficiis quae in illo constat<note>constat <hi rend="italics">ed. V</hi>: constant <hi rend="italics">codd.</hi>
-               </note> esse hoc intellegatur verum ex hoc 
-etiam, si quo de<note>quo de <hi rend="italics">Gulielmius</hi>: quod de <hi rend="italics">codd.</hi>: quod <hi rend="italics">Ascens.</hi> (2)</note> illorum forte dubitabitur<note>dubitatur <hi rend="italics">A<foreign xml:lang="grc">sxy1</foreign>
-                  </hi>
-               </note>, convincatur.  <reg>quid</reg> tandem, 
+                  </note> esse hoc intellegatur verum ex hoc 
+etiam, si quo de<note>quo de <hi rend="italics">Gulielmius</hi>: quod de <hi rend="italics">codd.</hi>: quod <hi rend="italics">Ascens.</hi> (2)</note> illorum forte dubitabitur<note>dubitatur <hi rend="italics">A<foreign xml:lang="grc">σχψ1</foreign>
+                     </hi>
+                  </note>, convincatur.  <reg>quid</reg> tandem, 
 quaeso,
 iudices? num aut ille lanista omnino iam a gladio recessisse<note>gladio recessisse <hi rend="italics">Madvig</hi>: gladiatore cessisse <hi rend="italics">codd.</hi>: gladiatura cessisse <hi rend="italics">Manutius</hi>
-               </note> videtur 
+                  </note> videtur 
 aut hic<note>hic <hi rend="italics">Schol.</hi>: is (his <hi rend="italics">A</hi>
-                  <foreign xml:lang="grc">f</foreign>) <hi rend="italics">codd.</hi>: iste <hi rend="italics">ed. Lambin.</hi> 
-                  <hi rend="italics">A. D.</hi> 1584</note> discipulus<note>discipulis <foreign xml:lang="grc">S<hi rend="italics">A</hi>p2f</foreign>
-               </note> magistro tantulum de arte concedere? <reg>par</reg> est 
+                     <foreign xml:lang="grc">φ</foreign>) <hi rend="italics">codd.</hi>: iste <hi rend="italics">ed. Lambin.</hi>
+                     <hi rend="italics">A. D.</hi> 1584</note> discipulus<note>discipulis <foreign xml:lang="grc">ς<hi rend="italics">α</hi>π2φ</foreign>
+                  </note> magistro tantulum de arte concedere? <reg>par</reg> est 
 avaritia, similis improbitas, eadem impudentia, gemina audacia.
 
 
 
             </p>
-         </div>
-         <milestone n="41" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="119"><p>
-               <reg>etenim</reg>, quoniam fidem magistri cognostis, cognoscite<note>cognoscitis <hi rend="italics">A<foreign xml:lang="grc">psf</foreign>
-                  </hi>
-               </note> nunc 
+            </div>
+            <milestone n="41" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="119">
+               <p>
+                  <reg>etenim</reg>, quoniam fidem magistri cognostis, cognoscite<note>cognoscitis <hi rend="italics">A<foreign xml:lang="grc">πσφ</foreign>
+                     </hi>
+                  </note> nunc 
 discipuli aequitatem.  <reg>dixi</reg> iam antea saepe numero postulatos esse ab 
-istis duos servos in quaestionem.  <reg>tu</reg> semper, <choice><abbr>T.</abbr><expan>T<ex>iti</ex></expan></choice> Rosci, recusasti.  
+istis duos servos in quaestionem.  <reg>tu</reg> semper, <choice>
+                     <abbr>T.</abbr>
+                     <expan>T<ex>iti</ex>
+                     </expan>
+                  </choice> Rosci, recusasti.  
 <reg>quaero</reg> abs te: 'Eine qui postulabant indigni erant qui impetrarent, an 
 is te<note>is te <hi rend="italics">Heusinger</hi>: iste <hi rend="italics">codd.</hi>
-               </note> non commovebat pro quo postulabant, an res ipsa tibi iniqua 
+                  </note> non commovebat pro quo postulabant, an res ipsa tibi iniqua 
 videbatur?'  <reg>postulabant</reg> homines nobilissimi atque integerrimi 
 nostrae civitatis quos iam antea nominavi; qui ita vixerunt talesque 
 a populo Romano putantur ut quicquid dicerent nemo esset qui non 
 aequum putaret.  <reg>postulabant</reg> autem pro homine miserrimo atque 
 infelicissimo qui vel ipse sese in cruciatum dari cuperet, dum de 
 patris morte
-quaereretur.</p></div> 
-
-<div type="textpart" subtype="section" n="120"><p>
-               <reg>res</reg> porro abs te eius modi postulabatur ut nihil 
+quaereretur.</p>
+            </div>
+            <div type="textpart" subtype="section" n="120">
+               <p>
+                  <reg>res</reg> porro abs te eius modi postulabatur ut nihil 
 interesset, utrum eam rem<note>rem <hi rend="italics">del. Halm</hi> (2)</note> recusares an de maleficio confiterere.  
-<reg>quae</reg> cum<note>cum <hi rend="italics">om. <foreign xml:lang="grc">S</foreign> in lac.</hi>
-               </note> ita sint, quaero abs te quam ob causam recusaris.  <reg>cum</reg> 
+<reg>quae</reg> cum<note>cum <hi rend="italics">om. <foreign xml:lang="grc">ς</foreign> in lac.</hi>
+                  </note> ita sint, quaero abs te quam ob causam recusaris.  <reg>cum</reg> 
 occiditur Sex. Roscius ibidem fuerunt. <reg>servos</reg> ipsos, quod ad me 
 attinet, neque arguo neque purgo; quod a vobis oppugnari<note>repugnari <hi rend="italics">Sylvius</hi>
-               </note> video ne 
+                  </note> video ne 
 in quaestionem dentur, suspiciosum est; quod vero apud vos ipsos in 
 honore tanto sunt, profecto necesse est sciant aliquid, quod si 
 dixerint perniciosum vobis futurum sit. — <reg>in</reg> dominos quaeri de servis 
-iniquum<note>iniquom <foreign xml:lang="grc">Ssx1</foreign> at non quaeritur <hi rend="italics">Büchner</hi>: at ne quaeritur <hi rend="italics">codd.</hi>: anne quaeritur <hi rend="italics">Ascens.</hi> (2): at neque in vos quaeritur <hi rend="italics">Madvig</hi>
-               </note> est.  — <reg>at</reg> non quaeritur; <reg>sex</reg>. enim Roscius reus est; neque 
+iniquum<note>iniquom <foreign xml:lang="grc">σσχ1</foreign> at non quaeritur <hi rend="italics">Büchner</hi>: at ne quaeritur <hi rend="italics">codd.</hi>: anne quaeritur <hi rend="italics">Ascens.</hi> (2): at neque in vos quaeritur <hi rend="italics">Madvig</hi>
+                  </note> est.  — <reg>at</reg> non quaeritur; <reg>sex</reg>. enim Roscius reus est; neque 
 enim<note>
-                  <app><lem>neque enim</lem></app> neque in dominum <hi rend="italics">Müller</hi>
-               </note>, cum de hoc quaeritur, in dominos quaeritur ; vos enim dominos<note>in dominos quaeritur <hi rend="italics">Halm:om. codd.</hi>
-               </note> 
+                     <app>
+                        <lem>neque enim</lem>
+                     </app> neque in dominum <hi rend="italics">Müller</hi>
+                  </note>, cum de hoc quaeritur, in dominos quaeritur ; vos enim dominos<note>in dominos quaeritur <hi rend="italics">Halm:om. codd.</hi>
+                  </note> 
 esse dicitis. — <reg>cum</reg> Chrysogono sunt.
  — <reg>ita</reg> credo; litteris eorum et urbanitate Chrysogonus ducitur ut inter 
 suos omnium deliciarum atque omnium artium puerulos ex tot 
 elegantissimis familiis lectos velit hos versari, homines paene 
 operarios, ex Amerina disciplina patris
-familiae rusticani. </p></div>  
-
-<div type="textpart" subtype="section" n="121"><p>
-               <reg>non</reg> ita est profecto, iudices; non est veri 
+familiae rusticani. </p>
+            </div>
+            <div type="textpart" subtype="section" n="121">
+               <p>
+                  <reg>non</reg> ita est profecto, iudices; non est veri 
 simile ut Chrysogonus horum litteras adamarit aut
 humanitatem, non ut rei familiaris negotio diligentiam cognorit 
 eorum et fidem. <reg>est</reg> quiddam quod occultatur; quod quo studiosius 
 ab istis<note>istis <hi rend="italics">Halm</hi>: ipsis <hi rend="italics">codd.</hi>
-               </note> opprimitur et absconditur, eo magis
+                  </note> opprimitur et absconditur, eo magis
 eminet et apparet.  <reg>quid</reg> igitur?
 
 </p>
-         </div>
-         <milestone n="42" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="122"><p>Chrysogonus suine<note>suine <hi rend="italics">cod. Paris.</hi> 6369: tuine <foreign xml:lang="grc">Sy2</foreign>: tui <hi rend="italics">cett.</hi>
-               </note> malefici occultandi causa 
+            </div>
+            <milestone n="42" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="122">
+               <p>Chrysogonus suine<note>suine <hi rend="italics">cod. Paris.</hi> 6369: tuine <foreign xml:lang="grc">σψ2</foreign>: tui <hi rend="italics">cett.</hi>
+                  </note> malefici occultandi causa 
 quaestionem de eis haberi non volt?
 <reg>minime</reg>, iudices; non in omnis arbitror omnia convenire. <reg>ego</reg> in 
 Chrysogono, quod ad me attinet, nihil eius modi suspicor; neque hoc 
-mihi nunc<note>mihi nunc mihi <foreign xml:lang="grc">S</foreign>
-               </note> primum in mentem venit dicere.  <reg>meministis</reg> me ita 
-distribuisse initio causam<note>in causam <foreign xml:lang="grc">S</foreign>
-               </note>: in crimen cuius tota argumentatio 
+mihi nunc<note>mihi nunc mihi <foreign xml:lang="grc">ς</foreign>
+                  </note> primum in mentem venit dicere.  <reg>meministis</reg> me ita 
+distribuisse initio causam<note>in causam <foreign xml:lang="grc">ς</foreign>
+                  </note>: in crimen cuius tota argumentatio 
 permissa Erucio est, et in audaciam cuius partes Rosciis impositae<note>impostae <hi rend="italics">Zielinski p.</hi> 186</note> 
 sunt.  <reg>quicquid</reg> malefici, sceleris, caedis erit, proprium id Rosciorum 
 esse debebit. <reg>nimiam</reg> gratiam potentiamque Chrysogoni dicimus et 
 nobis obstare et perferri nullo modo posse et a vobis, quoniam 
 potestas data est, non modo infirmari verum etiam
-vindicari oportere. </p></div> 
-
-<div type="textpart" subtype="section" n="123"><p>
-               <reg>ego</reg> sic existimo, qui quaeri velit ex eis quos 
+vindicari oportere. </p>
+            </div>
+            <div type="textpart" subtype="section" n="123">
+               <p>
+                  <reg>ego</reg> sic existimo, qui quaeri velit ex eis quos 
 constat, eum caedes facta sit<note>
-                  <app><lem>sit</lem></app> est <hi rend="italics">Halm</hi>
-               </note>, adfuisse, cum cupere
+                     <app>
+                        <lem>sit</lem>
+                     </app> est <hi rend="italics">Halm</hi>
+                  </note>, adfuisse, cum cupere
 verum inveniri<note>inveniri <hi rend="italics">Pluygers</hi>: invenire <hi rend="italics">codd.</hi>
-               </note>; qui id<note>qui id <hi rend="italics">scripsi</hi>: quid <foreign xml:lang="grc">S</foreign>: qui <hi rend="italics">cett.</hi>
-               </note> recuset, eum profecto, tametsi verbo non 
+                  </note>; qui id<note>qui id <hi rend="italics">scripsi</hi>: quid <foreign xml:lang="grc">ς</foreign>: qui <hi rend="italics">cett.</hi>
+                  </note> recuset, eum profecto, tametsi verbo non 
 audeat, tamen re ipsa de maleficio suo confiteri.  <reg>dixi</reg> initio, iudices, 
 nolle me plura de istorum scelere dicere quam causa postularet ac 
 necessitas ipsa cogeret. <reg>nam</reg> et multae res adferri possunt, et una 
 quaeque<note>de una quaque <hi rend="italics">Lambinus</hi>
-               </note> earum multis cum argumentis dici potest.  <reg>verum</reg> ego quod 
+                  </note> earum multis cum argumentis dici potest.  <reg>verum</reg> ego quod 
 invitus ac necessario facio neque diu neque diligenter facere possum.  
 <reg>quae</reg>
 praeteriri nullo modo poterant, ea leviter, iudices, attigi, quae posita 
@@ -2219,169 +2599,203 @@ disserendum, ea vestris ingeniis coniecturaeque committo.
 
 
             </p>
-         </div>
-         <milestone n="43" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="124"><p>
-               <reg>venio</reg> nunc ad illud nomen aureum Chrysogoni sub quo nomine 
+            </div>
+            <milestone n="43" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="124">
+               <p>
+                  <reg>venio</reg> nunc ad illud nomen aureum Chrysogoni sub quo nomine 
 tota societas latuit<note>latuit <hi rend="italics">Madvig</hi>: statuit <hi rend="italics">codd.</hi>
-               </note>; de quo, iudices, neque quo modo dicam neque 
+                  </note>; de quo, iudices, neque quo modo dicam neque 
 quo modo taceam reperire possum.  <reg>si</reg> enim taceo, vel maximam 
 partem<note>partem causae <hi rend="italics">Kraffert</hi>
-               </note> relinquo; sin autem dico, vereor ne non ille solus, id quod ad 
+                  </note> relinquo; sin autem dico, vereor ne non ille solus, id quod ad 
 me nihil attinet, sed alii quoque plures laesos se<note>laesos se <hi rend="italics">scripsi</hi>: laesos se esse <hi rend="italics">codd.</hi> (<hi rend="italics">cf. Zielinski p.</hi> 192)</note> putent.  <reg>tametsi</reg> ita 
 se res habet ut mihi in communem causam sectorum dicendum nihil 
 magno opere videatur; haec enim causa nova profecto et singularis
-est.  <reg>bonorum</reg> Sex. Rosci emptor est Chrysogonus<note>emptor est Chrysogonus <hi rend="italics">w</hi>: emptorẽ Chrysogonus <foreign xml:lang="grc">S</foreign>: emptorem Chrysogonum <hi rend="italics">cett.</hi>
-</note>. </p></div> 
-
-<div type="textpart" subtype="section" n="125"><p>
-               <reg>primum</reg>
-               <note>primum <foreign xml:lang="grc">S</foreign>
-               </note> hoc 
+est.  <reg>bonorum</reg> Sex. Rosci emptor est Chrysogonus<note>emptor est Chrysogonus <hi rend="italics">w</hi>: emptorẽ Chrysogonus <foreign xml:lang="grc">ς</foreign>: emptorem Chrysogonum <hi rend="italics">cett.</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="125">
+               <p>
+                  <reg>primum</reg>
+                  <note>primum <foreign xml:lang="grc">ς</foreign>
+                  </note> hoc 
 videamus: eius hominis bona qua ratione venierunt aut quo modo 
 venire potuerunt? <reg>atque</reg> hoc non ita quaeram, iudices, ut id dicam 
 esse indignum, hominis innocentis bona venisse — <reg>si</reg> enim haec 
 audientur<note>
-                  <app><lem>audientur</lem></app> audaciter <hi rend="italics">Richter</hi> ac] ac || <foreign xml:lang="grc">S</foreign>: aut <foreign xml:lang="grc">sxy</foreign>: <hi rend="italics">fort.</hi> atque</note> ac libere dicentur, non fuit tantus homo Sex. Roscius in 
+                     <app>
+                        <lem>audientur</lem>
+                     </app> audaciter <hi rend="italics">Richter</hi> ac] ac || <foreign xml:lang="grc">ς</foreign>: aut <foreign xml:lang="grc">σχψ</foreign>: <hi rend="italics">fort.</hi> atque</note> ac libere dicentur, non fuit tantus homo Sex. Roscius in 
 civitate ut de eo potissimum conqueramur — verum ego hoc<note>
-                  <app><lem>ego hoc</lem></app> 
-                  <hi rend="italics">om.</hi> hoc <hi rend="italics">A</hi>: <hi rend="italics">om.</hi> ego <hi rend="italics">w, Halm</hi>
-               </note> quaero: 
-<reg>qui</reg> potuerunt<note>potuerint <foreign xml:lang="grc">S</foreign>
-               </note> ista ipsa lege quae de proscriptione est, sive Valeria 
+                     <app>
+                        <lem>ego hoc</lem>
+                     </app>
+                     <hi rend="italics">om.</hi> hoc <hi rend="italics">A</hi>: <hi rend="italics">om.</hi> ego <hi rend="italics">w, Halm</hi>
+                  </note> quaero: 
+<reg>qui</reg> potuerunt<note>potuerint <foreign xml:lang="grc">ς</foreign>
+                  </note> ista ipsa lege quae de proscriptione est, sive Valeria 
 est sive Cornelia — non enim novi nec scio — verum ista ipsa lege bona
-Sex. Rosci venire qui potuerunt? </p></div> 
-
-<div type="textpart" subtype="section" n="126"><p>
-               <reg>scriptum</reg> enim ita dicunt esse: 
-VT AVT<note>ut aut <hi rend="italics">scripsi</hi>: ut ut <foreign xml:lang="grc">S</foreign>: ut <hi rend="italics">cett.</hi> veneant <foreign xml:lang="grc">s</foreign>: veniant <hi rend="italics">cett.</hi>
-               </note> EORVM BONA VENEANT QVI PROSCRIPTI SVNT; quo in 
+Sex. Rosci venire qui potuerunt? </p>
+            </div>
+            <div type="textpart" subtype="section" n="126">
+               <p>
+                  <reg>scriptum</reg> enim ita dicunt esse: 
+VT AVT<note>ut aut <hi rend="italics">scripsi</hi>: ut ut <foreign xml:lang="grc">ς</foreign>: ut <hi rend="italics">cett.</hi> veneant <foreign xml:lang="grc">ς</foreign>: veniant <hi rend="italics">cett.</hi>
+                  </note> EORVM BONA VENEANT QVI PROSCRIPTI SVNT; quo in 
 numero Sex. Roscius non est: AVT EORVM QVI IN ADVERSARIORVM 
 PRAESIDIIS OCCISI SVNT.  Dum praesidia ulla fuerunt, in Sullae 
-praesidiis fuit; postea quam ab armis omnes recesserunt<note>omnes recesserunt <hi rend="italics">scripsi</hi>: recesserunt (disceps. <foreign xml:lang="grc">sx</foreign>. disces. <foreign xml:lang="grc">y</foreign>) <hi rend="italics">codd.</hi>: recessum est <hi rend="italics">C. Stephanus</hi>: recessimus <hi rend="italics">Richter</hi>
-               </note>, in summo 
+praesidiis fuit; postea quam ab armis omnes recesserunt<note>omnes recesserunt <hi rend="italics">scripsi</hi>: recesserunt (disceps. <foreign xml:lang="grc">σχ</foreign>. disces. <foreign xml:lang="grc">ψ</foreign>) <hi rend="italics">codd.</hi>: recessum est <hi rend="italics">C. Stephanus</hi>: recessimus <hi rend="italics">Richter</hi>
+                  </note>, in summo 
 otio rediens a cena Romae
-occisus est.  si<note>si <foreign xml:lang="grc">y2</foreign>: <hi rend="italics">om. cett.</hi>
-               </note> lege, bona quoque lege venisse fateor.  <reg>sin</reg> autem 
+occisus est.  si<note>si <foreign xml:lang="grc">ψ2</foreign>: <hi rend="italics">om. cett.</hi>
+                  </note> lege, bona quoque lege venisse fateor.  <reg>sin</reg> autem 
 constat contra omnis non modo<note>
-                  <app><lem>modo</lem></app> more <hi rend="italics">Ernesti</hi>
-               </note> veteres leges verum etiam novas 
+                     <app>
+                        <lem>modo</lem>
+                     </app> more <hi rend="italics">Ernesti</hi>
+                  </note> veteres leges verum etiam novas 
 occisum esse, bona quo iure aut quo modo aut
 qua lege venierint quaero.	
 
 
             </p>
-         </div>
-         <milestone n="44" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="127"><p>
-               <reg>in</reg> quem hoc dicam quaeris, Eruci?  <reg>non</reg> in eum quem vis et 
+            </div>
+            <milestone n="44" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="127">
+               <p>
+                  <reg>in</reg> quem hoc dicam quaeris, Eruci?  <reg>non</reg> in eum quem vis et 
 putas; nam Sullam et oratio mea ab initio et ipsius eximia virtus 
 omni tempore purgavit.  <reg>ego</reg> haec omnia Chrysogonum fecisse dico, ut 
 ementiretur, ut malum civem Sex. Roscium<note>Sex. <hi rend="italics">Ernesti</hi>: <hi rend="italics">om. codd.</hi>
-               </note> fuisse fingeret, ut eum 
+                  </note> fuisse fingeret, ut eum 
 apud adversarios occisum esse diceret, ut his de<note>his de <hi rend="italics">ed. R. Stephani</hi>: hisce <hi rend="italics">codd.</hi>: hisce de <hi rend="italics">Ascens.</hi> (2)</note> rebus a legatis 
-Amerinorum doceri <choice><abbr>L.</abbr><expan>L<ex>ucium</ex></expan></choice> Sullam passus non sit.  <reg>denique</reg> etiam illud 
+Amerinorum doceri <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucium</ex>
+                     </expan>
+                  </choice> Sullam passus non sit.  <reg>denique</reg> etiam illud 
 suspicor, omnino haec bona non venisse; id quod postea, si per vos, 
-iudices, licitum erit, aperietur. </p></div> 
-
-<div type="textpart" subtype="section" n="128"><p>
-               <reg>opinor</reg> enim esse in lege quam ad 
+iudices, licitum erit, aperietur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="128">
+               <p>
+                  <reg>opinor</reg> enim esse in lege quam ad 
 diem proscriptiones venditionesque fiant, nimirum Kalendas Iunias.  
 <reg>aliquot</reg> post mensis et homo occisus est et bona venisse dicuntur.  
-<reg>profecto</reg> aut haec bona in tabulas publicas nulla<note>nulla ratione <foreign xml:lang="grc">y2</foreign>
-               </note> redierunt nosque ab 
+<reg>profecto</reg> aut haec bona in tabulas publicas nulla<note>nulla ratione <foreign xml:lang="grc">ψ2</foreign>
+                  </note> redierunt nosque ab 
 isto nebulone facetius eludimur quam putamus, aut, si redierunt, 
 tabulae publicae corruptae aliqua ratione sunt; nam lege quidem 
 bona venire non potuisse constat.  <reg>intellego</reg> me ante tempus, iudices, 
 haec serutari et prope modum errare qui, cum capiti Sex. Rosci 
-mederi debeam, reduviam<note>redii viam <foreign xml:lang="grc">S</foreign>
-               </note> curem<note>curem <hi rend="italics">s, ed. R</hi>: cure (-ae <hi rend="italics">A</hi>) <hi rend="italics">mei</hi>
-               </note>. <reg>non</reg> enim laborat de pecunia, non 
+mederi debeam, reduviam<note>redii viam <foreign xml:lang="grc">ς</foreign>
+                  </note> curem<note>curem <hi rend="italics">s, ed. R</hi>: cure (-ae <hi rend="italics">A</hi>) <hi rend="italics">mei</hi>
+                  </note>. <reg>non</reg> enim laborat de pecunia, non 
 ullius rationem sui commodi ducit; facile egestatem suam Sc laturum 
-putat, si hac indigna suspicione et ficto crimine liberatus sit. </p></div>  
-
-<div type="textpart" subtype="section" n="129"><p>
-               <reg>verum</reg> 
+putat, si hac indigna suspicione et ficto crimine liberatus sit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="129">
+               <p>
+                  <reg>verum</reg> 
 quaeso a vobis, iudices, ut haec pauca quae restant ita audiatis ut 
 partim me dicere pro me ipso putetis, partim pro Sex. Roscio<note>pro Sex. <hi rend="italics">edd. VR</hi>: Sex. <hi rend="italics">codd.</hi>
-               </note>.  <reg>quae</reg> 
-enim mihi ipsi<note>ipsi <hi rend="italics">om.</hi> 
-                  <foreign xml:lang="grc">w</foreign>
-               </note> indigna et intolerabilia videntur quaeque ad omnis, 
+                  </note>.  <reg>quae</reg> 
+enim mihi ipsi<note>ipsi <hi rend="italics">om.</hi>
+                     <foreign xml:lang="grc">ω</foreign>
+                  </note> indigna et intolerabilia videntur quaeque ad omnis, 
 nisi providemus, arbitror pertinere, ea pro me ipso ex<note>ex <hi rend="italics">Naugerius</hi> (2): et <hi rend="italics">codd.</hi>
-               </note> animi mei 
+                  </note> animi mei 
 sensu ac dolore pronuntio; 
 quae ad huius vitae casum causamque<note>
-                  <app><lem>vitae casum causamque</lem></app> vitae discrimen casumque <hi rend="italics">w</hi>: vitae causamque <foreign xml:lang="grc">w</foreign>: vitae causam <hi rend="italics">Ruhnken</hi>: vitam causamque <hi rend="italics">Richter</hi> pertinent <hi rend="italics">Eberhard</hi>: pertineant (-eat <foreign xml:lang="grc">sfw</foreign>) <hi rend="italics">codd.</hi>
-               </note> pertinent et quid hic pro 
+                     <app>
+                        <lem>vitae casum causamque</lem>
+                     </app> vitae discrimen casumque <hi rend="italics">w</hi>: vitae causamque <foreign xml:lang="grc">ω</foreign>: vitae causam <hi rend="italics">Ruhnken</hi>: vitam causamque <hi rend="italics">Richter</hi> pertinent <hi rend="italics">Eberhard</hi>: pertineant (-eat <foreign xml:lang="grc">σφω</foreign>) <hi rend="italics">codd.</hi>
+                  </note> pertinent et quid hic pro 
 se dici velit et qua condicione contentus sit iam in extrema oratione 
 nostra, iudices, audietis.
 
 
             </p>
-         </div>
-         <milestone n="45" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="130"><p>
-               <reg>ego</reg> haec a Chrysogono mea sponte remoto Sex. Roscio 
+            </div>
+            <milestone n="45" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="130">
+               <p>
+                  <reg>ego</reg> haec a Chrysogono mea sponte remoto Sex. Roscio 
 quaero, primum qua re civis optimi bona venierint, deinde
 qua re hominis eius qui neque proscriptus<note>neque proscriptus <hi rend="italics">Hotoman: om. codd.</hi>
-               </note> neque apud adversarios 
-occisus est bona venierint<note>venierunt <foreign xml:lang="grc">S<hi rend="italics">A</hi>w</foreign>
-               </note>, cum<note>
-                  <app><lem>cum</lem></app> quin <foreign xml:lang="grc">px1y</foreign>
-               </note> in eos solos lex scripta sit, deinde qua 
+                  </note> neque apud adversarios 
+occisus est bona venierint<note>venierunt <foreign xml:lang="grc">ς<hi rend="italics">α</hi>ω</foreign>
+                  </note>, cum<note>
+                     <app>
+                        <lem>cum</lem>
+                     </app> quin <foreign xml:lang="grc">πχ1ψ</foreign>
+                  </note> in eos solos lex scripta sit, deinde qua 
 re aliquanto post eam diem venierint quae dies in lege praefinita est, 
 deinde<note>
-                  <app><lem>deinde</lem></app> denique <hi rend="italics">Halm</hi>
-               </note> cur tantulo venierint. <reg>quae</reg> omnia si, quem ad modum solent 
+                     <app>
+                        <lem>deinde</lem>
+                     </app> denique <hi rend="italics">Halm</hi>
+                  </note> cur tantulo venierint. <reg>quae</reg> omnia si, quem ad modum solent 
 liberti nequam et improbi facere, in patronum suum voluerit 
 conferre, nihil egerit; nemo est enim qui nesciat propter 
 magnitudinem rerum multa multos partim improbante partim 
 imprudente<note>partim improbante <hi rend="italics">scripsi: om. codd.</hi>: partim invito <hi rend="italics">Madvig</hi>: partim conivente <hi rend="italics">Ascens.</hi> (1)</note> L.
-                  Sulla commisisse. </p></div> 
-
-<div type="textpart" subtype="section" n="131"><p>
-               <reg>placet</reg> igitur in his rebus aliquid imprudentia 
+                  Sulla commisisse. </p>
+            </div>
+            <div type="textpart" subtype="section" n="131">
+               <p>
+                  <reg>placet</reg> igitur in his rebus aliquid imprudentia 
 praeteriri? <reg>non</reg> placet, iudices, sed necesse est. <reg>etenim</reg> si Iuppiter 
-<reg>optimus</reg> 
-               <reg>maximus</reg> cuius nutu et arbitrio caelum terra mariaque 
+<reg>optimus</reg>
+                  <reg>maximus</reg> cuius nutu et arbitrio caelum terra mariaque 
 reguntur saepe ventis vehementioribus aut immoderatis 
 tempestatibus aut nimio calore aut intolerabili frigore hominibus 
-nocuit, urbis delevit, fruges perdidit, quorum nihil pernicii<note>pernicii <hi rend="italics">Gellius</hi> ix. 14. 19, <hi rend="italics">Nonius p.</hi> 486: pernicie <hi rend="italics">codd.</hi> 21 commoda <hi rend="italics">s, ed. R</hi>: commodis a <foreign xml:lang="grc">S</foreign>: commodis <hi rend="italics">cett.</hi>
-               </note> causa 
+nocuit, urbis delevit, fruges perdidit, quorum nihil pernicii<note>pernicii <hi rend="italics">Gellius</hi> ix. 14. 19, <hi rend="italics">Nonius p.</hi> 486: pernicie <hi rend="italics">codd.</hi> 21 commoda <hi rend="italics">s, ed. R</hi>: commodis a <foreign xml:lang="grc">ς</foreign>: commodis <hi rend="italics">cett.</hi>
+                  </note> causa 
 divino consilio sed vi ipsa et magnitudine rerum factum putamus, 
 at contra commoda quibus utimur lucemque qua fruimur 
 spiritumque quem ducimus ab eo nobis dari atque impertiri 
 videmus, quid miramur, iudices<note>iudices <hi rend="italics">Schol. om. codd.</hi>
-               </note>, <choice><abbr>L.</abbr><expan>L<ex>ucium</ex></expan></choice> Sullam, cum solus rem publicam 
+                  </note>, <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucium</ex>
+                     </expan>
+                  </choice> Sullam, cum solus rem publicam 
 regeret orbemque terrarum gubernaret imperique maiestatem 
-quam armis receperat iam<note>iam <hi rend="italics">scripsi</hi>: tum <foreign xml:lang="grc">S</foreign>: ut <hi rend="italics">A<foreign xml:lang="grc">pfw</foreign>
-                  </hi>: cum <foreign xml:lang="grc">sxy</foreign>: <hi rend="italics">fort.</hi> suis</note> legibus confirmaret, aliqua animadvertere 
+quam armis receperat iam<note>iam <hi rend="italics">scripsi</hi>: tum <foreign xml:lang="grc">ς</foreign>: ut <hi rend="italics">A<foreign xml:lang="grc">πφω</foreign>
+                     </hi>: cum <foreign xml:lang="grc">σχψ</foreign>: <hi rend="italics">fort.</hi> suis</note> legibus confirmaret, aliqua animadvertere 
 non potuisse? nisi hoc mirum est quod vis divina
-adsequi non possit, si id mens humana adepta non sit.</p></div> 
-
-<div type="textpart" subtype="section" n="132"><p>
-               <reg>verum</reg> ut haec missa faciam quae iam facta sunt, ex eis quae 
-nunc cum<note>cum <foreign xml:lang="grc">S</foreign>: <hi rend="italics">om. cett.</hi>
-               </note> maxime fiunt nonne quivis potest intellegere
+adsequi non possit, si id mens humana adepta non sit.</p>
+            </div>
+            <div type="textpart" subtype="section" n="132">
+               <p>
+                  <reg>verum</reg> ut haec missa faciam quae iam facta sunt, ex eis quae 
+nunc cum<note>cum <foreign xml:lang="grc">ς</foreign>: <hi rend="italics">om. cett.</hi>
+                  </note> maxime fiunt nonne quivis potest intellegere
 omnium architectum et machinatorem unum esse Chrysogonum? qui 
 Sex. Rosci nomen deferendum curavit<note>
-                  <app><lem>curavit</lem></app> hoe iudicium <hi rend="italics">add. codd., del. Madvig</hi> (<hi rend="italics">fort. ex</hi> h. d., <hi rend="italics">i. e.</hi> hic deest, <hi rend="italics">ortum</hi>)</note>, cuius honoris causa accusare 
+                     <app>
+                        <lem>curavit</lem>
+                     </app> hoe iudicium <hi rend="italics">add. codd., del. Madvig</hi> (<hi rend="italics">fort. ex</hi> h. d., <hi rend="italics">i. e.</hi> hic deest, <hi rend="italics">ortum</hi>)</note>, cuius honoris causa accusare 
 <reg>se</reg> dixit Erucius...<note>
-                  <app><lem>Erucius</lem></app> 
-                  <hi rend="italics">lac.</hi>
-               </note>
-               <gap reason="lost"><desc>Desunt non pauca.</desc></gap>
-
-               <note anchored="true">
-                  <reg>in</reg> vico Pallacinae] <reg>locus</reg>  ubi cenaverat Roscius. — <reg>maxime</reg> metuit 
+                     <app>
+                        <lem>Erucius</lem>
+                     </app>
+                     <hi rend="italics">lac.</hi>
+                  </note>
+                  <gap reason="lost">
+                     <desc>Desunt non pauca.</desc>
+                  </gap>
+                  <note anchored="true">
+                     <reg>in</reg> vico Pallacinae] <reg>locus</reg>  ubi cenaverat Roscius. — <reg>maxime</reg> metuit 
 Sullam scilicet. — <reg>derivat</reg> tamen et ait se<note>
-                     <hi rend="italics">vers. et 2 pag. hab. A,</hi> 1 <hi rend="italics">pag.</hi> 
-                     <foreign xml:lang="grc">p</foreign>, <hi rend="italics">lac. non notat</hi> 
-                     <foreign xml:lang="grc">S</foreign> (<hi rend="italics">`Iterum non parva textus pars deest. Quod factum est situ et exemplaris vetustate decrepita, quod vir doctissimus Poggius ex Gallis ad nos reportaverat, qui et huius orationis et alterius pro Murena repertor hac aetate fuit. Vt autem Fr. Barbarus dicere ac deplorare solet, occaecatum adeo exemplaris codicem unde haec exarata est oratio Florentiae viderat ut nullo pacto inde transcribi verbum potuerit.'</hi> Guarinus <hi rend="italics">in Comment.</hi>)</note> id est suspicionem suam in 
+                        <hi rend="italics">vers. et 2 pag. hab. A,</hi> 1 <hi rend="italics">pag.</hi>
+                        <foreign xml:lang="grc">π</foreign>, <hi rend="italics">lac. non notat</hi>
+                        <foreign xml:lang="grc">ς</foreign> (<hi rend="italics">`Iterum non parva textus pars deest. Quod factum est situ et exemplaris vetustate decrepita, quod vir doctissimus Poggius ex Gallis ad nos reportaverat, qui et huius orationis et alterius pro Murena repertor hac aetate fuit. Vt autem Fr. Barbarus dicere ac deplorare solet, occaecatum adeo exemplaris codicem unde haec exarata est oratio Florentiae viderat ut nullo pacto inde transcribi verbum potuerit.'</hi> Guarinus <hi rend="italics">in Comment.</hi>)</note> id est suspicionem suam in 
 alium deducit.  <reg>hoc</reg> enini dicebat
 Chrysogonus:	<reg>non</reg> quia timui ne mihi tollerentur bona Rosci, ideo 
 eius praedia dissipavi, sed, quia aedificabam, in Vcientanam ideo de 
@@ -2391,54 +2805,63 @@ cupio] <reg>in</reg> hoc capite de potentia Chrysogoni invidiam facit, ut
 enunieret singula deliciarum genera, quod habeat pluris 
 possessiones, mancipia, quae omnia dicit de rapinis ipsum habere.  
 (Schol. Gron. p.436.14.)
-</note><milestone n="46" unit="chapter"/><milestone unit="para"/>
+</note>
+                  <milestone n="46" unit="chapter"/>
+                  <milestone unit="para"/>
          ... aptam et ratione dispositam se habere existimant, qui in 
 Sallentinis aut in Bruttiis habent unde vix ter in anno
-audire nuntium possunt.</p></div> 
-
-<div type="textpart" subtype="section" n="133"><p>
-               <reg>alter</reg> tibi descendit de Palatio et aedibus suis; habet animi 
-causa<note>animi relaxandi causa <foreign xml:lang="grc">y</foreign>
-               </note> rus amoenum et suburbanum, plura praeterea
+audire nuntium possunt.</p>
+            </div>
+            <div type="textpart" subtype="section" n="133">
+               <p>
+                  <reg>alter</reg> tibi descendit de Palatio et aedibus suis; habet animi 
+causa<note>animi relaxandi causa <foreign xml:lang="grc">ψ</foreign>
+                  </note> rus amoenum et suburbanum, plura praeterea
 praedia neque tamen ullum nisi praeclarum et propinquum.
 <reg>domus</reg> referta<note>
-                  <app><lem>referta</lem></app> 
-                  <hi rend="italics">fort.</hi> referta est</note> vasis Corinthiis et Deliacis, in quibus est authepsa illa 
+                     <app>
+                        <lem>referta</lem>
+                     </app>
+                     <hi rend="italics">fort.</hi> referta est</note> vasis Corinthiis et Deliacis, in quibus est authepsa illa 
 quam tanto pretio nuper mercatus est ut qui praetereuntes quid 
-praeco enumeraret<note>quid praeco enumeraret (-re <foreign xml:lang="grc">s</foreign>) <foreign xml:lang="grc">s</foreign>, <hi rend="italics">Steinmetz</hi>: quid praeconum numerare <foreign xml:lang="grc">S</foreign>: quid praeco enuntiare <foreign xml:lang="grc">x</foreign>: quid precium nuntiare <foreign xml:lang="grc">p</foreign>: quid praetium numerare (enum- <foreign xml:lang="grc">y2</foreign>) <hi rend="italics">A<foreign xml:lang="grc">fy1w</foreign>
-                  </hi>: pecuniam numerare <hi rend="italics">B</hi>
-               </note> audiebant fundum venire arbitrarentur.  <reg>quid</reg> 
+praeco enumeraret<note>quid praeco enumeraret (-re <foreign xml:lang="grc">ς</foreign>) <foreign xml:lang="grc">ς</foreign>, <hi rend="italics">Steinmetz</hi>: quid praeconum numerare <foreign xml:lang="grc">ς</foreign>: quid praeco enuntiare <foreign xml:lang="grc">χ</foreign>: quid precium nuntiare <foreign xml:lang="grc">π</foreign>: quid praetium numerare (enum- <foreign xml:lang="grc">ψ2</foreign>) <hi rend="italics">A<foreign xml:lang="grc">φψ1ω</foreign>
+                     </hi>: pecuniam numerare <hi rend="italics">B</hi>
+                  </note> audiebant fundum venire arbitrarentur.  <reg>quid</reg> 
 praeterea caelati argenti, quid stragulae vestis, quid pictarum 
 tabularum, quid signorum, quid marmoris apud illum putatis esse? 
 <reg>tantum</reg> scilicet quantum e multis splendidisque familiis in turba et 
-rapinis coacervari una in domo<note>una in domo <foreign xml:lang="grc">sxy</foreign>: una in (vi <hi rend="italics">AB<foreign xml:lang="grc">f</foreign>
-                  </hi>) nemo <foreign xml:lang="grc">S<hi rend="italics">AB</hi>pf</foreign>: una in venio <foreign xml:lang="grc">w</foreign>
-               </note> potuit.  <reg>familiam</reg> vero quantam et
-   quam variis cum artificiis habeat quid ego dicam? </p></div>  
-
-<div type="textpart" subtype="section" n="134"><p>Mitto hasce 
-artis volgaris, coquos<note>coquos <hi rend="italics">A<foreign xml:lang="grc">py</foreign>
-                  </hi>: cocos <hi rend="italics">cett.</hi>
-               </note>, pistores<note>pistores <hi rend="italics">Naugerius</hi>: pictores <hi rend="italics">codd.</hi>
-               </note>, lecticarios; animi et aurium causa tot 
+rapinis coacervari una in domo<note>una in domo <foreign xml:lang="grc">σχψ</foreign>: una in (vi <hi rend="italics">AB<foreign xml:lang="grc">φ</foreign>
+                     </hi>) nemo <foreign xml:lang="grc">ς<hi rend="italics">αβ</hi>πφ</foreign>: una in venio <foreign xml:lang="grc">ω</foreign>
+                  </note> potuit.  <reg>familiam</reg> vero quantam et
+   quam variis cum artificiis habeat quid ego dicam? </p>
+            </div>
+            <div type="textpart" subtype="section" n="134">
+               <p>Mitto hasce 
+artis volgaris, coquos<note>coquos <hi rend="italics">A<foreign xml:lang="grc">πψ</foreign>
+                     </hi>: cocos <hi rend="italics">cett.</hi>
+                  </note>, pistores<note>pistores <hi rend="italics">Naugerius</hi>: pictores <hi rend="italics">codd.</hi>
+                  </note>, lecticarios; animi et aurium causa tot 
 homines habet ut cotidiano cantu vocum et nervorum et tibiarum 
 nocturnisque conviviis<note>conviciis <hi rend="italics">Paul</hi> (<hi rend="italics">cf. Mur.</hi> 13)</note> tota vicinitas personet.  <reg>in</reg> hac vita, iudices, 
 quos sumptus cotidianos, quas effusiones fieri putatis, quae vero 
 convivia? honesta, credo, in eius modi domo, si domus haec habenda 
 est potius quam<note>quam <hi rend="italics">B</hi>
-                  <foreign xml:lang="grc">sxy</foreign>: <hi rend="italics">om. catt.</hi>
-               </note> officina nequitiae ac<note>
-                  <app><lem>ac</lem></app> et <foreign xml:lang="grc">fxy1w</foreign>
-               </note> deversorium flagitiorum 
-   omnium.</p></div> 
-
-<div type="textpart" subtype="section" n="135"><p>
-               <reg>ipse</reg> vero quem ad modum composito<note>compto <hi rend="italics">Bücheler</hi> delibuto <hi rend="italics">A<foreign xml:lang="grc">x1w</foreign>
-                  </hi>
-               </note> et dilibuto capillo passim 
-per forum volitet cum magna caterva togatorum videtis<note>videtis <hi rend="italics">Reid</hi>: et invidetis iudices et unum (inium <foreign xml:lang="grc">S</foreign> 
-                  <hi rend="italics">mg.</hi>) videtis <foreign xml:lang="grc">S</foreign>: etiam videtis iudices <hi rend="italics">cett.: om. B: del. Manutius</hi>: et unum videtis <hi rend="italics">Steinmetz</hi>
-               </note>, iudices; 
+                     <foreign xml:lang="grc">σχψ</foreign>: <hi rend="italics">om. catt.</hi>
+                  </note> officina nequitiae ac<note>
+                     <app>
+                        <lem>ac</lem>
+                     </app> et <foreign xml:lang="grc">φχψ1ω</foreign>
+                  </note> deversorium flagitiorum 
+   omnium.</p>
+            </div>
+            <div type="textpart" subtype="section" n="135">
+               <p>
+                  <reg>ipse</reg> vero quem ad modum composito<note>compto <hi rend="italics">Bücheler</hi> delibuto <hi rend="italics">A<foreign xml:lang="grc">χ1ω</foreign>
+                     </hi>
+                  </note> et dilibuto capillo passim 
+per forum volitet cum magna caterva togatorum videtis<note>videtis <hi rend="italics">Reid</hi>: et invidetis iudices et unum (inium <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">mg.</hi>) videtis <foreign xml:lang="grc">ς</foreign>: etiam videtis iudices <hi rend="italics">cett.: om. B: del. Manutius</hi>: et unum videtis <hi rend="italics">Steinmetz</hi>
+                  </note>, iudices; 
 videtis ut omnis despiciat, ut hominem prae se neminem putet, ut se 
 solum beatum, solum potentem putet.  <reg>quae</reg> vero efficiat et quae 
 conetur si velim commemorare, vereor, iudices, ne quis imperitior 
@@ -2449,26 +2872,32 @@ habuisse a causa nobilitatis existimet.
 
 
             </p>
-         </div>
-         <milestone n="47" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="136"><p>
-               <reg>sciunt</reg> ei qui me norunt me pro mea<note>mea <hi rend="italics">Madvig</hi>: illa <hi rend="italics">codd.</hi>
-               </note> tenui infirmaque
+            </div>
+            <milestone n="47" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="136">
+               <p>
+                  <reg>sciunt</reg> ei qui me norunt me pro mea<note>mea <hi rend="italics">Madvig</hi>: illa <hi rend="italics">codd.</hi>
+                  </note> tenui infirmaque
 
 parte, postea quam id quod maxime volui fieri non potuit, ut 
 componeretur, id maxime defendisse ut ei vincerent qui vicerunt.  
 <reg>quis</reg> enim erat qui non videret humilitatem cum dignitate de<note>dignitate de <hi rend="italics">del. Madvig</hi>
-               </note> 
+                  </note> 
 amplitudine contendere? quo in certamine perditi civis erat non se 
 ad eos iungere quibus incolumibus et domi dignitas et foris auctoritas 
 retineretur.  <reg>quae</reg> perfecta esse et suum cuique honorem et gradum 
 redditum gaudeo, iudices, vehementerque laetor eaque omnia 
 deorum voluntate, studio populi Romani, consilio et imperio et
-felicitate <choice><abbr>L.</abbr><expan>L<ex>ucii</ex></expan></choice> Sullae gesta esse intellego. </p></div> 
-
-<div type="textpart" subtype="section" n="137"><p>
-               <reg>quod</reg> animadversum est 
+felicitate <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucii</ex>
+                     </expan>
+                  </choice> Sullae gesta esse intellego. </p>
+            </div>
+            <div type="textpart" subtype="section" n="137">
+               <p>
+                  <reg>quod</reg> animadversum est 
 in eos qui contra omni ratione pugnarunt, non debeo
 reprehendere; quod viris fortibus quorum opera eximia in rebus 
 gerendis exstitit honos habitus est, laudo.  <reg>quae</reg> ut fierent idcirco 
@@ -2477,48 +2906,53 @@ pugnatum esse arbitror meque in eo studio partium fuisse confiteor.
 postremi pecuniis alienis locupletarentur et in fortunas unius 
 cuiusque impetum facerent, et id non modo re prohibere non licet 
 sed ne verbis quidem vituperare, tum vero in isto<note>
-                  <app><lem>in isto</lem></app> isto <hi rend="italics">w, Garatoni</hi>
-               </note> bello non recreatus 
+                     <app>
+                        <lem>in isto</lem>
+                     </app> isto <hi rend="italics">w, Garatoni</hi>
+                  </note> bello non recreatus 
 neque restitutus sed subactus oppressusque populus
-Romanus est.</p></div>   
-
-<div type="textpart" subtype="section" n="138"><p>
-               <reg>verum</reg> longe aliter est; nil horum est, iudices.  
+Romanus est.</p>
+            </div>
+            <div type="textpart" subtype="section" n="138">
+               <p>
+                  <reg>verum</reg> longe aliter est; nil horum est, iudices.  
 <reg>non</reg> modo non laedetur<note>laedetur <hi rend="italics">Angelius</hi>: laeditur <hi rend="italics">codd.</hi>
-               </note> causa nobilitatis, si istis
+                  </note> causa nobilitatis, si istis
 hominibus resistetis, verum etiam ornabitur. 
-         <milestone n="48" unit="chapter"/><milestone unit="para"/>
-         
-               <reg>etenim</reg> qui haec 
-vituperare volunt<note>volent <foreign xml:lang="grc">Spfw</foreign>
-               </note> Chrysogonum tantum posse queruntur; qui 
+         <milestone n="48" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>etenim</reg> qui haec 
+vituperare volunt<note>volent <foreign xml:lang="grc">σπφω</foreign>
+                  </note> Chrysogonum tantum posse queruntur; qui 
 laudare volunt concessum ei non esse commemorant.  <reg>ac</reg> iam nihil 
-est quod quisquam aut tam stultus aut tam improbus sit qui dicat<note>quid dicat <foreign xml:lang="grc">S</foreign> equidem <hi rend="italics">Siesbeye</hi>
-               </note>:  
+est quod quisquam aut tam stultus aut tam improbus sit qui dicat<note>quid dicat <foreign xml:lang="grc">ς</foreign> equidem <hi rend="italics">Siesbeye</hi>
+                  </note>:  
 '<reg>vellem</reg> quidem liceret; hoc dixissem.' <reg>dicas</reg> licet. '<reg>hoc</reg> fecissem.' 
 <reg>facias</reg> licet; nemo prohibet. '<reg>hoc</reg> decrevissem.'  <reg>decerne</reg>
-               <note>decerne || <foreign xml:lang="grc">S</foreign>: decernere <hi rend="italics">A</hi>
-               </note>,  modo 
+                  <note>decerne || <foreign xml:lang="grc">ς</foreign>: decernere <hi rend="italics">A</hi>
+                  </note>,  modo 
 recte; omnes approbabunt. '<reg>hoc</reg> iudicassem.' <reg>laudabunt</reg> omnes,  si 
-   recte et ordine iudicaris.</p></div>   
-
-<div type="textpart" subtype="section" n="139"><p>
-               <reg>dum</reg> necesse erat resque ipsa cogebat, 
+   recte et ordine iudicaris.</p>
+            </div>
+            <div type="textpart" subtype="section" n="139">
+               <p>
+                  <reg>dum</reg> necesse erat resque ipsa cogebat, 
 unus omnia poterat<note>potuerat <hi rend="italics">A</hi>
-               </note>; qui postea quam
+                  </note>; qui postea quam
 magistratus creavit legesque constituit, sua cuique procuratio 
 auctoritasque est restituta.  <reg>quam</reg> si retinere volunt<note>volent <hi rend="italics">Richter</hi>
-               </note> ei qui 
+                  </note> ei qui 
 reciperarunt in perpetuum poterunt obtinere; sin has caedis et 
 rapinas et hos tantos tamque profusos sumptus aut facient aut 
 approbabunt — nolo in eos gravius quicquam ne ominis<note>ominis <hi rend="italics">Manutius</hi>: hominis <hi rend="italics">codd.</hi>
-               </note> quidem causa 
+                  </note> quidem causa 
 dicere, unum hoc dico: nostri isti nobiles nisi vigilantes et boni et 
 fortes et misericordes erunt, eis hominibus in quibus haec erunt 
-ornamenta sua concedant necesse est. </p></div>  
-
-<div type="textpart" subtype="section" n="140"><p>
-               <reg>quapropter</reg> desinant 
+ornamenta sua concedant necesse est. </p>
+            </div>
+            <div type="textpart" subtype="section" n="140">
+               <p>
+                  <reg>quapropter</reg> desinant 
 aliquando dicere
 male aliquem locutum esse, si qui vere ac libere locutus sit, desinant 
 suam causam cum Chrysogono communicare, desinant, si ille laesus 
@@ -2527,33 +2961,37 @@ sit eos qui equestrem splendorem pati non potuerunt servi
 nequissimi dominationem ferre posse. <reg>quae</reg> quidem dominatio, 
 iudices, in aliis rebus antea versabatur, nunc vero quam viam 
 munitet et quod<note>
-                  <app><lem>et quod</lem></app> quod <foreign xml:lang="grc">y2</foreign>: quo <hi rend="italics">Boemoraeus</hi>
-               </note> iter adfectet<note>quam... adfectet <hi rend="italics">e poeta sumptum esse putavit Gruter</hi>
-               </note> videtis, ad fidem, ad ius iurandum, ad 
+                     <app>
+                        <lem>et quod</lem>
+                     </app> quod <foreign xml:lang="grc">ψ2</foreign>: quo <hi rend="italics">Boemoraeus</hi>
+                  </note> iter adfectet<note>quam... adfectet <hi rend="italics">e poeta sumptum esse putavit Gruter</hi>
+                  </note> videtis, ad fidem, ad ius iurandum, ad 
 iudicia vestra, ad id quod solum prope in civitate sincerum 
 sanctumque
-restat. </p></div> 
-
-<div type="textpart" subtype="section" n="141"><p>hic ne<note>hicine <hi rend="italics">Halm</hi>
-               </note> etiam sese putat aliquid posse Chrysogonus? hicne<note>hicne <hi rend="italics">scripsi</hi>: hic... <foreign xml:lang="grc">S</foreign>: hic <hi rend="italics">cett.</hi>
-               </note> 
+restat. </p>
+            </div>
+            <div type="textpart" subtype="section" n="141">
+               <p>hic ne<note>hicine <hi rend="italics">Halm</hi>
+                  </note> etiam sese putat aliquid posse Chrysogonus? hicne<note>hicne <hi rend="italics">scripsi</hi>: hic... <foreign xml:lang="grc">ς</foreign>: hic <hi rend="italics">cett.</hi>
+                  </note> 
 etiam potens esse volt? O rem miseram atque acerbam! <reg>neque</reg> me 
 hercules hoc indigne fero, quod verear ne quid possit, verum quod 
 ausus est, quod speravit sese apud talis viros aliquid ad perniciem 
-posse<note>posse <foreign xml:lang="grc">xy</foreign>: <hi rend="italics">om. cett. mei</hi> (<hi rend="italics">ante</hi> ad <hi rend="italics">hab. s</hi>): valiturum <hi rend="italics">Halm</hi> (2)</note> innocentis, id ipsum queror.
+posse<note>posse <foreign xml:lang="grc">χψ</foreign>: <hi rend="italics">om. cett. mei</hi> (<hi rend="italics">ante</hi> ad <hi rend="italics">hab. s</hi>): valiturum <hi rend="italics">Halm</hi> (2)</note> innocentis, id ipsum queror.
 
-         <milestone n="49" unit="chapter"/><milestone unit="para"/>
-         
-               <reg>idcircone</reg> exspectata<note>experrecta <hi rend="italics">Angelius</hi>
-               </note> nobilitas armis atque ferro rem publicam 
-reciperavit<note>reciperarit <hi rend="italics">A<foreign xml:lang="grc">y1</foreign>
-                  </hi>
-               </note> ut ad libidinem suam liberti servolique
-nobilium bona fortunas arasque nostras<note>fortunas arasque nostras <hi rend="italics">scripsi</hi> (<hi rend="italics">cf.</hi> §23, <hi rend="italics">dom.</hi> 109, <hi rend="italics">Sest.</hi> 145): fortunas vestrasque nostras <foreign xml:lang="grc">S</foreign>: fortunas vestras atque nostras (vestras nostrasque <foreign xml:lang="grc">sx</foreign>) <hi rend="italics">cett.</hi>: fortunasque nostras <hi rend="italics">Garatoni</hi>
-</note> vexare possent?</p></div> 
-
-<div type="textpart" subtype="section" n="142"><p>
-               <reg>si</reg> id 
+         <milestone n="49" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>idcircone</reg> exspectata<note>experrecta <hi rend="italics">Angelius</hi>
+                  </note> nobilitas armis atque ferro rem publicam 
+reciperavit<note>reciperarit <hi rend="italics">A<foreign xml:lang="grc">ψ1</foreign>
+                     </hi>
+                  </note> ut ad libidinem suam liberti servolique
+nobilium bona fortunas arasque nostras<note>fortunas arasque nostras <hi rend="italics">scripsi</hi> (<hi rend="italics">cf.</hi> §23, <hi rend="italics">dom.</hi> 109, <hi rend="italics">Sest.</hi> 145): fortunas vestrasque nostras <foreign xml:lang="grc">ς</foreign>: fortunas vestras atque nostras (vestras nostrasque <foreign xml:lang="grc">σχ</foreign>) <hi rend="italics">cett.</hi>: fortunasque nostras <hi rend="italics">Garatoni</hi>
+                  </note> vexare possent?</p>
+            </div>
+            <div type="textpart" subtype="section" n="142">
+               <p>
+                  <reg>si</reg> id 
 actum est, fateor me errasse qui hoc maluerim, fateor insanisse qui 
 cum illis senserim; tametsi inermis, iudices, sensi. <reg>sin</reg> autem victoria 
 nobilium ornamento atque emolumento 
@@ -2561,137 +2999,157 @@ rei publicae populoque Romano debet esse, tum vero optimo
 et nobilissimo cuique meam orationem gratissimam esse oportet.  
 <reg>quod</reg> si quis est qui et se et causam laedi putet, cum Chrysogonus 
 vituperetur, is causam ignorat, se ipsum probe<note>probe <hi rend="italics">Madvig</hi>: prope non <hi rend="italics">codd.</hi>
-               </note> novit; causa enim 
+                  </note> novit; causa enim 
 splendidior fiet, si nequissimo cuique resistetur, ille improbissimus 
 Chrysogoni fautor qui sibi cum illo rationem communicatam putat 
 laeditur, cum ab hoc splendore<note>splendor <hi rend="italics">Richter</hi>
-</note> causae separatur.</p></div> 
-
-
-               <div type="textpart" subtype="section" n="143"><p>
-               <reg>verum</reg> haec omnis oratio, ut iam ante dixi, mea est, qua me uti 
+                  </note> causae separatur.</p>
+            </div>
+            <div type="textpart" subtype="section" n="143">
+               <p>
+                  <reg>verum</reg> haec omnis oratio, ut iam ante dixi, mea est, qua me uti 
 res publica et dolor meus et istorum iniuria coegit.
 Sex. Roscius<note>Sex. <hi rend="italics">Madvig</hi>: sed <hi rend="italics">codd.</hi>
-               </note> horum nihil indignum putat, neminem accusat, nihil de 
+                  </note> horum nihil indignum putat, neminem accusat, nihil de 
 suo patrimonio queritur.  <reg>putat</reg> homo imperitus morum, agricola et 
 rusticus, ista omnia quae vos per Sullam gesta esse dicitis more, lege, 
 iure gentium facta; culpa liberatus et crimine nefario solutus cupit a 
-vobis discedere;</p></div>
-
-<div type="textpart" subtype="section" n="144"><p>si hac indigna suspicione careat, animo aequo se carere suis 
+vobis discedere;</p>
+            </div>
+            <div type="textpart" subtype="section" n="144">
+               <p>si hac indigna suspicione careat, animo aequo se carere suis 
 omnibus commodis dicit.  <reg>rogat</reg> oratque te, Chrysogone, si nihil de 
 patris fortunis amplissimis in suam rem convertit, si nulla in re te 
 fraudavit, si tibi optima fide sua omnia concessit, adnumeravit, 
 appendit, si vestitum quo ipse tectus erat anulumque de digito<note>de digito <hi rend="italics">Boemoraeus</hi>: dedit os <hi rend="italics">codd.</hi>
-               </note> suum 
+                  </note> suum 
 tibi tradidit, si ex omnibus rebus se ipsum nudum neque praeterea 
 quicquam excepit, ut sibi per te liceat innocenti amicorum opibus 
-vitam in egestate degere.</p></div>  
-
-         <milestone n="50" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="145"><p>
-               <reg>praedia</reg> mea tu possides, ego aliena 
+vitam in egestate degere.</p>
+            </div>
+            <milestone n="50" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="145">
+               <p>
+                  <reg>praedia</reg> mea tu possides, ego aliena 
 misericordia vivo; concedo, et quod animus aequus est et<note>est et <hi rend="italics">Angelius</hi>: esset <hi rend="italics">codd.</hi>
-               </note> quia 
+                  </note> quia 
 necesse est.  <reg>mea</reg> domus tibi patet, mihi clausa est; fero. <reg>familia</reg> mea 
-maxima tu uteris<note>maxima tu uteris <hi rend="italics">w</hi>: maximat uteris <foreign xml:lang="grc">S</foreign>: maxima uteris <hi rend="italics">cett.</hi>
-               </note>, ego servum habeo nullum; patior et ferendum 
+maxima tu uteris<note>maxima tu uteris <hi rend="italics">w</hi>: maximat uteris <foreign xml:lang="grc">ς</foreign>: maxima uteris <hi rend="italics">cett.</hi>
+                  </note>, ego servum habeo nullum; patior et ferendum 
 puto.  <reg>quid</reg> vis amplius? quid insequeris, quid oppugnas? qua in re 
 tuam voluntatem laedi a me putas? ubi tuis commodis officio? quid 
-tibi obsto? <reg>si</reg> spoliorum causa vis hominem occidere, spoliasti<note>spoliasti <hi rend="italics">om.</hi> 
-                  <foreign xml:lang="grc">x</foreign>
-               </note>; quid
+tibi obsto? <reg>si</reg> spoliorum causa vis hominem occidere, spoliasti<note>spoliasti <hi rend="italics">om.</hi>
+                     <foreign xml:lang="grc">χ</foreign>
+                  </note>; quid
 quaeris amplius? si inimicitiarum, quae sunt tibi inimicitiae cum eo 
 cuius ante praedia possedisti quam ipsum cognosti<note>cognovisti <hi rend="italics">w, Halm</hi>
-               </note>? si metus<note>si metus <hi rend="italics">Madvig</hi>: sin metuis <hi rend="italics">codd.</hi>
-               </note>, ab eone 
+                  </note>? si metus<note>si metus <hi rend="italics">Madvig</hi>: sin metuis <hi rend="italics">codd.</hi>
+                  </note>, ab eone 
 aliquid metuis quem vides ipsum ab se tam atrocem iniuriam 
 propulsare non posse? sin, quod<note>quod <hi rend="italics">Naugerius: om. codd.</hi>
-               </note> bona quae Rosci<note>Sex. Rosci <hi rend="italics">Richter</hi>
-               </note> fuerunt tua facta 
+                  </note> bona quae Rosci<note>Sex. Rosci <hi rend="italics">Richter</hi>
+                  </note> fuerunt tua facta 
 sunt, idcirco hunc illius filium studes perdere, nonne ostendis id te 
-vereri quod praeter ceteros tu metuere non debeas<note>debeas <foreign xml:lang="grc">S</foreign>: debebas <hi rend="italics">Heusinger</hi>
-               </note> ne quando liberis 
-                  proscriptorum bona patria reddantur?</p></div> 
-
-<div type="textpart" subtype="section" n="146"><p>
-               <reg>facis</reg> iniuriam, Chrysogone, si maiorem spem emptionis tuae in 
-huius exitio ponis quam in eis<note>iis <foreign xml:lang="grc">p</foreign>: his <hi rend="italics">cett.</hi>
-               </note> rebus quas <choice><abbr>L.</abbr><expan>L<ex>ucius</ex></expan></choice> Sulla gessit. <reg>quod</reg> si tibi 
+vereri quod praeter ceteros tu metuere non debeas<note>debeas <foreign xml:lang="grc">ς</foreign>: debebas <hi rend="italics">Heusinger</hi>
+                  </note> ne quando liberis 
+                  proscriptorum bona patria reddantur?</p>
+            </div>
+            <div type="textpart" subtype="section" n="146">
+               <p>
+                  <reg>facis</reg> iniuriam, Chrysogone, si maiorem spem emptionis tuae in 
+huius exitio ponis quam in eis<note>iis <foreign xml:lang="grc">π</foreign>: his <hi rend="italics">cett.</hi>
+                  </note> rebus quas <choice>
+                     <abbr>L.</abbr>
+                     <expan>L<ex>ucius</ex>
+                     </expan>
+                  </choice> Sulla gessit. <reg>quod</reg> si tibi 
 causa nulla est cur hunc miserum tanta calamitate adfici velis, si tibi 
-omnia sua praeter<note>praeter <foreign xml:lang="grc">sxy</foreign>: propter <hi rend="italics">cett.</hi>
-               </note> animam tradidit nec sibi quicquam paternum ne 
-monumenti quidem causa reservavit<note>causa reservavit <foreign xml:lang="grc">y2</foreign>: causa clare servavit <hi rend="italics">cett.</hi>: causa clam reservavit <hi rend="italics">pauci dett.</hi>
-               </note>, per deos immortalis! quae ista 
+omnia sua praeter<note>praeter <foreign xml:lang="grc">σχψ</foreign>: propter <hi rend="italics">cett.</hi>
+                  </note> animam tradidit nec sibi quicquam paternum ne 
+monumenti quidem causa reservavit<note>causa reservavit <foreign xml:lang="grc">ψ2</foreign>: causa clare servavit <hi rend="italics">cett.</hi>: causa clam reservavit <hi rend="italics">pauci dett.</hi>
+                  </note>, per deos immortalis! quae ista 
 tanta crudelitas est, quae tam fera immanisque natura? <reg>quis</reg> 
 umquam praedo fuit tam nefarius, quis pirata tam barbarus ut, cum 
 integram praedam sine sanguine habere posset, cruenta
-spolia detrahere mallet?</p></div>   
-
-<div type="textpart" subtype="section" n="147"><p>
-               <reg>scis</reg> hunc nihil habere, nihil audere<note>nihil audere <hi rend="italics">del. Eussner</hi>
-               </note>, 
+spolia detrahere mallet?</p>
+            </div>
+            <div type="textpart" subtype="section" n="147">
+               <p>
+                  <reg>scis</reg> hunc nihil habere, nihil audere<note>nihil audere <hi rend="italics">del. Eussner</hi>
+                  </note>, 
 nihil posse, nihil umquam contra rem tuam cogitasse, et tamen 
 oppugnas eum quem neque metuere potes neque odisse debes nec 
 quicquam iam habere reliqui vides quod ei detrahere possis.  Nisi hoc 
 indignum putas, quod vestitum sedere in iudicio vides quem tu e 
 patrimonio tamquam e naufragio nudum expulisti.  <reg>quasi</reg> vero 
 nescias hunc et ali et vestiri a Caecilia Baliarici<note>Baliarici <hi rend="italics">Manutius</hi>: Baliaris <hi rend="italics">codd.</hi>: Baliarici... sorore <hi rend="italics">del. Garatoni</hi>
-               </note> filia, Nepotis sorore, 
+                  </note> filia, Nepotis sorore, 
 spectatissima femina, quae cum patrem clarissimum<note>clarissimum patrem <hi rend="italics">w, Halm</hi>
-               </note>, amplissimos 
+                  </note>, amplissimos 
 patruos, ornatissimum fratrem haberet, tamen, cum esset mulier, 
 virtute perfecit ut, quanto honore ipsa ex illorum
 dignitate adficeretur, non minora illis ornamenta ex sua laude 
 redderet.</p>
-         </div>
-         <milestone n="51" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="148"><p>
-               <reg>an</reg>, quod diligenter defenditur, id tibi indignum facinus
+            </div>
+            <milestone n="51" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="148">
+               <p>
+                  <reg>an</reg>, quod diligenter defenditur, id tibi indignum facinus
 videtur?  <reg>mihi</reg> crede, si pro patris huius<note>
-                  <app><lem>huius</lem></app> eius <hi rend="italics">Naugerius</hi>
-               </note> hospitiis<note>hospitiis <hi rend="italics">ed. V</hi>: hospitis <hi rend="italics">codd.</hi>
-               </note> et gratia vellent 
+                     <app>
+                        <lem>huius</lem>
+                     </app> eius <hi rend="italics">Naugerius</hi>
+                  </note> hospitiis<note>hospitiis <hi rend="italics">ed. V</hi>: hospitis <hi rend="italics">codd.</hi>
+                  </note> et gratia vellent 
 omnes huic<note>huic <hi rend="italics">Eberhard</hi>: huius <hi rend="italics">codd.</hi>
-               </note> hospites adesse et auderent libere defendere, satis 
+                  </note> hospites adesse et auderent libere defendere, satis 
 copiose defenderetur; sin autem pro magnitudine iniuriae proque eo 
 quod summa res publica in huius periculo temptatur haec omnes 
 vindicarent, consistere me hercule vobis isto in loco non liceret.  <reg>nunc</reg> 
 ita defenditur, non sane ut moleste ferre adversarii debeant neque ut 
 se
-potentia superari putent.</p></div> 
-
-<div type="textpart" subtype="section" n="149"><p>
-               <reg>quae</reg> domi gerenda sunt, ea per 
-Caeciliam transiguntur, fori iudicique rationem <choice><abbr>M.</abbr><expan>M<ex>arcus</ex></expan></choice>
-               <note>M. <hi rend="italics">Garatoni: om. codd.</hi>
-               </note> Messala<note>Messala <hi rend="italics">codd.</hi>: Messalla <hi rend="italics">Lambinus</hi>
-               </note>, ut videtis, 
+potentia superari putent.</p>
+            </div>
+            <div type="textpart" subtype="section" n="149">
+               <p>
+                  <reg>quae</reg> domi gerenda sunt, ea per 
+Caeciliam transiguntur, fori iudicique rationem <choice>
+                     <abbr>M.</abbr>
+                     <expan>M<ex>arcus</ex>
+                     </expan>
+                  </choice>
+                  <note>M. <hi rend="italics">Garatoni: om. codd.</hi>
+                  </note> Messala<note>Messala <hi rend="italics">codd.</hi>: Messalla <hi rend="italics">Lambinus</hi>
+                  </note>, ut videtis, 
 iudices, suscepit; qui, si iam satis aetatis ac<note>
-                  <app><lem>ac</lem></app> atque <hi rend="italics">ed. R</hi>
-               </note> roboris haberet, ipse pro 
+                     <app>
+                        <lem>ac</lem>
+                     </app> atque <hi rend="italics">ed. R</hi>
+                  </note> roboris haberet, ipse pro 
 Sex. Roscio diceret.  <reg>quoniam</reg> ad dicendum impedimento est aetas et 
 pudor qui ornat aetatem causam mihi tradidit quem sua causa 
 cupere ac debere intellegebat, ipse adsiduitate, consilio, auctoritate, 
 diligentia perfecit ut Sex. Rosci vita erepta de manibus sectorum sententiis 
 iudicum permitteretur.  <reg>nimirum</reg>, iudices, pro hac nobilitate 
 pars maxima civitatis in armis fuit; haec acta res est ut ei<note>ut ii <hi rend="italics">Madvig</hi>: uti <hi rend="italics">codd.</hi>
-               </note> nobiles 
+                  </note> nobiles 
 restituerentur in civitatem qui hoc facerent quod facere Messalam 
 videtis, qui caput innocentis defenderent, qui iniuriae resisterent, qui 
 quantum possent in salute alterius quam in exitio mallent ostendere; 
-quod si omnes qui eodem loco nati sunt<note>sunt <foreign xml:lang="grc">sxy</foreign>: sint <hi rend="italics">cett.</hi>
-               </note> facerent, et res publica ex 
+quod si omnes qui eodem loco nati sunt<note>sunt <foreign xml:lang="grc">σχψ</foreign>: sint <hi rend="italics">cett.</hi>
+                  </note> facerent, et res publica ex 
 illis et ipsi ex invidia minus laborarent.
 
 
             </p>
-         </div>
-         <milestone n="52" unit="chapter"/><milestone unit="para"/>
-         
-               <div type="textpart" subtype="section" n="150"><p>
-               <reg>verum</reg> si a 
+            </div>
+            <milestone n="52" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="150">
+               <p>
+                  <reg>verum</reg> si a 
 Chrysogono, iudices, non impetramus ut pecunia nostra 
 contentus sit, vitam ne petat, si ille adduci non potest ut, cum 
 ademerit nobis omnia quae nostra erant propria, ne lucem quoque 
@@ -2699,18 +3157,19 @@ hanc quae communis est eripere cupiat, si
 non satis habet avaritiam suam pecunia explere, nisi etiam 
 crudelitati sanguis praebitus<note>crudelitati sanguis praebitus <hi rend="italics">Madvig</hi>: crudelitate (-i <hi rend="italics">A</hi>) sanguinis praeditus <hi rend="italics">codd.: fort.</hi> crudelitati sanguine perlitatum</note> sit, unum perfugium, iudices, una spes 
 reliqua est Sex. Roscio eadem quae<note>eadem quae <hi rend="italics">Naugerius</hi> (2): eademque <hi rend="italics">codd.</hi>
-               </note> rei publicae, vestra pristina 
+                  </note> rei publicae, vestra pristina 
 bonitas et misericordia.  <reg>quae</reg> si manet, salvi etiam nunc esse 
 possumus; sin ea crudelitas quae hoc tempore in re<note>in re p. <hi rend="italics">ed. Mediol.</hi>: in rem p. <hi rend="italics">codd.</hi>
-               </note> publica versata 
+                  </note> publica versata 
 est vestros quoque animos — id quod fieri profecto non potest — 
-duriores acerbioresque reddit<note>reddidit <foreign xml:lang="grc">y</foreign>
-               </note>, actum est, iudices; inter feras satius 
+duriores acerbioresque reddit<note>reddidit <foreign xml:lang="grc">ψ</foreign>
+                  </note>, actum est, iudices; inter feras satius 
 est aetatem degere quam
-in hac tanta immanitate versari.</p></div> 
-
-<div type="textpart" subtype="section" n="151"><p>
-               <reg>ad</reg> eamne rem vos reservati 
+in hac tanta immanitate versari.</p>
+            </div>
+            <div type="textpart" subtype="section" n="151">
+               <p>
+                  <reg>ad</reg> eamne rem vos reservati 
 estis, ad eamne rem delecti ut eos condemnaretis quos sectores ac 
 sicarii iugulare non potuissent? <reg>solent</reg> hoc boni imperatores facere 
 cum proelium committunt, ut in eo loco quo fugam hostium fore 
@@ -2718,46 +3177,54 @@ arbitrentur milites conlocent, in quos si qui ex acie fugerint de
 improviso incidant.  <reg>nimirum</reg> similiter arbitrantur isti bonorum 
 emptores vos hic, talis viros, sedere qui excipiatis eos qui de suis 
 manibus effugerint. <reg>di</reg> prohibeant, iudices, ne<note>ne <hi rend="italics">Whitte</hi>: ut <hi rend="italics">codd.</hi>
-               </note> hoc quod maiores 
+                  </note> hoc quod maiores 
 consilium publicum vocari voluerunt praesidium sectorum 
-existimetur!</p></div> 
-
-<div type="textpart" subtype="section" n="152"><p>
-               <reg>an</reg> vero, iudices, vos non intellegitis<note>intellegetis <foreign xml:lang="grc">S</foreign>
-                  <hi rend="italics">A</hi>
-               </note> nihil aliud agi nisi ut 
+existimetur!</p>
+            </div>
+            <div type="textpart" subtype="section" n="152">
+               <p>
+                  <reg>an</reg> vero, iudices, vos non intellegitis<note>intellegetis <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italics">A</hi>
+                  </note> nihil aliud agi nisi ut 
 proscriptorum liberi quavis ratione tollantur, et eius rei initium in 
 vestro iure iurando atque in Sex. Rosci periculo quaeri?  Dubium<note>dubiumne <hi rend="italics">w</hi>
-               </note> est 
+                  </note> est 
 ad quem maleficium pertineat, cum videatis ex altera parte sectorem, 
 inimicum, sicarium eundemque accusatorem hoc tempore, ex altera 
 parte egentem, probatum suis filium, in quo non modo culpa nulla 
 sed ne suspicio quidem potuit consistere?  <reg>numquid</reg> hic<note>
-                  <app><lem>hic</lem></app> huic <hi rend="italics">Madvig</hi>
-               </note> aliud videtis 
+                     <app>
+                        <lem>hic</lem>
+                     </app> huic <hi rend="italics">Madvig</hi>
+                  </note> aliud videtis 
 obstare Roscio<note>
-                  <app><lem>Roscio</lem></app> Sex. Roscio <hi rend="italics">Halm: del. Madvig</hi>
-               </note> nisi quod patris bona venierunt?
+                     <app>
+                        <lem>Roscio</lem>
+                     </app> Sex. Roscio <hi rend="italics">Halm: del. Madvig</hi>
+                  </note> nisi quod patris bona venierunt?
 
 </p>
-         </div>
-         <milestone n="53" unit="chapter"/><milestone unit="para"/>
-               <div type="textpart" subtype="section" n="153"><p>
-               <reg>quod</reg> si id vos suscipitis et eam ad rem<note>eam ad rem <hi rend="italics">Gulielmius</hi>: eadem (eandem <foreign xml:lang="grc">fx</foreign>) rem (esse <hi rend="italics">A</hi>) <hi rend="italics">codd.</hi>: ea de re <hi rend="italics">Reid</hi>
-               </note> operam vestram
+            </div>
+            <milestone n="53" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="153">
+               <p>
+                  <reg>quod</reg> si id vos suscipitis et eam ad rem<note>eam ad rem <hi rend="italics">Gulielmius</hi>: eadem (eandem <foreign xml:lang="grc">φχ</foreign>) rem (esse <hi rend="italics">A</hi>) <hi rend="italics">codd.</hi>: ea de re <hi rend="italics">Reid</hi>
+                  </note> operam vestram
 profitemini, si idcirco sedetis ut ad vos adducantur eorum liberi 
 quorum bona venierunt, cavete, per deos immortalis! iudices, ne 
 nova et multo crudelior per vos proscriptio instaurata esse videatur.  
 <reg>illam</reg> priorem quae facta est in eos qui arma capere potuerunt 
 tamen senatus suscipere noluit, ne quid acrius quam more maiorum 
 comparatum est<note>est <hi rend="italics">ed. R: om. codd.</hi>: esset <hi rend="italics">Rinkes</hi>
-               </note> publico consilio factum videretur, hanc vero quae ad 
+                  </note> publico consilio factum videretur, hanc vero quae ad 
 eorum liberos atque ad infantium puerorum incunabula pertinet nisi 
 hoc iudicio a vobis reicitis et aspernamini, videte, per deos immortalis! 
-quem in locum rem publicam perventuram putetis!</p></div> 
-
-<div type="textpart" subtype="section" n="154"><p>
-               <reg>homines</reg> sapientes et ista auctoritate et potestate praeditos 
+quem in locum rem publicam perventuram putetis!</p>
+            </div>
+            <div type="textpart" subtype="section" n="154">
+               <p>
+                  <reg>homines</reg> sapientes et ista auctoritate et potestate praeditos 
 qua  vos estis ex quibus rebus maxime res publica laborat, eis maxime 
 mederi convenit. <reg>vestrum</reg> nemo est quin intellegat populum 
 Romanum qui quondam in hostis lenissimus existimabatur hoc 
@@ -2769,8 +3236,8 @@ incommodorum.  <reg>nam</reg> cum omnibus horis aliquid atrociter fieri
 videmus aut audimus, etiam qui natura mitissimi sumus adsiduitate 
 molestiarum sensum omnem humanitatis ex animis amittimus.
 </p>
+            </div>
          </div>
-         </div> 
       </body>
    </text>
 </TEI>

--- a/data/phi0474/phi007/phi0474.phi007.perseus-lat2.xml
+++ b/data/phi0474/phi007/phi0474.phi007.perseus-lat2.xml
@@ -1,115 +1,127 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-	<teiHeader xml:lang="eng">
-		<fileDesc>
-			<titleStmt>
-				<title type="work">On Behalf Of Marcus Fonteius</title>
-				<title>Pro Tullio, Pro Fonteio, Pro Sulla, Pro Archia, Pro Plancio, Pro
+   <teiHeader xml:lang="eng">
+      <fileDesc>
+         <titleStmt>
+            <title type="work">On Behalf Of Marcus Fonteius</title>
+            <title>Pro Tullio, Pro Fonteio, Pro Sulla, Pro Archia, Pro Plancio, Pro
 					Scauro</title>
-				<title type="sub">Machine readable text</title>
-				<author n="M. Tullius Cicero">M. Tullius Cicero</author>
-				<editor role="editor" n="OCT">Albert Clark</editor>
-				<sponsor>Perseus Project, Tufts University</sponsor>
-				<principal>Gregory Crane</principal>
-				<respStmt>
-					<resp>Prepared under the supervision of</resp>
-					<name>Bridget Almas</name>
-					<name>Lisa Cerrato</name>
-					<name>William Merrill</name>
-					<name>David Mimno</name>
-					<name>Rashmi Singhal</name>
-					<name>David Smith</name>
-				</respStmt>
-				<funder n="org:NEH">National Endowment For The Humanities (NEH)</funder> 
-			</titleStmt>
-			<publicationStmt>
-				<publisher>Trustees of Tufts University</publisher>
-				<pubPlace>Medford, MA</pubPlace>
-				<authority>Perseus Project</authority>
-				<date type="release">1997-10-28</date>
-			</publicationStmt> 
-			
-			<sourceDesc>
-				<biblStruct>
-					<monogr>
-						<author>M. Tullius Cicero</author>
-						<title>M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica
+            <title type="sub">Machine readable text</title>
+            <author n="M. Tullius Cicero">M. Tullius Cicero</author>
+            <editor role="editor" n="OCT">Albert Clark</editor>
+            <sponsor>Perseus Project, Tufts University</sponsor>
+            <principal>Gregory Crane</principal>
+            <respStmt>
+               <resp>Prepared under the supervision of</resp>
+               <name>Bridget Almas</name>
+               <name>Lisa Cerrato</name>
+               <name>William Merrill</name>
+               <name>David Mimno</name>
+               <name>Rashmi Singhal</name>
+               <name>David Smith</name>
+            </respStmt>
+            <funder n="org:NEH">National Endowment For The Humanities (NEH)</funder>
+         </titleStmt>
+         <publicationStmt>
+            <publisher>Trustees of Tufts University</publisher>
+            <pubPlace>Medford, MA</pubPlace>
+            <authority>Perseus Project</authority>
+            <date type="release">1997-10-28</date>
+         </publicationStmt>
+         <sourceDesc>
+            <biblStruct>
+               <monogr>
+                  <author>M. Tullius Cicero</author>
+                  <title>M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica
 							instruxit Albertus Curtis Clark</title>
-						<editor role="editor">Albert Clark</editor>
-						<imprint>
-							<pubPlace>Oxonii</pubPlace>
-							<publisher>e Typographeo Clarendoniano</publisher>
-							<date>1909</date>
-						</imprint>
-					</monogr>
-					<series>
-						<title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
-					</series>
-				</biblStruct>
-			</sourceDesc>
-		</fileDesc>
-		
-		<encodingDesc>
-			<refsDecl n="CTS">
-				<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
-					<p>This pointer pattern extracts section</p>
-				</cRefPattern>
-			</refsDecl>
-			<refsDecl>
-				<refState unit="section"/>
-			</refsDecl>
-		</encodingDesc>
-		
-		<profileDesc>
-			<langUsage>
-				<language ident="lat">Latin</language>
-				<language ident="grc">Greek</language>
-			</langUsage>
-		</profileDesc>
-		
-		<revisionDesc>
-			<change when="2016-04-19" who="Lisa Cerrato">Minor edits and cleanup.</change>
-			<change when="2015-12-17" who="Zach Himes">Cleaned up teiHeader. Converted to TEI P5 and EpiDoc.</change>
-			<change when="2014-08-01" who="Stella Dee">edited markup</change>
-			<change when="2014-07-01" who="Stella Dee">split composite text and converted to unicode</change>
-			<change when="2013-09-13" who="balmas01">reverting texts back to pre_cts_reorg tagged version</change>
-			<change when="2011-07-19" who="gcrane">removed the earlier persName/placeName tags</change>
-			<change when="2011-01-15" who="gcrane">base SDL file</change>
-			<change when="2009-10-09" who="rsingh04">more reorganizing of texts module by collection</change>
-			<change when="2006-08-11" who="gcrane">small mods</change>
-			<change when="2006-04-21" who="gcrane">these now have the app crit entered as notes</change>
-			<change when="2005-08-01" who="packel">removed stray item tags</change>
-			<change when="2005-07-25" who="packel">Converted to XML</change>
-			<change when="2005-04-08" who="mimno">added default chunks</change>
-			<change when="2003-07-01" who="yorkc">Updated texts to TEI P4 and Perseus P4 extensions; minor cleanup (esp. character encodings and typos.)</change>
-			<change when="2002-12-02" who="amahoney">correct spelling of Quirites, improperly 'regularized'</change>
-			<change when="2000-03-04" who="dasmith">Added separate funder entity to TEI header.</change>
-			<change when="1999-10-14" who="dasmith">Added explanatory subtitles to titleStmt</change>
-			<change when="1999-08-12" who="dasmith">Fixed refsDecl</change>
-			<change when="1999-08-04" who="textgod">Random changes over a period of months.</change>
-			<change when="1997-10-17" who="textgod">Added CVS log.</change>
-			<change when="1997-03-26" who="DAS">ed.</change>
-		</revisionDesc>
-	</teiHeader>	
-<text>
-		<body><div type="edition" xml:lang="lat" n="urn:cts:latinLit:phi0474.phi007.perseus-lat2" subtype="edition">
-			<head>PRO M. FONTEIO ORATIO</head>
-			<milestone n="1" unit="chapter"/>
-				<div type="textpart" subtype="section" n="1"><p>
-			<milestone unit="para"/>
-				<gap reason="lost"/>
-				<add>o</add>portuisse an ita dissolvit ut omnes alii dissolverunt? <reg>nam</reg>
+                  <editor role="editor">Albert Clark</editor>
+                  <imprint>
+                     <pubPlace>Oxonii</pubPlace>
+                     <publisher>e Typographeo Clarendoniano</publisher>
+                     <date>1909</date>
+                  </imprint>
+               </monogr>
+               <series>
+                  <title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
+               </series>
+            </biblStruct>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <refsDecl n="CTS">
+            <cRefPattern n="section"
+                         matchPattern="(\w+)"
+                         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+               <p>This pointer pattern extracts section</p>
+            </cRefPattern>
+         </refsDecl>
+         <refsDecl>
+            <refState unit="section"/>
+         </refsDecl>
+      </encodingDesc>
+      <profileDesc>
+         <langUsage>
+            <language ident="lat">Latin</language>
+            <language ident="grc">Greek</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2016-04-19" who="Lisa Cerrato">Minor edits and cleanup.</change>
+         <change when="2015-12-17" who="Zach Himes">Cleaned up teiHeader. Converted to TEI P5 and EpiDoc.</change>
+         <change when="2014-08-01" who="Stella Dee">edited markup</change>
+         <change when="2014-07-01" who="Stella Dee">split composite text and converted to unicode</change>
+         <change when="2013-09-13" who="balmas01">reverting texts back to pre_cts_reorg tagged version</change>
+         <change when="2011-07-19" who="gcrane">removed the earlier persName/placeName tags</change>
+         <change when="2011-01-15" who="gcrane">base SDL file</change>
+         <change when="2009-10-09" who="rsingh04">more reorganizing of texts module by collection</change>
+         <change when="2006-08-11" who="gcrane">small mods</change>
+         <change when="2006-04-21" who="gcrane">these now have the app crit entered as notes</change>
+         <change when="2005-08-01" who="packel">removed stray item tags</change>
+         <change when="2005-07-25" who="packel">Converted to XML</change>
+         <change when="2005-04-08" who="mimno">added default chunks</change>
+         <change when="2003-07-01" who="yorkc">Updated texts to TEI P4 and Perseus P4 extensions; minor cleanup (esp. character encodings and typos.)</change>
+         <change when="2002-12-02" who="amahoney">correct spelling of Quirites, improperly 'regularized'</change>
+         <change when="2000-03-04" who="dasmith">Added separate funder entity to TEI header.</change>
+         <change when="1999-10-14" who="dasmith">Added explanatory subtitles to titleStmt</change>
+         <change when="1999-08-12" who="dasmith">Fixed refsDecl</change>
+         <change when="1999-08-04" who="textgod">Random changes over a period of months.</change>
+         <change when="1997-10-17" who="textgod">Added CVS log.</change>
+         <change when="1997-03-26" who="DAS">ed.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <div type="edition"
+              xml:lang="lat"
+              n="urn:cts:latinLit:phi0474.phi007.perseus-lat2"
+              subtype="edition">
+            <head>PRO M. FONTEIO ORATIO</head>
+            <milestone n="1" unit="chapter"/>
+            <div type="textpart" subtype="section" n="1">
+               <p>
+                  <milestone unit="para"/>
+                  <gap reason="lost"/>
+                  <add>o</add>portuisse an ita dissolvit ut omnes alii dissolverunt? <reg>nam</reg>
 				ita ego defendo M. Fonteium, iudices, itaque contendo post legem Valeriam
-						latam<note><app><lem>latam</lem></app> a Metello <hi rend="italic">suppl.
-						Mommsen</hi></note>
-				<gap reason="lost"/> te <gap reason="lost"/> quaestore usque ad T. Crispinum quaestorem aliter neminem solvisse;
+						latam<note>
+                     <app>
+                        <lem>latam</lem>
+                     </app> a Metello <hi rend="italic">suppl.
+						Mommsen</hi>
+                  </note>
+                  <gap reason="lost"/> te <gap reason="lost"/> quaestore usque ad T. Crispinum quaestorem aliter neminem solvisse;
 				hunc omnium superiorum, huius autem omnis qui postea fuerint auctoritatem dico
-				secutos. </p></div>
-				<div type="textpart" subtype="section" n="2"><p><reg>quid</reg> accusas, quid reprendis?
+				secutos. </p>
+            </div>
+            <div type="textpart" subtype="section" n="2">
+               <p>
+                  <reg>quid</reg> accusas, quid reprendis?
 					<reg>nam</reg> quod in tabulis dodrantariis et quadrantariis, quas ait ab
 				Hirtuleio institutas, Fontei officium desiderat, non possum<note>possimus <hi rend="italic">Cus. m.</hi> 1: <hi rend="italic">corr. m.</hi> 2</note>
-				existimare utrum ipse erret an vos<note>vos <hi rend="italic">P</hi>: alios <hi rend="italic">Cus.</hi></note> in errorem inducere<note>inducere <hi rend="italic">Madvig</hi>: induci (<hi rend="italic">ex</hi> -ici) <hi rend="italic">Cus.</hi>: ducere <hi rend="italic">P</hi></note> velit.
+				existimare utrum ipse erret an vos<note>vos <hi rend="italic">P</hi>: alios <hi rend="italic">Cus.</hi>
+                  </note> in errorem inducere<note>inducere <hi rend="italic">Madvig</hi>: induci (<hi rend="italic">ex</hi> -ici) <hi rend="italic">Cus.</hi>: ducere <hi rend="italic">P</hi>
+                  </note> velit.
 					<reg>quaero</reg> enim abs te, M. Plaetori, possitne tibi ipsi probata esse
 				nostra causa, si, qua in re abs te M. Fonteius accusatur, auctorem habet eum quem tu
 				maxime laudas Hirtuleium; qua in re autem laudas Hirtuleium, Fonteius idem fecisse
@@ -118,21 +130,38 @@
 				tabulas instituerit; easdem Fonteius instituit et eodem genere pecuniae.
 					<reg>nam</reg> ne forte sis nescius et istas tabulas existimes <add>a</add>d
 					<add>diversam v</add>e<add>te</add>ris<note>diversam <hi rend="italic">suppl.
-						Niebuhr</hi></note> aeris alieni rationem pertinere, ob unam causam et in
+						Niebuhr</hi>
+                  </note> aeris alieni rationem pertinere, ob unam causam et in
 				uno genere sunt institutae. <reg>nam</reg> cum publicanis qui Africam, qui
-					Aquileiense<note>Aquilei. <hi rend="italic">Mommsen</hi>: Aquili. <hi rend="italic">P</hi></note> por<add>torium</add><note>por <hi rend="italic">P</hi>: <hi rend="italic">suppl. Niebuhr</hi></note>
-				<gap reason="lost"/>
-				</p></div><milestone n="2" unit="chapter"/>
-				<div type="textpart" subtype="section" n="3"><p>
-			<milestone unit="para"/>
-				<gap reason="lost"/> cite<note><app><lem>cite</lem></app> recitet <hi rend="italic">Niebuhr</hi></note>
-				<gap reason="lost"/>
-				<reg>nemo</reg>, nemo, inquam, iudices, reperietur qui unum se in quaestura M.
+					Aquileiense<note>Aquilei. <hi rend="italic">Mommsen</hi>: Aquili. <hi rend="italic">P</hi>
+                  </note> por<add>torium</add>
+                  <note>por <hi rend="italic">P</hi>: <hi rend="italic">suppl. Niebuhr</hi>
+                  </note>
+                  <gap reason="lost"/>
+               </p>
+            </div>
+            <milestone n="2" unit="chapter"/>
+            <div type="textpart" subtype="section" n="3">
+               <p>
+                  <milestone unit="para"/>
+                  <gap reason="lost"/> cite<note>
+                     <app>
+                        <lem>cite</lem>
+                     </app> recitet <hi rend="italic">Niebuhr</hi>
+                  </note>
+                  <gap reason="lost"/>
+                  <reg>nemo</reg>, nemo, inquam, iudices, reperietur qui unum se in quaestura M.
 				Fonteio nummum dedisse, aut illum ex ea pecunia quae pro aerario solveretur
 				detraxisse dicat; nullius in tabulis ulla huius furti significatio, nullum in eis
 				nominibus intertrimenti aut deminutionis vestigium reperietur. <reg>atqui</reg>
-						homines<note><app><lem>homines</lem></app> omnes <hi rend="italic">Niebuhr</hi></note>, si qui in<note>in <hi rend="italic">sup. lin. hab.
-					P</hi></note> hoc genere quaestionis accusati sunt<note>accusati sunt <hi rend="italic">Madvig</hi>: accusatos <hi rend="italic">P</hi></note>,
+						homines<note>
+                     <app>
+                        <lem>homines</lem>
+                     </app> omnes <hi rend="italic">Niebuhr</hi>
+                  </note>, si qui in<note>in <hi rend="italic">sup. lin. hab.
+					P</hi>
+                  </note> hoc genere quaestionis accusati sunt<note>accusati sunt <hi rend="italic">Madvig</hi>: accusatos <hi rend="italic">P</hi>
+                  </note>,
 				reprehensos videmus primum testibus; difficile est enim eum qui magistratui pecuniam
 				dederit non aut induci odio ut dicat aut cogi religione; deinde si qua gratia testes
 				deterrentur, tabulae quidem certe incorruptae atque integrae manent. <reg>fac</reg>
@@ -142,14 +171,20 @@
 				fingatur, aut surripiatur, aut non constet, appareat. <reg>acceptas</reg> populo
 				Romano pecunias omnis isti rettulerunt; si protinus aliis aeque magnas aut solverunt
 				aut dederunt, ut, quod acceptum populo Romano est, id expensum cuipiam sit, certe
-				nihil potest esse detractum. <reg>sin</reg> aliquid<note>aliqui <hi rend="italic">P</hi>: <hi rend="italic">corr. Mommsen</hi></note> domum tulerunt, ex
+				nihil potest esse detractum. <reg>sin</reg> aliquid<note>aliqui <hi rend="italic">P</hi>: <hi rend="italic">corr. Mommsen</hi>
+                  </note> domum tulerunt, ex
 				eorum arca, e ra<note>ra <hi rend="italic">P</hi>: rationibus <hi rend="italic">Niebuhr</hi> (accepti et expensi constabit <hi rend="italic">suppl.
 						Mommsen</hi>)</note>
-				<gap reason="lost"/>
-				</p></div><milestone n="3" unit="chapter"/>
-				<div type="textpart" subtype="section" n="4"><p>
-			<milestone unit="para"/><reg>deorum</reg> hominumque fidem! testis non invenitur in ducentiens<note>ducentis
-						<hi rend="italic">P</hi>: <hi rend="italic">corr. Mommsen</hi></note> et
+                  <gap reason="lost"/>
+               </p>
+            </div>
+            <milestone n="3" unit="chapter"/>
+            <div type="textpart" subtype="section" n="4">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>deorum</reg> hominumque fidem! testis non invenitur in ducentiens<note>ducentis
+						<hi rend="italic">P</hi>: <hi rend="italic">corr. Mommsen</hi>
+                  </note> et
 				triciens sestertio! <reg>quam</reg> multorum hominum? <reg>sescentorum</reg>
 				amplius. <reg>quibus</reg> in terris gestum negotium est? <reg>illo</reg>, illo,
 				inquam, loco quem videtis. <reg>extra</reg> ordinemne pecunia est data?
@@ -158,468 +193,894 @@
 				possit A<add>l</add>pis quam paucos aerari gradus ascendere, diligentius Rutenorum
 				quam populi Romani defendat aerarium, libentius ignotis quam notis utatur,
 				alienigenis quam domesticis testibus, planius se confirmare crimen libidine
-				barbarorum quam nostrorum hominum litteris arbitretur? </p></div>
-				<div type="textpart" subtype="section" n="5"><p><reg>duorum</reg> magistratuum, quorum uterque in pecunia maxima
+				barbarorum quam nostrorum hominum litteris arbitretur? </p>
+            </div>
+            <div type="textpart" subtype="section" n="5">
+               <p>
+                  <reg>duorum</reg> magistratuum, quorum uterque in pecunia maxima
 				tractanda procurandaque versatus est, triumviratus et quaesturae, ratio sic
 				redditur, iudices, ut in eis rebus quae ante oculos gestae sunt, ad
 				mu<add>l</add>tos pertinuerunt, confectae publicis privatisque tabulis
 					sunt<note>sint <hi rend="italic">P</hi>: <hi rend="italic">corr.
-					Niebuhr</hi></note>, nulla significatio furti, nulla alicuius delicti suspicio
-					reperiatur<note>reperiatur <hi rend="italic">Madvig</hi>: referatur <hi rend="italic">P</hi>: proferatur <hi rend="italic">Kayser</hi></note>.
-					</p></div>
-				<div type="textpart" subtype="section" n="6"><p>Hispaniensis legatio consecuta est
+					Niebuhr</hi>
+                  </note>, nulla significatio furti, nulla alicuius delicti suspicio
+					reperiatur<note>reperiatur <hi rend="italic">Madvig</hi>: referatur <hi rend="italic">P</hi>: proferatur <hi rend="italic">Kayser</hi>
+                  </note>.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="6">
+               <p>Hispaniensis legatio consecuta est
 				turbulentissimo rei publicae tempore, cum adventu L. Sullae maximi exercitus in
-					Italiam<note>Italia <hi rend="italic">Niebuhr</hi></note> cives vi<note>cives
-					vi <hi rend="italic">scripsi</hi>: civium <hi rend="italic">P</hi></note>
-				dissiderent, <add>non</add><note>non <hi rend="italic">suppl. Schenkl</hi></note>
-				iudiciis ac legibus; atque hoc rei publicae statu desperato qualis <gap reason="lost"/></p></div>
-	<milestone n="4" unit="chapter"/>
-			<milestone unit="para"/><div type="textpart" subtype="section" n="7"><p><reg>si</reg> nulla pecunia numerata est, cuius pecuniae quinquagesima est?</p></div>			
-			<milestone unit="para"/><div type="textpart" subtype="section" n="8"><p><reg>frumenti</reg><note>frumenti <hi rend="italic">om. Mart. Cap.</hi></note> maximus numerus e Gallia, peditatus amplissimae copiae e Gallia, equites numero plurimi e Gallia.</p></div>
-		<milestone unit="para"/><div type="textpart" subtype="section" n="9"><p>Gallos post haec dilutius esse poturos, quod illi venenum esse
-					arbitrabuntur<note>arbitrabantur <hi rend="italic">codd. Ammiani</hi>: <hi rend="italic">corr. Bentley</hi></note>. </p></div>
-			<milestone unit="para"/><div type="textpart" subtype="section" n="10"><p>Plaetori matrem dum vixisset ludum, postquam mortua esset magistros habuisse.</p></div>
-			<milestone n="5" unit="chapter"/>
-				<div type="textpart" subtype="section" n="11"><p>
-			<milestone unit="para"/>
-				<gap reason="lost"/> hoc praetore oppressam esse aere alieno<note>aere alieno <foreign xml:lang="grc">s</foreign>: alieniso <hi rend="italic">V</hi></note>
-				Galliam. A quibus versuras tantarum pecuniarum factas<note>factas <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: tactas <hi rend="italic">V</hi>: tractas <hi rend="italic">k</hi></note> esse dicunt? a Gallis?
+					Italiam<note>Italia <hi rend="italic">Niebuhr</hi>
+                  </note> cives vi<note>cives
+					vi <hi rend="italic">scripsi</hi>: civium <hi rend="italic">P</hi>
+                  </note>
+				dissiderent, <add>non</add>
+                  <note>non <hi rend="italic">suppl. Schenkl</hi>
+                  </note>
+				iudiciis ac legibus; atque hoc rei publicae statu desperato qualis <gap reason="lost"/>
+               </p>
+            </div>
+            <milestone n="4" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="7">
+               <p>
+                  <reg>si</reg> nulla pecunia numerata est, cuius pecuniae quinquagesima est?</p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="8">
+               <p>
+                  <reg>frumenti</reg>
+                  <note>frumenti <hi rend="italic">om. Mart. Cap.</hi>
+                  </note> maximus numerus e Gallia, peditatus amplissimae copiae e Gallia, equites numero plurimi e Gallia.</p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="9">
+               <p>Gallos post haec dilutius esse poturos, quod illi venenum esse
+					arbitrabuntur<note>arbitrabantur <hi rend="italic">codd. Ammiani</hi>: <hi rend="italic">corr. Bentley</hi>
+                  </note>. </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="10">
+               <p>Plaetori matrem dum vixisset ludum, postquam mortua esset magistros habuisse.</p>
+            </div>
+            <milestone n="5" unit="chapter"/>
+            <div type="textpart" subtype="section" n="11">
+               <p>
+                  <milestone unit="para"/>
+                  <gap reason="lost"/> hoc praetore oppressam esse aere alieno<note>aere alieno <foreign xml:lang="grc">ς</foreign>: alieniso <hi rend="italic">V</hi>
+                  </note>
+				Galliam. A quibus versuras tantarum pecuniarum factas<note>factas <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: tactas <hi rend="italic">V</hi>: tractas <hi rend="italic">k</hi>
+                  </note> esse dicunt? a Gallis?
 					<reg>nihil</reg> minus. A quibus igitur? A civibus Romanis qui negotiantur in
-				Gallia. <reg>cur</reg> eorum verba <add>non</add><note>non <foreign xml:lang="grc">s</foreign>: <hi rend="italic">om. V</hi></note> audimus? cur eorum
+				Gallia. <reg>cur</reg> eorum verba <add>non</add>
+                  <note>non <foreign xml:lang="grc">ς</foreign>: <hi rend="italic">om. V</hi>
+                  </note> audimus? cur eorum
 				tabulae nullae proferuntur? <reg>insector</reg> ultro atque insto accusatori,
-				iudices; insector, inquam, et flagito<note>flagitio <hi rend="italic">V<foreign xml:lang="grc">x1</foreign></hi></note> testis. <reg>plus</reg> ego in
+				iudices; insector, inquam, et flagito<note>flagitio <hi rend="italic">V<foreign xml:lang="grc">χ1</foreign>
+                     </hi>
+                  </note> testis. <reg>plus</reg> ego in
 				hac causa laboris et operae consumo in poscendis testibus quam ceteri defensores in
-				refutandis. <reg>audaciter</reg><note>audaciter <hi rend="italic">V</hi>: audacter
-						<foreign xml:lang="grc">s</foreign></note> hoc dico, iudices, non temere
+				refutandis. <reg>audaciter</reg>
+                  <note>audaciter <hi rend="italic">V</hi>: audacter
+						<foreign xml:lang="grc">ς</foreign>
+                  </note> hoc dico, iudices, non temere
 				confirmo. Referta Gallia negotiatorum est, plena civium Romanorum. <reg>nemo</reg>
 				Gallorum sine cive Romano quicquam negoti gerit, nummus in Gallia nullus sine civium
-				Romanorum tabulis commovetur. </p></div>
-				<div type="textpart" subtype="section" n="12"><p><reg>videte</reg>
+				Romanorum tabulis commovetur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="12">
+               <p>
+                  <reg>videte</reg>
 				quo descendam, iudices, quam longe videar ab consuetudine mea et cautione ac
-				diligentia discedere. Vnae<note>unae <foreign xml:lang="grc">s</foreign>: una <hi rend="italic">V</hi></note> tabulae proferantur, in quibus vestigium sit
-				aliquod quod significet pecuniam <add>M.</add><note>M. <hi rend="italic">suppl.
-						Baiter</hi></note> Fonteio datam, unum<note>unum <foreign xml:lang="grc">s</foreign>: unam <hi rend="italic">V</hi></note> ex tot<note>tot <hi rend="italic">Gulielmius</hi>: toto <hi rend="italic">codd.</hi>: tanto
-						<hi rend="italic">Halm</hi></note> negotiatorum, colonorum, publicanorum,
-				aratorum, pecuariorum numero testem producant<note>producant <foreign xml:lang="grc">s</foreign>: producantur <hi rend="italic">V</hi></note>; vere accusatum
-				esse concedam. <reg>pro</reg> di immortales! quae haec est<note>est haec <foreign xml:lang="grc">x</foreign></note> causa, quae defensio?
+				diligentia discedere. Vnae<note>unae <foreign xml:lang="grc">ς</foreign>: una <hi rend="italic">V</hi>
+                  </note> tabulae proferantur, in quibus vestigium sit
+				aliquod quod significet pecuniam <add>M.</add>
+                  <note>M. <hi rend="italic">suppl.
+						Baiter</hi>
+                  </note> Fonteio datam, unum<note>unum <foreign xml:lang="grc">ς</foreign>: unam <hi rend="italic">V</hi>
+                  </note> ex tot<note>tot <hi rend="italic">Gulielmius</hi>: toto <hi rend="italic">codd.</hi>: tanto
+						<hi rend="italic">Halm</hi>
+                  </note> negotiatorum, colonorum, publicanorum,
+				aratorum, pecuariorum numero testem producant<note>producant <foreign xml:lang="grc">ς</foreign>: producantur <hi rend="italic">V</hi>
+                  </note>; vere accusatum
+				esse concedam. <reg>pro</reg> di immortales! quae haec est<note>est haec <foreign xml:lang="grc">χ</foreign>
+                  </note> causa, quae defensio?
 					<reg>provinciae</reg> Galliae M. Fonteius praefuit, quae constat ex eis
 				generibus hominum et civitatum qui, ut vetera mittam, partim nostra memoria bella
-				cum populo Romano acerba ac diuturna gesserunt, partim<note>partim <hi rend="italic">del. Madvig</hi></note> modo ab nostris imperatoribus
+				cum populo Romano acerba ac diuturna gesserunt, partim<note>partim <hi rend="italic">del. Madvig</hi>
+                  </note> modo ab nostris imperatoribus
 				subacti, modo bello domiti, modo triumphis ac monumentis notati, modo ab senatu
 				agris urbibusque multati sunt, partim qui cum ipso M. Fonteio ferrum ac manus
 				contulerunt multoque eius sudore ac labore sub populi Romani imperium dicionemque
-				ceciderunt. </p></div>
-				<div type="textpart" subtype="section" n="13"><p><reg>est</reg> in eadem provincia
+				ceciderunt. </p>
+            </div>
+            <div type="textpart" subtype="section" n="13">
+               <p>
+                  <reg>est</reg> in eadem provincia
 				Narbo Martius, colonia nostrorum civium, specula populi Romani ac propugnaculum
 				istis ipsis nationibus oppositum et obiectum; est item urbs Massilia, de qua ante
 				dixi, fortissimorum fidelissimorumque sociorum, qui Gallicorum bellorum pericula
 				praecipuis <add>populi Romani</add> praemiis<note>praecipuis p. R. praemiis <hi rend="italic">scripsi</hi>: P. R. copiis .. r. mis <hi rend="italic">V1</hi>: P. R. copiisq; remis <hi rend="italic">V2</hi> (que <hi rend="italic">i. e.</hi> quaere <hi rend="italic">omissum aliquid
-						significat, cf. Mur.</hi> 51): P. R. copiis remisque <foreign xml:lang="grc">s</foreign>: populi Romani copiis atque praemiis <hi rend="italic">Madvig</hi></note> compensarunt<note>compensarunt <hi rend="italic">V</hi></note>; est praeterea <add>maximus</add><note>maximus <hi rend="italic">suppl. Hotoman</hi></note> numerus civium Romanorum atque<note>atque <hi rend="italic">del. Hotoman</hi></note>
-				<add>equitum<note>equitum <hi rend="italic">supplevi</hi> (<hi rend="italic">i. e.
+						significat, cf. Mur.</hi> 51): P. R. copiis remisque <foreign xml:lang="grc">ς</foreign>: populi Romani copiis atque praemiis <hi rend="italic">Madvig</hi>
+                  </note> compensarunt<note>compensarunt <hi rend="italic">V</hi>
+                  </note>; est praeterea <add>maximus</add>
+                  <note>maximus <hi rend="italic">suppl. Hotoman</hi>
+                  </note> numerus civium Romanorum atque<note>atque <hi rend="italic">del. Hotoman</hi>
+                  </note>
+                  <add>equitum<note>equitum <hi rend="italic">supplevi</hi> (<hi rend="italic">i. e.
 							Gallicorum, cf.</hi> § 26, <hi rend="italic">Caes. B. G.</hi> vi.
-						15)</note>,</add> hominum honestissimorum. <milestone n="6" unit="chapter"/><reg>huic</reg> provinciae quae ex hac generum varietate constaret M.
-				Fonteius, ut dixi, praefuit; qui erant hostes, subegit, qui proxime<note>proximi <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Hotoman</hi></note>
+						15)</note>,</add> hominum honestissimorum. <milestone n="6" unit="chapter"/>
+                  <reg>huic</reg> provinciae quae ex hac generum varietate constaret M.
+				Fonteius, ut dixi, praefuit; qui erant hostes, subegit, qui proxime<note>proximi <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Hotoman</hi>
+                  </note>
 				fuerant, eos ex eis agris quibus erant multati decedere coegit, ceteris qui<note>his
-					qui <hi rend="italic">V</hi></note> idcirco magnis saepe erant bellis superati
+					qui <hi rend="italic">V</hi>
+                  </note> idcirco magnis saepe erant bellis superati
 				ut semper populo Romano parerent, magnos equitatus ad ea bella quae tum in toto orbe
 				terrarum a populo Romano gerebantur, magnas pecunias ad eorum stipendium, maximum
-				frumenti numerum ad Hispaniense bellum tolerandum imperavit. </p></div>
-				<div type="textpart" subtype="section" n="14"><p><reg>is</reg> qui gessit in iudicium vocatur, vos qui in re non
+				frumenti numerum ad Hispaniense bellum tolerandum imperavit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="14">
+               <p>
+                  <reg>is</reg> qui gessit in iudicium vocatur, vos qui in re non
 				interfuistis causam una cum populo Romano cognoscitis, dicunt contra quibus
-				invitissimis imperatum est, dicunt qui ex agris<note><app><lem>ex agris</lem></app> agris
-						<hi rend="italic">Schütz</hi></note> ex<note>ex <hi rend="italic">om.
-						l</hi></note> Cn. Pompei decreto decedere sunt coacti, dicunt qui ex
-					belli<note>belli <hi rend="italic">Madvig</hi>: bello <hi rend="italic">codd.</hi></note> caede et fuga nunc primum audent contra M. Fonteium
+				invitissimis imperatum est, dicunt qui ex agris<note>
+                     <app>
+                        <lem>ex agris</lem>
+                     </app> agris
+						<hi rend="italic">Schütz</hi>
+                  </note> ex<note>ex <hi rend="italic">om.
+						l</hi>
+                  </note> Cn. Pompei decreto decedere sunt coacti, dicunt qui ex
+					belli<note>belli <hi rend="italic">Madvig</hi>: bello <hi rend="italic">codd.</hi>
+                  </note> caede et fuga nunc primum audent contra M. Fonteium
 				inermem consistere. <reg>quid</reg>? coloni Narbonenses quid volunt, quid
-				existimant? <reg>hunc</reg> per vos <add>salvum</add><note>salvum <hi rend="italic">supplevi</hi></note> volunt, se per<note>se per <hi rend="italic">Naugerius</hi> (1): semper <hi rend="italic">codd.</hi></note> hunc
+				existimant? <reg>hunc</reg> per vos <add>salvum</add>
+                  <note>salvum <hi rend="italic">supplevi</hi>
+                  </note> volunt, se per<note>se per <hi rend="italic">Naugerius</hi> (1): semper <hi rend="italic">codd.</hi>
+                  </note> hunc
 					incolumis<note>incolumem <hi rend="italic">codd.</hi>: <hi rend="italic">corr.
 						Naugerius</hi> (1)</note> existimant esse. <reg>quid</reg> Massiliensium
 				civitas? <reg>hunc</reg> praesentem eis adfecit honoribus quos habuit amplissimos;
 				vos autem absens orat atque obsecrat ut sua religio, laudatio, auctoritas aliquid
-				apud vestros animos momenti habuisse videatur. </p></div>
-				<div type="textpart" subtype="section" n="15"><p><reg>quid</reg>? civium Romanorum quae voluntas est? <reg>nemo</reg> est ex
-				tanto numero quin<note>quin <foreign xml:lang="grc">s</foreign>: quia <hi rend="italic">V</hi></note> hunc optime de provincia, de imperio, de sociis
-				et civibus meritum esse arbitretur. <milestone n="7" unit="chapter"/><reg>quoniam</reg> igitur, iudices<note>iudices <hi rend="italic">k</hi>:
+				apud vestros animos momenti habuisse videatur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="15">
+               <p>
+                  <reg>quid</reg>? civium Romanorum quae voluntas est? <reg>nemo</reg> est ex
+				tanto numero quin<note>quin <foreign xml:lang="grc">ς</foreign>: quia <hi rend="italic">V</hi>
+                  </note> hunc optime de provincia, de imperio, de sociis
+				et civibus meritum esse arbitretur. <milestone n="7" unit="chapter"/>
+                  <reg>quoniam</reg> igitur, iudices<note>iudices <hi rend="italic">k</hi>:
 					vidctis <hi rend="italic">cett.</hi> (<hi rend="italic">cf.</hi> § § 21,
-					42)</note>, qui oppugnatum<note>oppugnent <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed. R</hi></note> M. Fonteium
-					cognostis<note>cognostis <hi rend="italic">post</hi> velint <hi rend="italic">hab. k</hi></note>, qui defensum velint, statuite nunc quid vestra
+					42)</note>, qui oppugnatum<note>oppugnent <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed. R</hi>
+                  </note> M. Fonteium
+					cognostis<note>cognostis <hi rend="italic">post</hi> velint <hi rend="italic">hab. k</hi>
+                  </note>, qui defensum velint, statuite nunc quid vestra
 				aequitas, quid populi Romani dignitas postulet, utrum colonis vestris,
 				negotiatoribus vestris, amicissimis atque antiquissimis sociis et credere et
 				consulere malitis, an eis<note>malitis an iis <hi rend="italic">k</hi>: malitisanis
-						<hi rend="italic">V</hi>: an adversariis <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi></note> quibus neque propter iracundiam
-				fidem neque propter infidelitatem honorem habere debetis. </p></div>
-				<div type="textpart" subtype="section" n="16"><p><reg>quid</reg>? si maiorem etiam hominum honestissimorum copiam
-					adferam<note>adferam <hi rend="italic">Halm</hi>: adferta <hi rend="italic">V</hi>: affert <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: affero <hi rend="italic">k</hi> quae] qui <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed. R</hi></note> quae
+						<hi rend="italic">V</hi>: an adversariis <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note> quibus neque propter iracundiam
+				fidem neque propter infidelitatem honorem habere debetis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="16">
+               <p>
+                  <reg>quid</reg>? si maiorem etiam hominum honestissimorum copiam
+					adferam<note>adferam <hi rend="italic">Halm</hi>: adferta <hi rend="italic">V</hi>: affert <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: affero <hi rend="italic">k</hi> quae] qui <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed. R</hi>
+                  </note> quae
 				huius virtuti atque innocentiae testimonio possit<note>possint <hi rend="italic">l,
-						ed. R</hi></note> esse, tamenne plus Gallorum consensio valebit quam
-					summa<note>summa <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>:
-					summae <hi rend="italic">Vk</hi></note> auctoritas<note>auctoritas <hi rend="italic">l, Angelius</hi>: auctoritatis <hi rend="italic">cett.</hi></note> omnium<note><app><lem>omnium</lem></app> hominum <hi rend="italic">k, Faernus</hi></note>? Cum Galliae Fonteius praeesset, scitis, iudices,
+						ed. R</hi>
+                  </note> esse, tamenne plus Gallorum consensio valebit quam
+					summa<note>summa <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>:
+					summae <hi rend="italic">Vk</hi>
+                  </note> auctoritas<note>auctoritas <hi rend="italic">l, Angelius</hi>: auctoritatis <hi rend="italic">cett.</hi>
+                  </note> omnium<note>
+                     <app>
+                        <lem>omnium</lem>
+                     </app> hominum <hi rend="italic">k, Faernus</hi>
+                  </note>? Cum Galliae Fonteius praeesset, scitis, iudices,
 				maximos populi Romani exercitus in duabus Hispaniis clarissimosque imperatores
 				fuisse. <reg>quam</reg> multi equites Romani, quam multi tribuni militum, quales et
-				quot et quotiens legati ad eos <add>exierunt</add><note>exierunt <hi rend="italic">suppl. Pluygers</hi></note>! <reg>exercitus</reg> praeterea Cn. Pompei
+				quot et quotiens legati ad eos <add>exierunt</add>
+                  <note>exierunt <hi rend="italic">suppl. Pluygers</hi>
+                  </note>! <reg>exercitus</reg> praeterea Cn. Pompei
 				maximus atque ornatissimus hiemavit in Gallia M. Fonteio imperante.
 					<reg>satisne</reg> vobis multos, satis idoneos testis et conscios<note>conscios
-						<foreign xml:lang="grc">s</foreign>: conscissos <hi rend="italic">V</hi></note> videtur ipsa fortuna esse voluisse earum rerum quae M. Fonteio
+						<foreign xml:lang="grc">ς</foreign>: conscissos <hi rend="italic">V</hi>
+                  </note> videtur ipsa fortuna esse voluisse earum rerum quae M. Fonteio
 				praetore gererentur in Gallia? <reg>quem</reg> ex tanto hominum numero testem in hac
 				causa producere potestis? quis est ex eo numero qui vobis auctor placeat? eo nos iam
-				laudatore et teste utemur. </p></div>
-				<div type="textpart" subtype="section" n="17"><p><reg>dubitabitis</reg>
+				laudatore et teste utemur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="17">
+               <p>
+                  <reg>dubitabitis</reg>
 				etiam diutius, iudices, quin illud quod initio vobis proposui verissimum sit, aliud
 				per hoc iudicium nihil agi nisi ut M. Fonteio oppresso testimoniis eorum quibus
 				multa rei publicae causa invitissimis imperata sunt, segniores posthac ad imperandum
-				ceteri sint, cum videatis<note>videatis <hi rend="italic">V</hi>: videant <foreign xml:lang="grc">s</foreign></note> eos oppugnare<note>oppugnare <hi rend="italic">V</hi>: oppugnari <foreign xml:lang="grc">s</foreign></note>
-				quibus <add>victoribus</add><note>victoribus <hi rend="italic">Niebuhr</hi>:
-					oppressis <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: <hi rend="italic">om. Vk</hi>: si cesseritis <hi rend="italic">Müller</hi></note> populi Romani imperium incolume esse non possit? <milestone n="8" unit="chapter"/>
-			<milestone unit="para"/><reg>obiectum</reg> est etiam quaestum M. Fonteium ex viarum munitione fecisse, ut
+				ceteri sint, cum videatis<note>videatis <hi rend="italic">V</hi>: videant <foreign xml:lang="grc">ς</foreign>
+                  </note> eos oppugnare<note>oppugnare <hi rend="italic">V</hi>: oppugnari <foreign xml:lang="grc">ς</foreign>
+                  </note>
+				quibus <add>victoribus</add>
+                  <note>victoribus <hi rend="italic">Niebuhr</hi>:
+					oppressis <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: <hi rend="italic">om. Vk</hi>: si cesseritis <hi rend="italic">Müller</hi>
+                  </note> populi Romani imperium incolume esse non possit? <milestone n="8" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>obiectum</reg> est etiam quaestum M. Fonteium ex viarum munitione fecisse, ut
 				aut ne cogeret munire, aut id quod munitum esset ne improbaret. <reg>si</reg> et
 				coacti sunt munire omnes et multorum opera improbata sunt, certe utrumque falsum
 				est, et<note>est et <hi rend="italic">k</hi>: esset <hi rend="italic">V</hi>:
-					esset et <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed.
-					R</hi></note> ob vacationem pretium datum, cum immunis nemo fuerit, et ob
+					esset et <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed.
+					R</hi>
+                  </note> ob vacationem pretium datum, cum immunis nemo fuerit, et ob
 				probationem, cum multa improbata sint<note>sint <hi rend="italic">ed. R</hi>: sunt
-						<hi rend="italic">codd.</hi></note>. <reg>quid</reg>? </p></div>
-				<div type="textpart" subtype="section" n="18"><p>si hoc crimen optimis nominibus<note><app><lem>nominibus</lem></app>
-					hominibus <hi rend="italic">Angelius</hi></note> delegare<note>denegare <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed. R</hi></note>
-					possimus<note>possumus <hi rend="italic">l, ed. R</hi></note>, et ita non ut
+						<hi rend="italic">codd.</hi>
+                  </note>. <reg>quid</reg>? </p>
+            </div>
+            <div type="textpart" subtype="section" n="18">
+               <p>si hoc crimen optimis nominibus<note>
+                     <app>
+                        <lem>nominibus</lem>
+                     </app>
+					hominibus <hi rend="italic">Angelius</hi>
+                  </note> delegare<note>denegare <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed. R</hi>
+                  </note>
+					possimus<note>possumus <hi rend="italic">l, ed. R</hi>
+                  </note>, et ita non ut
 				culpam in alios transferamus, sed uti doceamus eos isti munitioni praefuisse qui
 				facile officium suum et praestare et probare possunt, tamenne vos omnia in M.
 				Fonteium iratis testibus freti conferetis? Cum maioribus rei publicae negotiis M.
 				Fonteius impediretur, et cum ad rem publicam pertineret viam Domitiam
-					muniri<note>muniri <hi rend="italic">Hotoman</hi>: munire <hi rend="italic">codd.</hi></note>, legatis suis, primariis viris, C. Annio Bellieno et C.
+					muniri<note>muniri <hi rend="italic">Hotoman</hi>: munire <hi rend="italic">codd.</hi>
+                  </note>, legatis suis, primariis viris, C. Annio Bellieno et C.
 				Fonteio, negotium dedit; itaque praefuerunt; imperaverunt pro dignitate
-						sua<note><app><lem>sua</lem></app> sua cuique <hi rend="italic">Sylvius</hi></note> quod visum est et probaverunt; quod vos, si nulla alia ex
-				re, ex litteris quidem nostris quas exscripsistis<note>quas exscripsistis <hi rend="italic">Faernus</hi>: ex quas exscripsistis <hi rend="italic">V</hi>: quas scripsistis <foreign xml:lang="grc">s</foreign>, <hi rend="italic">ed. R</hi></note> et missis et adlatis certe scire potuistis.
+						sua<note>
+                     <app>
+                        <lem>sua</lem>
+                     </app> sua cuique <hi rend="italic">Sylvius</hi>
+                  </note> quod visum est et probaverunt; quod vos, si nulla alia ex
+				re, ex litteris quidem nostris quas exscripsistis<note>quas exscripsistis <hi rend="italic">Faernus</hi>: ex quas exscripsistis <hi rend="italic">V</hi>: quas scripsistis <foreign xml:lang="grc">ς</foreign>, <hi rend="italic">ed. R</hi>
+                  </note> et missis et adlatis certe scire potuistis.
 					<reg>quas</reg> si antea non legistis, nunc ex nobis quid de eis rebus Fonteius
 				ad legatos suos scripserit, quid ad eum illi rescripserint, cognoscite. L. M.
-					<quote>ad C. Annivm<note>ad Cannium (ad C. Cann. <hi rend="italic">k2</hi>) <hi rend="italic">Vk</hi>: ad C. Canninium <foreign xml:lang="grc">x</foreign>: <hi rend="italic">corr. Angelius</hi></note> leg., ad C.
-					Fonteivm leg., L. <add>A.</add><note>A. (<hi rend="italic">i. e.</hi> adlatae)
-							<hi rend="italic">suppl. Orelli</hi></note> ab<note>ab <hi rend="italic">Müller</hi>: a <hi rend="italic">codd.</hi></note> C.
-						Annio<note>C. Cannio <hi rend="italic">k</hi>: Canninio <hi rend="italic">V<foreign xml:lang="grc">x</foreign>l</hi>: <hi rend="italic">corr. Angelius</hi></note> leg., ab C.Fonteio leg.</quote>
-				</p></div>
-				<div type="textpart" subtype="section" n="19"><p><reg>satis</reg> opinor esse perspicuum, iudices,
+					<quote>ad C. Annivm<note>ad Cannium (ad C. Cann. <hi rend="italic">k2</hi>) <hi rend="italic">Vk</hi>: ad C. Canninium <foreign xml:lang="grc">χ</foreign>: <hi rend="italic">corr. Angelius</hi>
+                     </note> leg., ad C.
+					Fonteivm leg., L. <add>A.</add>
+                     <note>A. (<hi rend="italic">i. e.</hi> adlatae)
+							<hi rend="italic">suppl. Orelli</hi>
+                     </note> ab<note>ab <hi rend="italic">Müller</hi>: a <hi rend="italic">codd.</hi>
+                     </note> C.
+						Annio<note>C. Cannio <hi rend="italic">k</hi>: Canninio <hi rend="italic">V<foreign xml:lang="grc">χ</foreign>l</hi>: <hi rend="italic">corr. Angelius</hi>
+                     </note> leg., ab C.Fonteio leg.</quote>
+               </p>
+            </div>
+            <div type="textpart" subtype="section" n="19">
+               <p>
+                  <reg>satis</reg> opinor esse perspicuum, iudices,
 				hanc rationem munitionis neque ad M. Fonteium pertinere et ab eis esse
-					tractatam<note>tractatum <hi rend="italic">V1</hi>: tractatum <hi rend="italic">V2</hi></note> quos nemo possit reprehendere. <milestone n="9" unit="chapter"/>
-			<milestone unit="para"/><reg>cognoscite</reg> nunc de crimine vinario, quod illi invidiosissimum et maximum
+					tractatam<note>tractatum <hi rend="italic">V1</hi>: tractatum <hi rend="italic">V2</hi>
+                  </note> quos nemo possit reprehendere. <milestone n="9" unit="chapter"/>
+                  <milestone unit="para"/>
+                  <reg>cognoscite</reg> nunc de crimine vinario, quod illi invidiosissimum et maximum
 				esse voluerunt. <reg>crimen</reg> a Plaetorio, iudices, ita constitutum est, M.
-					Fonteio<note>M. <hi rend="italic">k, Halm</hi>: a <hi rend="italic">V<foreign xml:lang="grc">x</foreign>l</hi></note> non in Gallia primum venisse in
+					Fonteio<note>M. <hi rend="italic">k, Halm</hi>: a <hi rend="italic">V<foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note> non in Gallia primum venisse in
 				mentem ut portorium vini institueret, sed hac<note>hac <hi rend="italic">V</hi>:
-						<hi rend="italic">om. <foreign xml:lang="grc">s</foreign></hi></note> inita
-				iam ac<note>inita iam ac <hi rend="italic">Kayser</hi>: in Italiam (-a <foreign xml:lang="grc">s</foreign>) ac (hac <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, om. k</hi>) <hi rend="italic">codd.</hi></note> proposita ratione Roma profectum. <reg>itaque</reg> Titurium
+						<hi rend="italic">om. <foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> inita
+				iam ac<note>inita iam ac <hi rend="italic">Kayser</hi>: in Italiam (-a <foreign xml:lang="grc">ς</foreign>) ac (hac <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, om. k</hi>) <hi rend="italic">codd.</hi>
+                  </note> proposita ratione Roma profectum. <reg>itaque</reg> Titurium
 				Tolosae quaternos denarios in singulas vini amphoras portori nomine exegisse;
-				Croduni Porcium et <reg>munium</reg> ternos <add>et</add><note>et <hi rend="italic">supplevi</hi></note> victoriatum<note>victoriatum <hi rend="italic">scripsi</hi>: victoriatos m. <hi rend="italic">codd.</hi>: victoriatos <hi rend="italic">Angelius</hi>: <hi rend="italic">del. Mommsen</hi></note>,
+				Croduni Porcium et <reg>munium</reg> ternos <add>et</add>
+                  <note>et <hi rend="italic">supplevi</hi>
+                  </note> victoriatum<note>victoriatum <hi rend="italic">scripsi</hi>: victoriatos m. <hi rend="italic">codd.</hi>: victoriatos <hi rend="italic">Angelius</hi>: <hi rend="italic">del. Mommsen</hi>
+                  </note>,
 				Vulchalone Servaeum binos et victoriatum<note>et victoriatos m. <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Mommsen</hi> (<hi rend="italic">mendum e duplici lectione</hi> -os <hi rend="italic">et</hi> -um <hi rend="italic">ortum</hi>)</note>; atque in his
-						locis<note><app><lem>locis</lem></app> secrodunt (= scilicet Croduni et) Vulchalone
+						locis<note>
+                     <app>
+                        <lem>locis</lem>
+                     </app> secrodunt (= scilicet Croduni et) Vulchalone
 						<hi rend="italic">add. codd.</hi>: <hi rend="italic">del. Vrsinus</hi> his
-						<hi rend="italic">codd.</hi>: <hi rend="italic">corr. Halm</hi></note> ab
-				eis portorium esse exactum si qui Cobiomago<note>Cobiomacho (-ia- <foreign xml:lang="grc">s</foreign>) <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Mommsen</hi></note>—qui vicus inter Tolosam et Narbonem
-					est—deverterentur<note>devort. <hi rend="italic">V2</hi></note> neque Tolosam
+						<hi rend="italic">codd.</hi>: <hi rend="italic">corr. Halm</hi>
+                  </note> ab
+				eis portorium esse exactum si qui Cobiomago<note>Cobiomacho (-ia- <foreign xml:lang="grc">ς</foreign>) <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Mommsen</hi>
+                  </note>—qui vicus inter Tolosam et Narbonem
+					est—deverterentur<note>devort. <hi rend="italic">V2</hi>
+                  </note> neque Tolosam
 				ire vellent; Elesiodulis<note>Elesiodulis (<hi rend="italic">an</hi> -duni?) C.
 					Annium ... exegisse <hi rend="italic">Pantagathus</hi>: elesioduluscantum ...
-					exegissent <hi rend="italic">codd.</hi></note> C. Annium senos denarios ab eis
-				qui ad hostem portarent exegisse. </p></div>
-				<div type="textpart" subtype="section" n="20"><p><reg>video</reg>, iudices, esse crimen et genere ipso magnum—vectigal enim esse
+					exegissent <hi rend="italic">codd.</hi>
+                  </note> C. Annium senos denarios ab eis
+				qui ad hostem portarent exegisse. </p>
+            </div>
+            <div type="textpart" subtype="section" n="20">
+               <p>
+                  <reg>video</reg>, iudices, esse crimen et genere ipso magnum—vectigal enim esse
 				impositum fructibus nostris dicitur, et pecuniam permagnam ratione ista cogi
-				potuisse confiteor—et invidia<note>invidiam <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Ernesti</hi></note> vel <add>maximum</add><note>maximum
-						<hi rend="italic">suppl. Pluygers</hi></note>; maxime enim inimici hanc rem
-				sermonibus divolgare<note>divulgari <hi rend="italic">Pluygers</hi></note>
+				potuisse confiteor—et invidia<note>invidiam <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Ernesti</hi>
+                  </note> vel <add>maximum</add>
+                  <note>maximum
+						<hi rend="italic">suppl. Pluygers</hi>
+                  </note>; maxime enim inimici hanc rem
+				sermonibus divolgare<note>divulgari <hi rend="italic">Pluygers</hi>
+                  </note>
 				voluerunt. <reg>sed</reg> ego ita existimo, quo maius crimen sit id quod ostendatur
 				esse falsum, hoc maiorem ab eo iniuriam fieri qui id confingat. <reg>volt</reg> enim
 				magnitudine rei sic occupare animos eorum qui audiunt ut difficilis aditus veritati
 				relinquatur. 
-			<milestone unit="para"/><quote><reg>de</reg> crimine vinario.</quote>
-				<quote><reg>de</reg> bello Vocontiorvm<note>Contionum <hi rend="italic">V</hi></note>.</quote>
-				<quote><reg>de</reg>
-				</quote>
-				<quote>dispositione hibernorvm.</quote>
-				</p></div><milestone n="10" unit="chapter"/>
-				<div type="textpart" subtype="section" n="21"><p>
-			<milestone unit="para"/>'<reg>at</reg> hoc Galli negant.' <reg>at</reg> ratio<note>at ratio <hi rend="italic">l, Faernus</hi>: atrio <hi rend="italic">V</hi>: actio
-						<foreign xml:lang="grc">s</foreign></note> rerum et vis argumentorum
+			<milestone unit="para"/>
+                  <quote>
+                     <reg>de</reg> crimine vinario.</quote>
+                  <quote>
+                     <reg>de</reg> bello Vocontiorvm<note>Contionum <hi rend="italic">V</hi>
+                     </note>.</quote>
+                  <quote>
+                     <reg>de</reg>
+                  </quote>
+                  <quote>dispositione hibernorvm.</quote>
+               </p>
+            </div>
+            <milestone n="10" unit="chapter"/>
+            <div type="textpart" subtype="section" n="21">
+               <p>
+                  <milestone unit="para"/>'<reg>at</reg> hoc Galli negant.' <reg>at</reg> ratio<note>at ratio <hi rend="italic">l, Faernus</hi>: atrio <hi rend="italic">V</hi>: actio
+						<foreign xml:lang="grc">ς</foreign>
+                  </note> rerum et vis argumentorum
 				coarguit. <reg>potest</reg> igitur testibus iudex non credere? <reg>cupidis</reg> et
 				iratis et coniuratis et ab religione remotis non solum potest sed etiam debet.
 					<reg>etenim</reg> si, quia Galli dicunt, idcirco M. Fonteius nocens existimandus
 				est, quid mihi opus est sapiente iudice, quid aequo quaesitore, quid oratore non
 				stulto? dicunt enim Galli; negare non possumus. <reg>hic</reg> si ingeniosi et
 				periti et aequi iudicis has partis esse existimatis ut, quoniam quidem testes
-				dicunt, sine ulla dubitatione credendum sit, <reg>salus</reg><note>Salus <hi rend="italic">Manutius</hi>: salus <hi rend="italic">priores</hi></note>
+				dicunt, sine ulla dubitatione credendum sit, <reg>salus</reg>
+                  <note>Salus <hi rend="italic">Manutius</hi>: salus <hi rend="italic">priores</hi>
+                  </note>
 				ipsa virorum fortium innocentiam tueri non potest; sin autem in rebus iudicandis non
-				minimam partem <add>tenere</add><note>tenere <hi rend="italic">supplevi</hi></note>
+				minimam partem <add>tenere</add>
+                  <note>tenere <hi rend="italic">supplevi</hi>
+                  </note>
 				ad unam quamque rem aestimandam<note>aestimandam <hi rend="italic">Naugerius</hi>
-					(2): existimandam <hi rend="italic">codd.</hi></note> momentoque suo
-				ponderandam sapientiam<note>sapientia <foreign xml:lang="grc">s</foreign></note>
-					iudicis<note>iudicis <hi rend="italic">V</hi>: iudicis tenet <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: iudicis adhibetur <hi rend="italic">k</hi></note>, <add>videte</add><note>videte <hi rend="italic">suppl. Faernus</hi></note> ne multo vestrae<note>vostrae <hi rend="italic">V2</hi></note> maiores gravioresque partes sint<note>sint <hi rend="italic">V</hi>: sunt <foreign xml:lang="grc">s</foreign></note> ad
-				cogitandum quam ad dicendum meae. </p></div>
-				<div type="textpart" subtype="section" n="22"><p><reg>mihi</reg>
+					(2): existimandam <hi rend="italic">codd.</hi>
+                  </note> momentoque suo
+				ponderandam sapientiam<note>sapientia <foreign xml:lang="grc">ς</foreign>
+                  </note>
+					iudicis<note>iudicis <hi rend="italic">V</hi>: iudicis tenet <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: iudicis adhibetur <hi rend="italic">k</hi>
+                  </note>, <add>videte</add>
+                  <note>videte <hi rend="italic">suppl. Faernus</hi>
+                  </note> ne multo vestrae<note>vostrae <hi rend="italic">V2</hi>
+                  </note> maiores gravioresque partes sint<note>sint <hi rend="italic">V</hi>: sunt <foreign xml:lang="grc">ς</foreign>
+                  </note> ad
+				cogitandum quam ad dicendum meae. </p>
+            </div>
+            <div type="textpart" subtype="section" n="22">
+               <p>
+                  <reg>mihi</reg>
 				enim semper una quaque de re testis non solum semel verum etiam breviter
-				interrogandus est<note>est <hi rend="italic">Klotz</hi>: et <hi rend="italic">codd.</hi>: est et <hi rend="italic">Orelli</hi></note>, saepe etiam non
+				interrogandus est<note>est <hi rend="italic">Klotz</hi>: et <hi rend="italic">codd.</hi>: est et <hi rend="italic">Orelli</hi>
+                  </note>, saepe etiam non
 				interrogandus, ne aut irato facultas ad dicendum data aut cupido auctoritas
 				attributa esse videatur; vos et saepius eandem rem animis agitare et diutius uno
-					<add>quoque</add><note>quoque <hi rend="italic">suppl. ed. Hervag.</hi></note>
-				de teste cogitare potestis et, si quem nos interrogare noluimus<note>nolumus <hi rend="italic">ed. R</hi></note>, quae causa nobis tacendi fuerit existimare
+					<add>quoque</add>
+                  <note>quoque <hi rend="italic">suppl. ed. Hervag.</hi>
+                  </note>
+				de teste cogitare potestis et, si quem nos interrogare noluimus<note>nolumus <hi rend="italic">ed. R</hi>
+                  </note>, quae causa nobis tacendi fuerit existimare
 				debetis. <reg>quam</reg> ob rem, si hoc iudici praescriptum lege aut officio
 				putatis, testibus credere, nihil est cur alius alio iudice melior aut sapientior
 					existimetur<note>existimetur his <hi rend="italic">Vk</hi> (<hi rend="italic">e duplici lectione</hi> -tur <hi rend="italic">et</hi> -tis)</note>. Vnum
-				est enim et simplex aurium iudicium et promisce<note>promiscue <hi rend="italic"><foreign xml:lang="grc">x2</foreign>kl</hi></note> et communiter
-				stultis ac sapientibus ab natura datum. </p></div>
-				<div type="textpart" subtype="section" n="23"><p><reg>quid</reg> est igitur ubi elucere possit prudentia, ubi discerni stultus
+				est enim et simplex aurium iudicium et promisce<note>promiscue <hi rend="italic">
+                        <foreign xml:lang="grc">χ2</foreign>kl</hi>
+                  </note> et communiter
+				stultis ac sapientibus ab natura datum. </p>
+            </div>
+            <div type="textpart" subtype="section" n="23">
+               <p>
+                  <reg>quid</reg> est igitur ubi elucere possit prudentia, ubi discerni stultus
 				auditor et credulus ab religioso et sapienti iudice? <reg>nimirum</reg> illud in quo
-				ea quae dicuntur a testibus coniecturae<note>coniectura <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi></note> et cogitationi<note>cogitationi
+				ea quae dicuntur a testibus coniecturae<note>coniectura <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note> et cogitationi<note>cogitationi
 						<hi rend="italic">k, Hotoman</hi>: cogitatione <hi rend="italic">cett.</hi> (<hi rend="italic">fort.</hi> coniectura et cogitatione
 					tractantur)</note> traduntur, quanta auctoritate, quanta animi aequitate, quanto
 				pudore, quanta fide, quanta religione, quanto studio existimationis bonae, quanta
-				cura, quanto timore dicantur. <milestone n="11" unit="chapter"/><reg>an</reg> vero
+				cura, quanto timore dicantur. <milestone n="11" unit="chapter"/>
+                  <reg>an</reg> vero
 				vos id in testimoniis hominum barbarorum dubitabitis quod persaepe et nostra et
 				patrum memoria sapientissimi iudices de clarissimis nostrae civitatis viris
-					dubitandum<note>clariss. dubitandum nostrae civ. viris dubitandum <hi rend="italic">V</hi></note> non putaverunt? qui Cn. et Q. Caepionibus, L.
+					dubitandum<note>clariss. dubitandum nostrae civ. viris dubitandum <hi rend="italic">V</hi>
+                  </note> non putaverunt? qui Cn. et Q. Caepionibus, L.
 				et Q. Metellis testibus in Q. Pompeium, hominem novum, non crediderunt, quorum
 				virtuti, generi, rebus gestis fidem et auctoritatem in testimonio cupiditatis atque
-				inimicitiarum suspicio derogavit. <reg>ecquem</reg> hominem vidimus, </p></div>
-				<div type="textpart" subtype="section" n="24"><p>ecquem<note>haec quem <hi rend="italic">V</hi>: et quem
-						<foreign xml:lang="grc">s</foreign>: <hi rend="italic">corr. ed. R</hi>
-						(<hi rend="italic">ita mox</hi>)</note> vere<note><app><lem>vere</lem></app>
-					<hi rend="italic">fort.</hi> fere</note> commemorare possumus parem consilio,
-				gravitate, constantia, ceteris virtutibus<note>virtutis <hi rend="italic">Koch</hi></note>, honoris, ingeni, rerum gestarum ornamentis M. Aemilio Scauro
-				fuisse? <reg>tamen</reg> huius cuius<note>eius <hi rend="italic">Schütz</hi></note>
+				inimicitiarum suspicio derogavit. <reg>ecquem</reg> hominem vidimus, </p>
+            </div>
+            <div type="textpart" subtype="section" n="24">
+               <p>ecquem<note>haec quem <hi rend="italic">V</hi>: et quem
+						<foreign xml:lang="grc">ς</foreign>: <hi rend="italic">corr. ed. R</hi>
+						(<hi rend="italic">ita mox</hi>)</note> vere<note>
+                     <app>
+                        <lem>vere</lem>
+                     </app>
+                     <hi rend="italic">fort.</hi> fere</note> commemorare possumus parem consilio,
+				gravitate, constantia, ceteris virtutibus<note>virtutis <hi rend="italic">Koch</hi>
+                  </note>, honoris, ingeni, rerum gestarum ornamentis M. Aemilio Scauro
+				fuisse? <reg>tamen</reg> huius cuius<note>eius <hi rend="italic">Schütz</hi>
+                  </note>
 				iniurati nutu prope terrarum orbis regebatur iurati testimonio neque in C. Fimbriam
-				neque in C. Memmium creditum est; noluerunt ei<note><app><lem>ii</lem></app> .11. <hi rend="italic">V</hi></note> qui iudicabant hanc patere inimicitiis viam,
+				neque in C. Memmium creditum est; noluerunt ei<note>
+                     <app>
+                        <lem>ii</lem>
+                     </app> .11. <hi rend="italic">V</hi>
+                  </note> qui iudicabant hanc patere inimicitiis viam,
 				quem quisque odisset, ut eum testimonio posset<note>posset <hi rend="italic">kl,
-						ed. R</hi>: possit <hi rend="italic">V<foreign xml:lang="grc">x</foreign></hi></note> tollere. <reg>quantus</reg> in L. Crasso pudor
+						ed. R</hi>: possit <hi rend="italic">V<foreign xml:lang="grc">χ</foreign>
+                     </hi>
+                  </note> tollere. <reg>quantus</reg> in L. Crasso pudor
 				fuerit, quod ingenium, quanta auctoritas, quis ignorat? <reg>tamen</reg> is cuius
 				etiam sermo testimoni auctoritatem habebat, testimonio ipso, quae in M. Marcellum
-				inimico animo dixit, probare non potuit. </p></div>
-				<div type="textpart" subtype="section" n="25"><p><reg>fuit</reg>, fuit illis iudicibus divinum ac singulare,
-					iudices<note>iudices <hi rend="italic">l, Naugerius</hi> (1): iudicium (-ii <hi rend="italic">k</hi>) <hi rend="italic">cett.</hi></note>, consilium, qui
-				se non solum de reo<note><app><lem>reo</lem></app> iudicium (iud. facere <hi rend="italic">k</hi>) <hi rend="italic">add. codd.</hi>: <hi rend="italic">del.
-						Naugerius</hi> (1)</note> sed etiam de accusatore<note>de accusatore <hi rend="italic">del. Müller</hi></note>, de teste iudicare arbitrabantur,
+				inimico animo dixit, probare non potuit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="25">
+               <p>
+                  <reg>fuit</reg>, fuit illis iudicibus divinum ac singulare,
+					iudices<note>iudices <hi rend="italic">l, Naugerius</hi> (1): iudicium (-ii <hi rend="italic">k</hi>) <hi rend="italic">cett.</hi>
+                  </note>, consilium, qui
+				se non solum de reo<note>
+                     <app>
+                        <lem>reo</lem>
+                     </app> iudicium (iud. facere <hi rend="italic">k</hi>) <hi rend="italic">add. codd.</hi>: <hi rend="italic">del.
+						Naugerius</hi> (1)</note> sed etiam de accusatore<note>de accusatore <hi rend="italic">del. Müller</hi>
+                  </note>, de teste iudicare arbitrabantur,
 				quid fictum, quid fortuna ac tempore adlatum, quid pretio corruptum, quid spe aut
 				metu depravatum, quid a cupiditate aliqua aut inimicitiis profectum videretur.
 					<reg>quae</reg> si iudex non amplectetur omnia consilio, non animo ac mente
-				circumspiciet, si, ut quidque<note><app><lem>ut quidque</lem></app> quicquam <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: quidquid <hi rend="italic">Naugerius</hi> (1)</note> ex illo loco dicetur, ex oraculo
+				circumspiciet, si, ut quidque<note>
+                     <app>
+                        <lem>ut quidque</lem>
+                     </app> quicquam <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: quidquid <hi rend="italic">Naugerius</hi> (1)</note> ex illo loco dicetur, ex oraculo
 				aliquo dici arbitrabitur, profecto satis erit, id quod dixi antea, non surdum
-					iudicem<note>iudicem <hi rend="italic">del. Madvig</hi></note> huic muneri
+					iudicem<note>iudicem <hi rend="italic">del. Madvig</hi>
+                  </note> huic muneri
 				atque officio praeesse; nihil erit quam ob rem ille nescio quis sapiens homo ac
-				multarum rerum peritus ad res iudicandas requiratur. </p></div><milestone n="12" unit="chapter"/>
-				<div type="textpart" subtype="section" n="26"><p><reg>an</reg> vero illi
+				multarum rerum peritus ad res iudicandas requiratur. </p>
+            </div>
+            <milestone n="12" unit="chapter"/>
+            <div type="textpart" subtype="section" n="26">
+               <p>
+                  <reg>an</reg> vero illi
 				equites Romani quos nos vidimus, qui nuper in re publica iudiciisque
 					maxime<note>maximis <hi rend="italic">codd.</hi>: <hi rend="italic">corr.
-						Klotz</hi></note> floruerunt, habuerunt tantum animi, tantum roboris ut L.
+						Klotz</hi>
+                  </note> floruerunt, habuerunt tantum animi, tantum roboris ut L.
 					<add>Crasso, M.</add> Scauro<note>L. Crasso M. Scauro <hi rend="italic">k</hi>:
-					L. Scauro <hi rend="italic">V</hi>: M. Scauro <foreign xml:lang="grc">x</foreign></note> testi non crederent; vos Volcarum<note>Vulgarum <hi rend="italic">V</hi>: Belgarum <foreign xml:lang="grc">s</foreign>: <hi rend="italic">corr. Graevius</hi></note> atque Allobrogum testimoniis non
+					L. Scauro <hi rend="italic">V</hi>: M. Scauro <foreign xml:lang="grc">χ</foreign>
+                  </note> testi non crederent; vos Volcarum<note>Vulgarum <hi rend="italic">V</hi>: Belgarum <foreign xml:lang="grc">ς</foreign>: <hi rend="italic">corr. Graevius</hi>
+                  </note> atque Allobrogum testimoniis non
 				credere timetis? <reg>si</reg> inimico testi credi non oportuit, inimicior Marcello
 				Crassus aut Fimbriae Scaurus ex civilibus studiis atque obtrectatione domestica quam
-				huic Galli? quorum qui optima<note>optima <hi rend="italic">k</hi>: optumo <hi rend="italic">V</hi>: optumi <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi></note> in causa sunt, equites, frumentum pecuniam
-				semel atque iterum ac saepius<note><app><lem>saepius</lem></app> semper <hi rend="italic">Mommsen</hi></note> invitissimi dare coacti sunt, ceteri partim ex
+				huic Galli? quorum qui optima<note>optima <hi rend="italic">k</hi>: optumo <hi rend="italic">V</hi>: optumi <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note> in causa sunt, equites, frumentum pecuniam
+				semel atque iterum ac saepius<note>
+                     <app>
+                        <lem>saepius</lem>
+                     </app> semper <hi rend="italic">Mommsen</hi>
+                  </note> invitissimi dare coacti sunt, ceteri partim ex
 				veteribus bellis agro multati, partim ab hoc ipso bello superati et oppressi.
-					</p></div>
-				<div type="textpart" subtype="section" n="27"><p><reg>si</reg>, qui ob aliquod emolumentum suum
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="27">
+               <p>
+                  <reg>si</reg>, qui ob aliquod emolumentum suum
 				cupidius aliquid dicere videntur, eis credi non convenit, credo maius emolumentum
 				Caepionibus et Metellis propositum fuisse ex Q. Pompei damnatione, cum studiorum
 				suorum obtrectatorem sustulissent, quam cunctae Galliae ex M. Fontei calamitate, in
-				qua illa<note>illa <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed.
-						R</hi>: ille <hi rend="italic">Vk</hi></note> provincia prope suam
+				qua illa<note>illa <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed.
+						R</hi>: ille <hi rend="italic">Vk</hi>
+                  </note> provincia prope suam
 				immunitatem ac libertatem positam esse arbitratur. <reg>an</reg>, si homines ipsos
 				spectare convenit, id quod in teste profecto valere plurimum debet, non modo cum
-				summis civitatis nostrae viris sed cum infimo<note>infimo <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: infirmo <hi rend="italic">Vk</hi></note> cive Romano quisquam amplissimus Galliae comparandus est?
+				summis civitatis nostrae viris sed cum infimo<note>infimo <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: infirmo <hi rend="italic">Vk</hi>
+                  </note> cive Romano quisquam amplissimus Galliae comparandus est?
 					<reg>scit</reg> Indutiomarus quid sit testimonium dicere? movetur eo timore quo
-				nostrum unus quisque, cum in eum locum productus est? </p></div><milestone n="13" unit="chapter"/>
-				<div type="textpart" subtype="section" n="28"><p><reg>recordamini</reg>,
+				nostrum unus quisque, cum in eum locum productus est? </p>
+            </div>
+            <milestone n="13" unit="chapter"/>
+            <div type="textpart" subtype="section" n="28">
+               <p>
+                  <reg>recordamini</reg>,
 				iudices, quanto opere laborare soleatis non modo quid dicatis pro testimonio sed
 				etiam quibus verbis utamini, ne quod minus moderate positum, ne quod ab aliqua
 				cupiditate prolapsum verbum esse videatur; voltu denique laboratis ne qua
 				significari possit suspicio cupiditatis, ut et, cum proditis, existimatio
-					sit<note>sit <hi rend="italic">ed. R</hi>: sic <foreign xml:lang="grc">x</foreign>: est <hi rend="italic">Vk</hi>: <hi rend="italic">om.
-					l</hi></note> quaedam tacita de vobis pudoris ac religionis et, cum<note>et cum
-						<hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: at cum <hi rend="italic">V</hi>: ac cum <hi rend="italic">b</hi></note> disceditis,
-				ea diligenter conservata ac retenta videatur. </p></div>
-				<div type="textpart" subtype="section" n="29"><p><reg>credo</reg> haec eadem Indutiomarum in testimonio timuisse aut
+					sit<note>sit <hi rend="italic">ed. R</hi>: sic <foreign xml:lang="grc">χ</foreign>: est <hi rend="italic">Vk</hi>: <hi rend="italic">om.
+					l</hi>
+                  </note> quaedam tacita de vobis pudoris ac religionis et, cum<note>et cum
+						<hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: at cum <hi rend="italic">V</hi>: ac cum <hi rend="italic">b</hi>
+                  </note> disceditis,
+				ea diligenter conservata ac retenta videatur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="29">
+               <p>
+                  <reg>credo</reg> haec eadem Indutiomarum in testimonio timuisse aut
 				cogitavisse, qui primum illud verbum consideratissimum nostrae consuetudinis
 				'arbitror', quo nos etiam tunc utimur cum ea dicimus iurati quae comperta habemus,
 				quae ipsi vidimus, ex toto testimonio suo sustulit atque omnia se 'scire' dixit.
 					<reg>verebatur</reg> enim videlicet ne quid apud vos populumque Romanum de
 				existimatione sua deperderet, ne qua fama consequeretur eius modi, Indutiomarum,
-				talem virum, tam cupide, tam temere dixisse; non<note><app><lem>non</lem></app> hoc <hi rend="italic">Bake</hi></note> intellegebat se in testimonio nihil praeter
-				vocem et<note>vocem et <hi rend="italic">del. Bake</hi></note> os et audaciam neque
-				civibus suis neque accusatoribus nostris praestare debere. </p></div>
-				<div type="textpart" subtype="section" n="30"><p><reg>an</reg> vero istas nationes religione iuris iurandi ac
+				talem virum, tam cupide, tam temere dixisse; non<note>
+                     <app>
+                        <lem>non</lem>
+                     </app> hoc <hi rend="italic">Bake</hi>
+                  </note> intellegebat se in testimonio nihil praeter
+				vocem et<note>vocem et <hi rend="italic">del. Bake</hi>
+                  </note> os et audaciam neque
+				civibus suis neque accusatoribus nostris praestare debere. </p>
+            </div>
+            <div type="textpart" subtype="section" n="30">
+               <p>
+                  <reg>an</reg> vero istas nationes religione iuris iurandi ac
 				metu deorum immortalium in testimoniis dicendis commoveri arbitramini? quae tantum a
 				ceterarum gentium more ac natura dissentiunt, quod ceterae pro religionibus suis
 				bella suscipiunt, istae contra omnium religiones; illae in bellis gerendis ab dis
 				immortalibus pacem ac veniam petunt, istae cum ipsis dis immortalibus bella
-				gesserunt. <milestone n="14" unit="chapter"/><reg>hae</reg> sunt nationes quae
+				gesserunt. <milestone n="14" unit="chapter"/>
+                  <reg>hae</reg> sunt nationes quae
 				quondam tam longe ab suis sedibus Delphos usque ad Apollinem Pythium atque ad
 				oraculum orbis terrae vexandum ac spoliandum profectae sunt. <reg>ab</reg> isdem
 				gentibus sanctis et in testimonio religiosis obsessum Capitolium est atque ille
-				Iuppiter cuius nomine maiores nostri vinctam<note><app><lem>vinctam</lem></app> sanctam <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi></note>
-				testimoniorum fidem esse voluerunt. </p></div>
-				<div type="textpart" subtype="section" n="31"><p><reg>postremo</reg> his<note><app><lem>his</lem></app> iis <hi rend="italic">kl</hi></note> quicquam<note>quicquam <hi rend="italic"><foreign xml:lang="grc">x2</foreign>kl</hi>: quisquam <hi rend="italic">V</hi>
-					<foreign xml:lang="grc">x1</foreign></note> sanctum ac religiosum videri potest
+				Iuppiter cuius nomine maiores nostri vinctam<note>
+                     <app>
+                        <lem>vinctam</lem>
+                     </app> sanctam <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note>
+				testimoniorum fidem esse voluerunt. </p>
+            </div>
+            <div type="textpart" subtype="section" n="31">
+               <p>
+                  <reg>postremo</reg> his<note>
+                     <app>
+                        <lem>his</lem>
+                     </app> iis <hi rend="italic">kl</hi>
+                  </note> quicquam<note>quicquam <hi rend="italic">
+                        <foreign xml:lang="grc">χ2</foreign>kl</hi>: quisquam <hi rend="italic">V</hi>
+                     <foreign xml:lang="grc">χ1</foreign>
+                  </note> sanctum ac religiosum videri potest
 				qui, etiam si quando aliquo metu adducti deos placandos esse
-					arbitrantur<note>arbitrantur <foreign xml:lang="grc">s</foreign>, <hi rend="italic">ed. R</hi>: arbitrabantur <hi rend="italic">V</hi></note>,
+					arbitrantur<note>arbitrantur <foreign xml:lang="grc">ς</foreign>, <hi rend="italic">ed. R</hi>: arbitrabantur <hi rend="italic">V</hi>
+                  </note>,
 				humanis hostiis eorum aras ac templa funestant, ut ne religionem quidem colere
 				possint, nisi eam ipsam prius scelere violarint? <reg>quis</reg> enim ignorat eos
 				usque ad hanc diem retinere illam immanem ac barbaram consuetudinem hominum
 				immolandorum? <reg>quam</reg> ob rem quali fide, quali pietate existimatis esse
-					eos<note>eos <foreign xml:lang="grc">s</foreign>: nos <hi rend="italic">V</hi>:
-					hos <hi rend="italic">Klotz</hi></note> qui etiam deos immortalis arbitrentur
-				hominum scelere<note><app><lem>scelere</lem></app> caede <hi rend="italic">Pluygers</hi></note> et sanguine facillime posse placari? Cum his vos testibus
+					eos<note>eos <foreign xml:lang="grc">ς</foreign>: nos <hi rend="italic">V</hi>:
+					hos <hi rend="italic">Klotz</hi>
+                  </note> qui etiam deos immortalis arbitrentur
+				hominum scelere<note>
+                     <app>
+                        <lem>scelere</lem>
+                     </app> caede <hi rend="italic">Pluygers</hi>
+                  </note> et sanguine facillime posse placari? Cum his vos testibus
 				vestram religionem coniungetis, ab <add>his</add> quicquam<note>ab his quicquam <hi rend="italic">ed. Hervag.</hi>: ab quicquam <hi rend="italic">V</hi>: aut
-					his quicquam <foreign xml:lang="grc">x</foreign>: aut cuiusquam <hi rend="italic">k</hi></note> sancte aut moderate<note>sancte aut moderate
-						<hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed. R</hi>: sancta
-					faui moderatae <hi rend="italic">V</hi>: sancte fieri moderate <hi rend="italic">k</hi></note> dictum putabitis? <reg>hoc</reg> vestrae mentes
-				tam castae, </p></div>
-				<div type="textpart" subtype="section" n="32"><p>tam integrae sibi suscipient ut, cum
+					his quicquam <foreign xml:lang="grc">χ</foreign>: aut cuiusquam <hi rend="italic">k</hi>
+                  </note> sancte aut moderate<note>sancte aut moderate
+						<hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed. R</hi>: sancta
+					faui moderatae <hi rend="italic">V</hi>: sancte fieri moderate <hi rend="italic">k</hi>
+                  </note> dictum putabitis? <reg>hoc</reg> vestrae mentes
+				tam castae, </p>
+            </div>
+            <div type="textpart" subtype="section" n="32">
+               <p>tam integrae sibi suscipient ut, cum
 				omnes legati nostri qui illo triennio in Galliam venerunt, omnes equites<note>omnes
-					in equites <hi rend="italic">V</hi></note> Romani qui in illa provincia
+					in equites <hi rend="italic">V</hi>
+                  </note> Romani qui in illa provincia
 				fuerunt, omnes negotiatores eius provinciae, denique omnes in Gallia qui sunt socii
 				populi Romani atque amici, M. Fonteium incolumem esse cupiant, iurati privatim et
-				publice laudent, vos tamen cum<note>cum <hi rend="italic">om. <foreign xml:lang="grc">x</foreign>l</hi></note> Gallis iugulare<note>iugulare
+				publice laudent, vos tamen cum<note>cum <hi rend="italic">om. <foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note> Gallis iugulare<note>iugulare
 						<hi rend="italic">Müller</hi>: iurare <hi rend="italic">Vk</hi>: credere
-						<hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: peierare <hi rend="italic">Koch</hi></note> malitis? <reg>quid</reg> ut secuti esse
+						<hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: peierare <hi rend="italic">Koch</hi>
+                  </note> malitis? <reg>quid</reg> ut secuti esse
 				videamini? voluntatemne hominum? gravior igitur vobis erit hostium voluntas quam
 				civium? <reg>an</reg> dignitatem testium? potestis igitur ignotos notis, iniquos
 				aequis, alienigenas domesticis, cupidos moderatis, mercennarios gratuitis, impios
-				religiosis, inimicissimos huic imperio ac nomini<note>ac nomini <hi rend="italic">om. Cus.</hi></note> bonis ac fidelibus<note>ac fid. <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: ad fid. <hi rend="italic">V</hi>: et fid. <hi rend="italic">k</hi></note> et sociis et civibus
-				anteferre? </p></div><milestone n="15" unit="chapter"/>
-				<div type="textpart" subtype="section" n="33"><p>
-			<milestone unit="para"/><reg>an</reg> vero dubitatis, iudices, quin insitas inimicitias istae gentes omnes et
+				religiosis, inimicissimos huic imperio ac nomini<note>ac nomini <hi rend="italic">om. Cus.</hi>
+                  </note> bonis ac fidelibus<note>ac fid. <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: ad fid. <hi rend="italic">V</hi>: et fid. <hi rend="italic">k</hi>
+                  </note> et sociis et civibus
+				anteferre? </p>
+            </div>
+            <milestone n="15" unit="chapter"/>
+            <div type="textpart" subtype="section" n="33">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>an</reg> vero dubitatis, iudices, quin insitas inimicitias istae gentes omnes et
 				habeant et gerant cum populi Romani nomine? <reg>sic</reg> existimatis eos
-					hic<note>eos hic <hi rend="italic">Naugerius</hi> (1): eosic <hi rend="italic">V</hi>: eos sic <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: eos <hi rend="italic">k</hi></note> sagatos bracatosque
-				versari, animo demisso<note>animos <hi rend="italic">V</hi> demissos <hi rend="italic">V1</hi></note> atque humili, ut solent ei qui adfecti
+					hic<note>eos hic <hi rend="italic">Naugerius</hi> (1): eosic <hi rend="italic">V</hi>: eos sic <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: eos <hi rend="italic">k</hi>
+                  </note> sagatos bracatosque
+				versari, animo demisso<note>animos <hi rend="italic">V</hi> demissos <hi rend="italic">V1</hi>
+                  </note> atque humili, ut solent ei qui adfecti
 				iniuriis ad opem iudicum supplices inferioresque confugiunt? <reg>nihil</reg> vero
-				minus. <reg>hi</reg><note>ii <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed. R</hi></note> contra vagantur laeti atque
-					erecti<note>erecti <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>:
-					recti <hi rend="italic">Vk</hi></note> passim toto foro cum quibusdam minis et
+				minus. <reg>hi</reg>
+                  <note>ii <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed. R</hi>
+                  </note> contra vagantur laeti atque
+					erecti<note>erecti <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>:
+					recti <hi rend="italic">Vk</hi>
+                  </note> passim toto foro cum quibusdam minis et
 				barbaro atque immani terrore verborum; quod ego profecto non crederem, nisi
 				aliquotiens ex ipsis accusatoribus vobiscum simul, iudices, audissem, cum
 				praeciperent ut caveretis ne hoc absoluto novum aliquod bellum Gallicum
-				concitaretur. </p></div>
-				<div type="textpart" subtype="section" n="34"><p><reg>si</reg> M. Fonteium, iudices,
+				concitaretur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="34">
+               <p>
+                  <reg>si</reg> M. Fonteium, iudices,
 				in causa deficerent omnia, si turpi adulescentia, vita infami, magistratibus quos
-				ante oculos vestros gessit <add>male gestis</add><note>male gestis <hi rend="italic">suppl. Lambinus</hi></note>, convictus<note>convictus
-						<foreign xml:lang="grc">s</foreign>, <hi rend="italic">ed. R</hi>:
-					convictis <hi rend="italic">V</hi></note> virorum bonorum<note>virorum bon.
-					testimoniis <hi rend="italic">del. Madvig</hi></note> testimoniis, legationibus
-				flagitiose obitis, invisus<note>invitus <hi rend="italic">V</hi>: invitis <foreign xml:lang="grc">s</foreign>: <hi rend="italic">corr. Manutius</hi></note>
+				ante oculos vestros gessit <add>male gestis</add>
+                  <note>male gestis <hi rend="italic">suppl. Lambinus</hi>
+                  </note>, convictus<note>convictus
+						<foreign xml:lang="grc">ς</foreign>, <hi rend="italic">ed. R</hi>:
+					convictis <hi rend="italic">V</hi>
+                  </note> virorum bonorum<note>virorum bon.
+					testimoniis <hi rend="italic">del. Madvig</hi>
+                  </note> testimoniis, legationibus
+				flagitiose obitis, invisus<note>invitus <hi rend="italic">V</hi>: invitis <foreign xml:lang="grc">ς</foreign>: <hi rend="italic">corr. Manutius</hi>
+                  </note>
 				suis omnibus in iudicium vocaretur, si in eo iudicio colonorum populi Romani
 				Narbonensium, fidelissimorum sociorum Massiliensium, civium Romanorum omnium
-				testimoniis tabulisque premeretur, tamen esset vobis<note><app><lem>vobis</lem></app> vel
-					vobis <hi rend="italic">V2</hi></note> magno opere providendum ne, quos ita
+				testimoniis tabulisque premeretur, tamen esset vobis<note>
+                     <app>
+                        <lem>vobis</lem>
+                     </app> vel
+					vobis <hi rend="italic">V2</hi>
+                  </note> magno opere providendum ne, quos ita
 				adflictos a vestris patribus maioribusque accepissetis ut contemnendi essent, eos
-				pertimuisse et eorum minis et terrore commoti esse videremini. </p></div>
-				<div type="textpart" subtype="section" n="35"><p><reg>nunc</reg> vero cum laedat nemo bonus, laudent omnes vestri
-				cives atque socii, oppugnent idem<note>idem <hi rend="italic">Müller</hi>: id <hi rend="italic">V</hi>: ii <foreign xml:lang="grc">s</foreign></note> qui
+				pertimuisse et eorum minis et terrore commoti esse videremini. </p>
+            </div>
+            <div type="textpart" subtype="section" n="35">
+               <p>
+                  <reg>nunc</reg> vero cum laedat nemo bonus, laudent omnes vestri
+				cives atque socii, oppugnent idem<note>idem <hi rend="italic">Müller</hi>: id <hi rend="italic">V</hi>: ii <foreign xml:lang="grc">ς</foreign>
+                  </note> qui
 				saepissime hanc urbem et hoc imperium oppugnarunt, cumque inimici M. Fontei vobis ac
 				populo Romano minentur, amici ac propinqui supplicent vobis, dubitabitis non modo
 				vestris civibus, qui maxime gloria ac laude ducuntur, verum etiam exteris nationibus
-					<add>et</add><note>et <hi rend="italic">l, Halm</hi>: ac <hi rend="italic">suppl. Naugerius</hi> (1)</note> gentibus ostendere vos in sententiis
-				ferendis civi parcere quam hosti cedere maluisse? </p></div><milestone n="16" unit="chapter"/>
-				<div type="textpart" subtype="section" n="36"><p>Magna me hercules<note>mehercule <foreign xml:lang="grc">s</foreign></note> causa, iudices, absolutionis cum ceteris
-				causis haec est, ne quae<note>quae <hi rend="italic">Halm</hi>: que <hi rend="italic">V</hi>: qua <foreign xml:lang="grc">s</foreign></note>
+					<add>et</add>
+                  <note>et <hi rend="italic">l, Halm</hi>: ac <hi rend="italic">suppl. Naugerius</hi> (1)</note> gentibus ostendere vos in sententiis
+				ferendis civi parcere quam hosti cedere maluisse? </p>
+            </div>
+            <milestone n="16" unit="chapter"/>
+            <div type="textpart" subtype="section" n="36">
+               <p>Magna me hercules<note>mehercule <foreign xml:lang="grc">ς</foreign>
+                  </note> causa, iudices, absolutionis cum ceteris
+				causis haec est, ne quae<note>quae <hi rend="italic">Halm</hi>: que <hi rend="italic">V</hi>: qua <foreign xml:lang="grc">ς</foreign>
+                  </note>
 				insignis huic imperio macula atque ignominia suscipiatur, si hoc ita perlatum erit
-				in Galliam, senatores<note>senatores <hi rend="italic">Faernus</hi>: senates <hi rend="italic">V</hi>: senatus (-um <hi rend="italic">k</hi>) <foreign xml:lang="grc">s</foreign></note> equitesque populi Romani non testimoniis
-				Gallorum, sed minis commotos rem ad illorum libidinem<note><app><lem>lib.</lem></app> lub.
-						<hi rend="italic">V2</hi></note> iudicasse. <reg>ita</reg> vero, si illi
+				in Galliam, senatores<note>senatores <hi rend="italic">Faernus</hi>: senates <hi rend="italic">V</hi>: senatus (-um <hi rend="italic">k</hi>) <foreign xml:lang="grc">ς</foreign>
+                  </note> equitesque populi Romani non testimoniis
+				Gallorum, sed minis commotos rem ad illorum libidinem<note>
+                     <app>
+                        <lem>lib.</lem>
+                     </app> lub.
+						<hi rend="italic">V2</hi>
+                  </note> iudicasse. <reg>ita</reg> vero, si illi
 				bellum facere conabuntur, excitandus nobis erit ab inferis C. Marius qui Indutiomaro
-				isti minaci atque adroganti par in bello gerendo<note>belligerendo <hi rend="italic">V1</hi>: belligerando <hi rend="italic">V2<foreign xml:lang="grc">s</foreign></hi>: <hi rend="italic">corr.
-					Faernus</hi></note> esse possit, excitandus Cn. Domitius et Q. Maximus<note>Q.
+				isti minaci atque adroganti par in bello gerendo<note>belligerendo <hi rend="italic">V1</hi>: belligerando <hi rend="italic">V2<foreign xml:lang="grc">ς</foreign>
+                     </hi>: <hi rend="italic">corr.
+					Faernus</hi>
+                  </note> esse possit, excitandus Cn. Domitius et Q. Maximus<note>Q.
 						<hi rend="italic">k, Faernus</hi>: O. <hi rend="italic">V</hi>: <hi rend="italic">om.</hi>
-					<foreign xml:lang="grc">x</foreign></note> qui nationem Allobrogum et
-					<add>belli</add><note>belli <hi rend="italic">supplevi</hi> (<hi rend="italic">cf. Prov. Cons.</hi> 19, <hi rend="italic">Verr.</hi> v. 39, <hi rend="italic">et ad Phil.</hi> xiii. 2 <hi rend="italic">et</hi>
-					47)</note> reliquias<note>reliquas <hi rend="italic">Lambinus</hi></note> suis
+                     <foreign xml:lang="grc">χ</foreign>
+                  </note> qui nationem Allobrogum et
+					<add>belli</add>
+                  <note>belli <hi rend="italic">supplevi</hi> (<hi rend="italic">cf. Prov. Cons.</hi> 19, <hi rend="italic">Verr.</hi> v. 39, <hi rend="italic">et ad Phil.</hi> xiii. 2 <hi rend="italic">et</hi>
+					47)</note> reliquias<note>reliquas <hi rend="italic">Lambinus</hi>
+                  </note> suis
 				iterum armis conficiat atque opprimat, aut, quoniam id quidem non potest, orandus
 				erit nobis amicus meus, M. Plaetorius, ut suos novos clientis a bello faciendo
 				deterreat, ut eorum iratos animos atque horribilis impetus deprecetur, aut, si non
 				poterit, M. Fabium, subscriptorem eius, rogabimus ut Allobrogum animos mitiget,
-				quoniam apud illos Fabiorum nomen amplissimum <add>est</add><note>est <hi rend="italic">k</hi>: <hi rend="italic">om. V<foreign xml:lang="grc">x</foreign>l</hi> (est ampl. <hi rend="italic">Halm</hi>) volunt] ut
-					velint <hi rend="italic">Angelius</hi></note>. <reg>volunt</reg> isti aut
+				quoniam apud illos Fabiorum nomen amplissimum <add>est</add>
+                  <note>est <hi rend="italic">k</hi>: <hi rend="italic">om. V<foreign xml:lang="grc">χ</foreign>l</hi> (est ampl. <hi rend="italic">Halm</hi>) volunt] ut
+					velint <hi rend="italic">Angelius</hi>
+                  </note>. <reg>volunt</reg> isti aut
 				quiescere, id quod victi ac subacti solent, aut, cum minantur, intellegere se populo
-				Romano non metum belli sed spem triumphi<note>triumphos (-is <hi rend="italic"><foreign xml:lang="grc">x</foreign>l,</hi> -i <hi rend="italic">k</hi>) tendere <hi rend="italic">codd.</hi>: <hi rend="italic">corr.
-						Naugerius</hi> (2)</note> ostendere? </p></div>
-				<div type="textpart" subtype="section" n="37"><p>
-			<milestone unit="para"/><reg>quod</reg> si in turpi reo patiendum non esset ut quicquam isti se minis
-				profecisse arbitrarentur, quid faciendum vobis <add>in</add><note>in <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: de <hi rend="italic">k</hi>: <hi rend="italic">om. V</hi></note> M.
-					Fonteio<note>Fontei <hi rend="italic">V</hi></note> arbitramini? de quo homine,
+				Romano non metum belli sed spem triumphi<note>triumphos (-is <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l,</hi> -i <hi rend="italic">k</hi>) tendere <hi rend="italic">codd.</hi>: <hi rend="italic">corr.
+						Naugerius</hi> (2)</note> ostendere? </p>
+            </div>
+            <div type="textpart" subtype="section" n="37">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>quod</reg> si in turpi reo patiendum non esset ut quicquam isti se minis
+				profecisse arbitrarentur, quid faciendum vobis <add>in</add>
+                  <note>in <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: de <hi rend="italic">k</hi>: <hi rend="italic">om. V</hi>
+                  </note> M.
+					Fonteio<note>Fontei <hi rend="italic">V</hi>
+                  </note> arbitramini? de quo homine,
 				iudices—iam enim mihi videor hoc prope causa duabus actionibus perorata debere
 				dicere—de quo vos homine ne ab inimicis quidem ullum fictum probrorum<note>probrorum
 						<hi rend="italic">scripsi</hi> (<hi rend="italic">cf.</hi> § 39):
-					probrosum <hi rend="italic">codd.</hi></note> non modo crimen sed ne maledictum
-				quidem audistis. <reg>ecquis</reg><note>ecquis (et- <hi rend="italic">kl</hi>)
-						<foreign xml:lang="grc">s</foreign>: haec quis <hi rend="italic">V</hi></note> umquam reus, praesertim in hac vitae ratione
-					versatus<note>vorsatus <hi rend="italic">V2</hi></note>, in honoribus petendis,
-				in potestatibus<note>potestatibus obtinendis <hi rend="italic">Mommsen</hi></note>,
+					probrosum <hi rend="italic">codd.</hi>
+                  </note> non modo crimen sed ne maledictum
+				quidem audistis. <reg>ecquis</reg>
+                  <note>ecquis (et- <hi rend="italic">kl</hi>)
+						<foreign xml:lang="grc">ς</foreign>: haec quis <hi rend="italic">V</hi>
+                  </note> umquam reus, praesertim in hac vitae ratione
+					versatus<note>vorsatus <hi rend="italic">V2</hi>
+                  </note>, in honoribus petendis,
+				in potestatibus<note>potestatibus obtinendis <hi rend="italic">Mommsen</hi>
+                  </note>,
 				in imperiis gerendis, sic accusatus est ut nullum probrum, nullum facinus, nulla
-				turpitudo quae a libidine<note><app><lem>lib.</lem></app> lub. <hi rend="italic">V</hi></note> aut a petulantia aut ab audacia nata esset, ab accusatore
-				obiceretur, si non vera<note>si vera non <hi rend="italic">V</hi></note>, at
+				turpitudo quae a libidine<note>
+                     <app>
+                        <lem>lib.</lem>
+                     </app> lub. <hi rend="italic">V</hi>
+                  </note> aut a petulantia aut ab audacia nata esset, ab accusatore
+				obiceretur, si non vera<note>si vera non <hi rend="italic">V</hi>
+                  </note>, at
 					ficta<note>at ficta <hi rend="italic">k</hi>: atdeficta (<hi rend="italic">ex</hi> atficta <hi rend="italic">credo</hi>) <hi rend="italic">V</hi>:
-					at tamen ficta <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: at
-					commode ficta <hi rend="italic">Halm</hi></note> cum aliqua ratione ac
-				suspicione? </p></div><milestone n="17" unit="chapter"/>
-				<div type="textpart" subtype="section" n="38"><p>M.
+					at tamen ficta <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: at
+					commode ficta <hi rend="italic">Halm</hi>
+                  </note> cum aliqua ratione ac
+				suspicione? </p>
+            </div>
+            <milestone n="17" unit="chapter"/>
+            <div type="textpart" subtype="section" n="38">
+               <p>M.
 				Aemilium Scaurum, summum nostrae civitatis virum, scimus accusatum a M. Bruto.
 					<reg>exstant</reg> orationes, ex quibus intellegi potest multa in illum ipsum
 				Scaurum esse dicta, falso; quis negat? verum tamen ab inimico dicta et obiecta.
 					<reg>quam</reg> multa M'. Aquilius<note>M'. <hi rend="italic">Manutius</hi>: M.
-						<hi rend="italic">codd.</hi></note> audivit in suo iudicio, quam multa L.
+						<hi rend="italic">codd.</hi>
+                  </note> audivit in suo iudicio, quam multa L.
 				Cotta, denique P. Rutilius! qui, etsi damnatus est, mihi videtur tamen inter viros
 				optimos atque innocentissimos esse numerandus. <reg>ille</reg> igitur ipse homo
-				sanctissimus ac temperantissimus<note>temperatissimus <foreign xml:lang="grc">s</foreign></note> multa audivit in sua causa quae ad<note>ad libidinem <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Faernus</hi></note>
-				suspicionem stuprorum ac libidinum pertinerent. </p></div>
-				<div type="textpart" subtype="section" n="39"><p><reg>exstat</reg> oratio hominis, ut opinio mea fert, nostrorum hominum longe
+				sanctissimus ac temperantissimus<note>temperatissimus <foreign xml:lang="grc">ς</foreign>
+                  </note> multa audivit in sua causa quae ad<note>ad libidinem <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Faernus</hi>
+                  </note>
+				suspicionem stuprorum ac libidinum pertinerent. </p>
+            </div>
+            <div type="textpart" subtype="section" n="39">
+               <p>
+                  <reg>exstat</reg> oratio hominis, ut opinio mea fert, nostrorum hominum longe
 				ingeniosissimi atque eloquentissimi, C. Gracchi; qua in oratione permulta in L.
 				Pisonem turpia ac flagitiosa dicuntur. <reg>at</reg> in quem virum! qui tanta
-				virtute atque integritate fuit ut etiam illis optimis<note>optumis <hi rend="italic">V</hi></note> temporibus, cum hominem invenire nequam neminem
+				virtute atque integritate fuit ut etiam illis optimis<note>optumis <hi rend="italic">V</hi>
+                  </note> temporibus, cum hominem invenire nequam neminem
 				posses, solus tamen Frugi nominaretur. <reg>quem</reg> cum in contionem Gracchus
-				vocari iuberet et viator<note>iuberet et viator <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: iubertet vator <hi rend="italic">V</hi>: iuberet viator <hi rend="italic">k</hi></note> quaereret, quem
+				vocari iuberet et viator<note>iuberet et viator <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: iubertet vator <hi rend="italic">V</hi>: iuberet viator <hi rend="italic">k</hi>
+                  </note> quaereret, quem
 				Pisonem, quod erant plures: 'cogis me,' inquit, 'dicere inimicum meum Frugi.'
-					<reg>is</reg> igitur vir quem ne inimicus quidem satis in<note>in <hi rend="italic">del. Bake</hi></note> appellando significare poterat, nisi
+					<reg>is</reg> igitur vir quem ne inimicus quidem satis in<note>in <hi rend="italic">del. Bake</hi>
+                  </note> appellando significare poterat, nisi
 				ante laudasset, qui uno cognomine declarabatur non modo quis esset sed etiam qualis
 				esset, tamen in falsam atque iniquam probrorum insimulationem vocabatur; M.
-					</p></div>
-				<div type="textpart" subtype="section" n="40"><p>Fonteius ita duabus actionibus accusatus est
-				ut obiectum nihil sit quo significari vestigium libidinis<note><app><lem>lib.</lem></app>
-					lub. <hi rend="italic">V2</hi></note>, petulantiae, crudelitatis, audaciae
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="40">
+               <p>Fonteius ita duabus actionibus accusatus est
+				ut obiectum nihil sit quo significari vestigium libidinis<note>
+                     <app>
+                        <lem>lib.</lem>
+                     </app>
+					lub. <hi rend="italic">V2</hi>
+                  </note>, petulantiae, crudelitatis, audaciae
 				possit; non modo nullum facinus huius protulerunt sed ne dictum quidem aliquod
-					reprehenderunt<note>reprehenderint <foreign xml:lang="grc">x</foreign></note>.
-					<milestone n="18" unit="chapter"/><reg>quod</reg> si aut quantam voluntatem
+					reprehenderunt<note>reprehenderint <foreign xml:lang="grc">χ</foreign>
+                  </note>.
+					<milestone n="18" unit="chapter"/>
+                  <reg>quod</reg> si aut quantam voluntatem
 				habent ad hunc opprimendum aut quantam ad male dicendum licentiam, tantum haberent
-				aut <add>ad</add> ementiendum<note>aut ad ement. <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: aut ement. <hi rend="italic">Vk</hi></note> animi aut ad fingendum ingeni, non meliore fortuna ad probra
-						non<note><app><lem>probra non</lem></app> probra nunc <hi rend="italic">l, ed.
-						R</hi></note> audienda M. Fonteius<note>audienda M. <hi rend="italic">Halm</hi>: audiendam <hi rend="italic">V</hi>: audienda <foreign xml:lang="grc">s</foreign></note> quam illi de quibus antea commemoravi
+				aut <add>ad</add> ementiendum<note>aut ad ement. <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: aut ement. <hi rend="italic">Vk</hi>
+                  </note> animi aut ad fingendum ingeni, non meliore fortuna ad probra
+						non<note>
+                     <app>
+                        <lem>probra non</lem>
+                     </app> probra nunc <hi rend="italic">l, ed.
+						R</hi>
+                  </note> audienda M. Fonteius<note>audienda M. <hi rend="italic">Halm</hi>: audiendam <hi rend="italic">V</hi>: audienda <foreign xml:lang="grc">ς</foreign>
+                  </note> quam illi de quibus antea commemoravi
 				fuisset. Frugi igitur hominem, iudices, frugi, inquam, et in omnibus vitae partibus
 				moderatum ac temperantem, plenum pudoris, plenum offici, plenum religionis videtis
 				positum in vestra fide ac potestate, atque ita ut commissus sit fidei, permissus
-				potestati. </p></div>
-				<div type="textpart" subtype="section" n="41"><p>
-			<milestone unit="para"/><reg>videte</reg><note><app><lem>videte</lem></app> vitę<hi rend="italic">V</hi></note> igitur utrum sit aequius hominem honestissimum, virum
+				potestati. </p>
+            </div>
+            <div type="textpart" subtype="section" n="41">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>videte</reg>
+                  <note>
+                     <app>
+                        <lem>videte</lem>
+                     </app> vitę<hi rend="italic">V</hi>
+                  </note> igitur utrum sit aequius hominem honestissimum, virum
 				fortissimum, civem optimum dedi inimicissimis atque immanissimis nationibus an reddi
 				amicis, praesertim cum tot res sint quae vestris animis pro huius innocentis salute
-					supplicent<note>supplicem <hi rend="italic">V</hi> Tusculo <hi rend="italic">del. Bake</hi></note>, primum generis antiquitas, quam Tusculo, ex
+					supplicent<note>supplicem <hi rend="italic">V</hi> Tusculo <hi rend="italic">del. Bake</hi>
+                  </note>, primum generis antiquitas, quam Tusculo, ex
 				clarissimo municipio, profectam in monumentis rerum gestarum incisam ac notatam
 				videmus, tum autem continuae praeturae, quae et ceteris ornamentis et existimatione
-				innocentiae maxime<note>maximae <hi rend="italic">V</hi></note> floruerunt, deinde
+				innocentiae maxime<note>maximae <hi rend="italic">V</hi>
+                  </note> floruerunt, deinde
 				recens memoria parentis, cuius sanguine non solum Asculanorum manus, a qua
-				interfectus est<note>a qua ... est <hi rend="italic">del. Pluygers</hi></note>, sed
+				interfectus est<note>a qua ... est <hi rend="italic">del. Pluygers</hi>
+                  </note>, sed
 				totum illud sociale bellum macula sceleris imbutum est, postremo ipse cum in omnibus
 				vitae partibus honestus atque integer, tum in re militari cum summi consili et
 				maximi animi, tum vero usu quoque bellorum gerendorum in primis eorum hominum qui
-				nunc sunt exercitatus. </p></div><milestone n="19" unit="chapter"/>
-				<div type="textpart" subtype="section" n="42"><p><reg>qua</reg> re si etiam monendi estis a me,
-					iudices<note>estis a me iudices <hi rend="italic">V</hi>: estis a me <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: estis iudices <hi rend="italic">k</hi> videor] iudices <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed. R</hi></note>, quod non estis, videor
-				hoc leviter<note>leniter <hi rend="italic">k, Klotz</hi></note> pro
-						mea<note><app><lem>mea</lem></app> me <hi rend="italic">V</hi></note> auctoritate
+				nunc sunt exercitatus. </p>
+            </div>
+            <milestone n="19" unit="chapter"/>
+            <div type="textpart" subtype="section" n="42">
+               <p>
+                  <reg>qua</reg> re si etiam monendi estis a me,
+					iudices<note>estis a me iudices <hi rend="italic">V</hi>: estis a me <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: estis iudices <hi rend="italic">k</hi> videor] iudices <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed. R</hi>
+                  </note>, quod non estis, videor
+				hoc leviter<note>leniter <hi rend="italic">k, Klotz</hi>
+                  </note> pro
+						mea<note>
+                     <app>
+                        <lem>mea</lem>
+                     </app> me <hi rend="italic">V</hi>
+                  </note> auctoritate
 				vobis praecipere posse, ut ex eo genere homines quorum cognita virtus, industria,
 				felicitas in re militari sit diligenter vobis retinendos existimetis.
-					<reg>fuit</reg> enim<note><app><lem>enim</lem></app> olim <hi rend="italic">Mommsen</hi></note> maior talium <add>tum</add><note>tum <hi rend="italic">supplevi</hi></note> virorum in hac re publica copia; quae cum esset, tamen
+					<reg>fuit</reg> enim<note>
+                     <app>
+                        <lem>enim</lem>
+                     </app> olim <hi rend="italic">Mommsen</hi>
+                  </note> maior talium <add>tum</add>
+                  <note>tum <hi rend="italic">supplevi</hi>
+                  </note> virorum in hac re publica copia; quae cum esset, tamen
 				eorum non modo saluti sed etiam honori consulebatur. <reg>quid</reg> nunc vobis
 				faciendum est studiis militaribus apud iuventutem obsoletis,
-					<add>fortissimis</add><note>fortissimis <hi rend="italic">suppl. hoc loco
-						Müller</hi> (<hi rend="italic">post</hi> hominibus <hi rend="italic">Orelli</hi>)</note> autem<note>autem <hi rend="italic">V</hi>: aut <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: aut claris <hi rend="italic">k</hi></note> hominibus ac summis ducibus partim aetate,
+					<add>fortissimis</add>
+                  <note>fortissimis <hi rend="italic">suppl. hoc loco
+						Müller</hi> (<hi rend="italic">post</hi> hominibus <hi rend="italic">Orelli</hi>)</note> autem<note>autem <hi rend="italic">V</hi>: aut <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: aut claris <hi rend="italic">k</hi>
+                  </note> hominibus ac summis ducibus partim aetate,
 				partim civitatis discordiis ac rei publicae calamitate consumptis, cum tot bella aut
-				a nobis necessario suscipiantur aut subito atque improvisa<note>improviso <hi rend="italic">Lambinus</hi></note> nascantur? nonne et hominem ipsum ad
+				a nobis necessario suscipiantur aut subito atque improvisa<note>improviso <hi rend="italic">Lambinus</hi>
+                  </note> nascantur? nonne et hominem ipsum ad
 				dubia rei publicae tempora reservandum et ceteros studio laudis ac virtutis
-				inflammandos putatis? </p></div>
-				<div type="textpart" subtype="section" n="43"><p><reg>recordamini</reg> quos
-				legatos nuper in bello <add>Italico</add><note>Italico <hi rend="italic">supplevi</hi></note> L. Iulius, quos P. Rutilius, quos L. Cato, quos Cn.
+				inflammandos putatis? </p>
+            </div>
+            <div type="textpart" subtype="section" n="43">
+               <p>
+                  <reg>recordamini</reg> quos
+				legatos nuper in bello <add>Italico</add>
+                  <note>Italico <hi rend="italic">supplevi</hi>
+                  </note> L. Iulius, quos P. Rutilius, quos L. Cato, quos Cn.
 				Pompeius habuerit; scietis fuisse tum M. Cornutum, L. Cinnam, L. Sullam, praetorios
 				homines, belli gerendi peritissimos; praeterea C. Marium, P. Didium, Q. Catulum, P.
 				Crassum, non litteris homines ad rei militaris scientiam, sed rebus gestis ac
@@ -630,88 +1091,148 @@
 				abundare? <reg>quae</reg> si diligenter attendetis, profecto, iudices, virum ad
 				labores belli impigrum, ad pericula fortem, ad usum ac disciplinam peritum, ad
 				consilia prudentem, ad casum fortunamque felicem domi vobis ac liberis vestris
-				retinere quam inimicissimis populo Romano<note>populo R. <hi rend="italic">Klotz</hi>: rei p. <hi rend="italic">codd.</hi></note> nationibus et
+				retinere quam inimicissimis populo Romano<note>populo R. <hi rend="italic">Klotz</hi>: rei p. <hi rend="italic">codd.</hi>
+                  </note> nationibus et
 				crudelissimis tradere et condonare<note>condonare <hi rend="italic">k,
-					Faernus</hi>: condemnare <hi rend="italic">V<foreign xml:lang="grc">x</foreign>l</hi></note> maletis<note>maletis <hi rend="italic">kl,
-						Naugerius</hi> (1): malitis <hi rend="italic">V<foreign xml:lang="grc">x</foreign>l</hi></note>. </p></div><milestone n="20" unit="chapter"/>
-				<div type="textpart" subtype="section" n="44"><p>
-			<milestone unit="para"/><reg>at</reg><note>at <hi rend="italic">V</hi>: an <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: et <hi rend="italic">k</hi></note>
-				infestis prope signis inferuntur<note>inferuntur <hi rend="italic"><foreign xml:lang="grc">x</foreign>l, ed. R</hi>: inseruntur <hi rend="italic">V</hi>: instruuntur <hi rend="italic">k</hi></note> Galli in M.
-					Fonteium<note>Galli in M. <hi rend="italic">Halm</hi>: Gallim <hi rend="italic">V</hi>: Galli in <foreign xml:lang="grc">s</foreign></note>
+					Faernus</hi>: condemnare <hi rend="italic">V<foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note> maletis<note>maletis <hi rend="italic">kl,
+						Naugerius</hi> (1): malitis <hi rend="italic">V<foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note>. </p>
+            </div>
+            <milestone n="20" unit="chapter"/>
+            <div type="textpart" subtype="section" n="44">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>at</reg>
+                  <note>at <hi rend="italic">V</hi>: an <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: et <hi rend="italic">k</hi>
+                  </note>
+				infestis prope signis inferuntur<note>inferuntur <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l, ed. R</hi>: inseruntur <hi rend="italic">V</hi>: instruuntur <hi rend="italic">k</hi>
+                  </note> Galli in M.
+					Fonteium<note>Galli in M. <hi rend="italic">Halm</hi>: Gallim <hi rend="italic">V</hi>: Galli in <foreign xml:lang="grc">ς</foreign>
+                  </note>
 				et instant atque urgent summo cum studio, summa cum audacia. <reg>video</reg>,
 				iudices; sed<note>sed <hi rend="italic">Halm</hi>: c. et <hi rend="italic">V</hi>:
-					et <foreign xml:lang="grc">s</foreign></note> multis et firmis praesidiis vobis
+					et <foreign xml:lang="grc">ς</foreign>
+                  </note> multis et firmis praesidiis vobis
 				adiutoribus isti immani atque intolerandae barbariae resistemus. <reg>primum</reg>
 				obicitur contra istorum impetus Macedonia, fidelis et amica populo Romano provincia;
 				quae cum se ac suas urbis non solum consilio sed etiam manu M. Fontei<note>manu M.
-						<hi rend="italic">Halm</hi>: manum <hi rend="italic">V</hi>: manu <foreign xml:lang="grc">s</foreign></note> conservatam esse dicat, ut<note>ut <hi rend="italic">om. V1</hi></note> ipsa<note>ipsa <hi rend="italic">scripsi</hi> (<hi rend="italic">cf vv.</hi> 14, 18): illa <hi rend="italic">codd.</hi></note> per hunc a Thraecum<note>a Thraecum <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: atgrecum <hi rend="italic">V</hi>: a Graecorum <hi rend="italic">k</hi></note> adventu
-				ac depopulatione defensa <add>est</add><note>est <hi rend="italic">Faernus</hi>:
-						<hi rend="italic">om. V<foreign xml:lang="grc">x</foreign></hi>: fuit <hi rend="italic">k</hi></note>, sic ab huius nunc capite Gallorum impetus
-				terroresque depellit. </p></div>
-				<div type="textpart" subtype="section" n="45"><p><reg>constituitur</reg> ex
-				altera parte ulterior Hispania, quae profecto <add>non</add><note>non <foreign xml:lang="grc">s</foreign>: <hi rend="italic">om. V</hi> modo <hi rend="italic">V<foreign xml:lang="grc">x</foreign>l</hi>: solum <hi rend="italic">k</hi></note> modo religione sua resistere istorum cupiditati
+						<hi rend="italic">Halm</hi>: manum <hi rend="italic">V</hi>: manu <foreign xml:lang="grc">ς</foreign>
+                  </note> conservatam esse dicat, ut<note>ut <hi rend="italic">om. V1</hi>
+                  </note> ipsa<note>ipsa <hi rend="italic">scripsi</hi> (<hi rend="italic">cf vv.</hi> 14, 18): illa <hi rend="italic">codd.</hi>
+                  </note> per hunc a Thraecum<note>a Thraecum <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: atgrecum <hi rend="italic">V</hi>: a Graecorum <hi rend="italic">k</hi>
+                  </note> adventu
+				ac depopulatione defensa <add>est</add>
+                  <note>est <hi rend="italic">Faernus</hi>:
+						<hi rend="italic">om. V<foreign xml:lang="grc">χ</foreign>
+                     </hi>: fuit <hi rend="italic">k</hi>
+                  </note>, sic ab huius nunc capite Gallorum impetus
+				terroresque depellit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="45">
+               <p>
+                  <reg>constituitur</reg> ex
+				altera parte ulterior Hispania, quae profecto <add>non</add>
+                  <note>non <foreign xml:lang="grc">ς</foreign>: <hi rend="italic">om. V</hi> modo <hi rend="italic">V<foreign xml:lang="grc">χ</foreign>l</hi>: solum <hi rend="italic">k</hi>
+                  </note> modo religione sua resistere istorum cupiditati
 				potest sed etiam sceleratorum hominum periuria testimoniis ac laudationibus suis
 				refutare. <reg>atque</reg> ex ipsa etiam Gallia fidelissima et gravissima auxilia
 				sumuntur. <reg>venit</reg> huic subsidio misero atque innocenti Massiliensium cuncta
 				civitas, quae non solum ob eam causam laborat ut huic, a quo ipsa servata est, parem
-				gratiam referre<note>referre <hi rend="italic">kl, ed. R</hi>: referri <hi rend="italic">V<foreign xml:lang="grc">x</foreign></hi></note> videatur sed
+				gratiam referre<note>referre <hi rend="italic">kl, ed. R</hi>: referri <hi rend="italic">V<foreign xml:lang="grc">χ</foreign>
+                     </hi>
+                  </note> videatur sed
 				etiam quod ea condicione atque eo fato se in eis<note>iis <hi rend="italic">l,
-						Manutius</hi>: his <hi rend="italic">cett.</hi></note> terris conlocatam
-				esse arbitratur ne quid nostris hominibus istae gentes nocere possint. </p></div>
-				<div type="textpart" subtype="section" n="46"><p><reg>propugnat</reg> pariter pro salute M. Fontei
+						Manutius</hi>: his <hi rend="italic">cett.</hi>
+                  </note> terris conlocatam
+				esse arbitratur ne quid nostris hominibus istae gentes nocere possint. </p>
+            </div>
+            <div type="textpart" subtype="section" n="46">
+               <p>
+                  <reg>propugnat</reg> pariter pro salute M. Fontei
 				Narbonensis colonia, quae per hunc ipsa nuper obsidione hostium liberata nunc
 				eiusdem miseriis ac periculis commovetur. <reg>denique</reg> ut oportet bello
 				Gallico, ut maiorum iura moresque praescribunt, nemo est civis Romanus qui sibi ulla
 				excusatione utendum putet; omnes illius provinciae publicani, agricolae, pecuarii,
-				ceteri negotiatores uno animo M. Fonteium atque una voce defendunt. <milestone n="21" unit="chapter"/><reg>quod</reg> si tantas auxiliorum nostrorum copias
+				ceteri negotiatores uno animo M. Fonteium atque una voce defendunt. <milestone n="21" unit="chapter"/>
+                  <reg>quod</reg> si tantas auxiliorum nostrorum copias
 				Indutiomarus ipse despexerit, dux Allobrogum ceterorumque Gallorum<note>dux ...
-					Gallorum <hi rend="italic">del. Bake</hi></note>, num etiam de matris hunc
+					Gallorum <hi rend="italic">del. Bake</hi>
+                  </note>, num etiam de matris hunc
 				complexu, lectissimae miserrimaeque feminae, vobis inspectantibus avellet atque
 				abstrahet? praesertim cum virgo Vestalis ex altera parte germanum fratrem complexa
-				teneat vestramque, iudices, ac populi Romani<note>ac populi R. <foreign xml:lang="grc">s</foreign>: a p. R. <hi rend="italic">V</hi></note> fidem
+				teneat vestramque, iudices, ac populi Romani<note>ac populi R. <foreign xml:lang="grc">ς</foreign>: a p. R. <hi rend="italic">V</hi>
+                  </note> fidem
 				imploret; quae pro vobis liberisque vestris tot annos in dis immortalibus placandis
 				occupata est ut ea nunc pro salute sua fratrisque sui animos vestros placare possit.
-					</p></div>
-				<div type="textpart" subtype="section" n="47"><p><reg>cui</reg> miserae quod praesidium, quod
-					solacium<note>solatium <foreign xml:lang="grc">s</foreign> (<hi rend="italic">ita v.</hi> 20)</note> reliquum<note>reliquum <hi rend="italic">k</hi>:
-					relicum <hi rend="italic">V</hi>: <hi rend="italic">om. <foreign xml:lang="grc">x</foreign>l</hi></note> est hoc amisso? <reg>nam</reg>
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="47">
+               <p>
+                  <reg>cui</reg> miserae quod praesidium, quod
+					solacium<note>solatium <foreign xml:lang="grc">ς</foreign> (<hi rend="italic">ita v.</hi> 20)</note> reliquum<note>reliquum <hi rend="italic">k</hi>:
+					relicum <hi rend="italic">V</hi>: <hi rend="italic">om. <foreign xml:lang="grc">χ</foreign>l</hi>
+                  </note> est hoc amisso? <reg>nam</reg>
 				ceterae feminae gignere ipsae sibi praesidia et habere domi fortunarum omnium socium
 				participemque possunt; huic vero virgini quid est praeter fratrem quod aut iucundum
 				aut carum esse possit? <reg>nolite</reg> pati, iudices, aras deorum immortalium
 				Vestaeque matris cotidianis virginis lamentationibus de vestro iudicio
-					commoneri<note>commoneri <hi rend="italic">V</hi>: commoveri <foreign xml:lang="grc">s</foreign></note>; prospicite ne ille ignis aeternus
+					commoneri<note>commoneri <hi rend="italic">V</hi>: commoveri <foreign xml:lang="grc">ς</foreign>
+                  </note>; prospicite ne ille ignis aeternus
 				nocturnis Fonteiae laboribus vigiliisque servatus sacerdotis
-						vestrae<note><app><lem>vestrae</lem></app> Vestae <hi rend="italic">ed.
-					R</hi></note> lacrimis exstinctus esse dicatur. </p></div>
-				<div type="textpart" subtype="section" n="48"><p><reg>tendit</reg><note>tendit <hi rend="italic">kl, Faernus</hi>: tendet <hi rend="italic">V<foreign xml:lang="grc">x</foreign></hi></note> ad vos virgo
+						vestrae<note>
+                     <app>
+                        <lem>vestrae</lem>
+                     </app> Vestae <hi rend="italic">ed.
+					R</hi>
+                  </note> lacrimis exstinctus esse dicatur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="48">
+               <p>
+                  <reg>tendit</reg>
+                  <note>tendit <hi rend="italic">kl, Faernus</hi>: tendet <hi rend="italic">V<foreign xml:lang="grc">χ</foreign>
+                     </hi>
+                  </note> ad vos virgo
 				Vestalis manus supplices easdem quas pro vobis dis immortalibus tendere consuevit.
 				Cavete ne periculosum superbumque sit eius vos obsecrationem repudiare cuius preces
-				si di aspernarentur, haec salva esse non possent<note>possent <foreign xml:lang="grc">s</foreign>: possunt <hi rend="italic">V</hi></note>.
+				si di aspernarentur, haec salva esse non possent<note>possent <foreign xml:lang="grc">ς</foreign>: possunt <hi rend="italic">V</hi>
+                  </note>.
 					<reg>videtisne</reg> subito, iudices, virum fortissimum, M. Fonteium, parentis
 				et sororis commemoratione lacrimas profudisse? <reg>qui</reg> numquam in acie
 				pertimuerit, qui se armatus saepe in hostium manum multitudinemque immiserit, cum in
 				eius modi periculis eadem se solacia suis relinquere arbitraretur quae suus pater
-				sibi reliquisset, idem nunc conturbato<note>perturbato <foreign xml:lang="grc">x</foreign></note> animo pertimescit ne non modo ornamento et adiumento non
+				sibi reliquisset, idem nunc conturbato<note>perturbato <foreign xml:lang="grc">χ</foreign>
+                  </note> animo pertimescit ne non modo ornamento et adiumento non
 				sit suis sed etiam cum acerbissimo luctu dedecus aeternum miseris atque ignominiam
-				relinquat. </p></div>
-				<div type="textpart" subtype="section" n="49"><p>O fortunam longe disparem, M. Fontei,
+				relinquat. </p>
+            </div>
+            <div type="textpart" subtype="section" n="49">
+               <p>O fortunam longe disparem, M. Fontei,
 				si deligere potuisses ut potius telis tibi Gallorum quam periuriis intereundum
-				esset! <reg>tum</reg> enim<note>tum enim <foreign xml:lang="grc">s</foreign>: tuam
-					enim <hi rend="italic">V</hi> cuius <hi rend="italic">Cus.</hi></note> vitae
-				socia virtus, mortis<note>morti <hi rend="italic">Cus.</hi></note> comes gloria
+				esset! <reg>tum</reg> enim<note>tum enim <foreign xml:lang="grc">ς</foreign>: tuam
+					enim <hi rend="italic">V</hi> cuius <hi rend="italic">Cus.</hi>
+                  </note> vitae
+				socia virtus, mortis<note>morti <hi rend="italic">Cus.</hi>
+                  </note> comes gloria
 				fuisset; nunc vero qui est dolor victoriae te atque imperi poenas ad eorum arbitrium
 				sufferre qui aut victi armis sunt aut invitissimi paruerunt! A quo periculo
 				defendite, iudices, civem fortem atque innocentem; curate ut nostris testibus plus
 				quam alienigenis credidisse videamini, plus saluti civium quam hostium libidini
 				consuluisse, graviorem duxisse eius obsecrationem quae vestris sacris
-					praesit<note>praeest <hi rend="italic">Madvig</hi></note> quam eorum audaciam
+					praesit<note>praeest <hi rend="italic">Madvig</hi>
+                  </note> quam eorum audaciam
 				qui cum omnium sacris delubrisque bella gesserunt<note>gesserint <hi rend="italic">Klotz</hi> (<hi rend="italic">malo numero</hi>)</note>.
 					<reg>postremo</reg> prospicite, iudices, id quod ad dignitatem populi Romani
-				maxime pertinet, ut plus<note>ut plus <hi rend="italic"><foreign xml:lang="grc">x</foreign>l</hi>: vitiis <hi rend="italic">V</hi>: ut potius <hi rend="italic">k</hi></note> apud vos preces virginis Vestalis quam minae
+				maxime pertinet, ut plus<note>ut plus <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>l</hi>: vitiis <hi rend="italic">V</hi>: ut potius <hi rend="italic">k</hi>
+                  </note> apud vos preces virginis Vestalis quam minae
 				Gallorum valuisse videantur. 
 				</p>
-				</div>
-			</div>
-	</body>
-</text>
+            </div>
+         </div>
+      </body>
+   </text>
 </TEI>

--- a/data/phi0474/phi015/phi0474.phi015.perseus-lat2.xml
+++ b/data/phi0474/phi015/phi0474.phi015.perseus-lat2.xml
@@ -1,68 +1,66 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
-
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-	<teiHeader xml:lang="eng">
-		<fileDesc>
-			<titleStmt>
-				<title>In Defense of Publius Sulla</title>
-				<title>Pro Tullio, Pro Fonteio, Pro Sulla, Pro Archia, Pro Plancio, Pro
+   <teiHeader xml:lang="eng">
+      <fileDesc>
+         <titleStmt>
+            <title>In Defense of Publius Sulla</title>
+            <title>Pro Tullio, Pro Fonteio, Pro Sulla, Pro Archia, Pro Plancio, Pro
 					Scauro</title>
-				<title type="sub">Machine readable text</title>
-				<author n="Cic.">M. Tullius Cicero</author>
-				<editor role="editor" n="OCT">Albert Clark</editor>
-				<sponsor>Perseus Project, Tufts University</sponsor>
-				<principal>Gregory Crane</principal>
-				<respStmt>
-					<resp>Prepared under the supervision of</resp>
-					<name>Bridget Almas</name>
-					<name>Lisa Cerrato</name>
-					<name>William Merrill</name>
-					<name>David Mimno</name>
-					<name>Rashmi Singhal</name>
-					<name>David Smith</name>
-				</respStmt>
-				<funder n="org:NEH">National Endowment For The Humanities (NEH)</funder> 
-			</titleStmt>
-			<publicationStmt>
-				<publisher>Trustees of Tufts University</publisher>
-				<pubPlace>Medford, MA</pubPlace>
-				<authority>Perseus Project</authority>
-				<date type="release">1997-10-28</date>
-			</publicationStmt> 
-			
-			<sourceDesc>
-				<biblStruct>
-					<monogr>
-						<author>M. Tullius Cicero</author>
-						<title>M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica
+            <title type="sub">Machine readable text</title>
+            <author n="Cic.">M. Tullius Cicero</author>
+            <editor role="editor" n="OCT">Albert Clark</editor>
+            <sponsor>Perseus Project, Tufts University</sponsor>
+            <principal>Gregory Crane</principal>
+            <respStmt>
+               <resp>Prepared under the supervision of</resp>
+               <name>Bridget Almas</name>
+               <name>Lisa Cerrato</name>
+               <name>William Merrill</name>
+               <name>David Mimno</name>
+               <name>Rashmi Singhal</name>
+               <name>David Smith</name>
+            </respStmt>
+            <funder n="org:NEH">National Endowment For The Humanities (NEH)</funder>
+         </titleStmt>
+         <publicationStmt>
+            <publisher>Trustees of Tufts University</publisher>
+            <pubPlace>Medford, MA</pubPlace>
+            <authority>Perseus Project</authority>
+            <date type="release">1997-10-28</date>
+         </publicationStmt>
+         <sourceDesc>
+            <biblStruct>
+               <monogr>
+                  <author>M. Tullius Cicero</author>
+                  <title>M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica
 							instruxit Albertus Curtis Clark</title>
-						<editor role="editor">Albert Clark</editor>
-						<imprint>
-							<pubPlace>Oxonii</pubPlace>
-							<publisher>e Typographeo Clarendoniano</publisher>
-							<date>1909</date>
-						</imprint>
-					</monogr>
-					<series>
-						<title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
-					</series>
-				</biblStruct>
-			</sourceDesc>
-		</fileDesc>
-		
-		<encodingDesc>
-			<refsDecl n="CTS">
-				<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
-					<p>This pointer pattern extracts section</p>
-				</cRefPattern>
-			</refsDecl>
-			<refsDecl>
-				<refState unit="section"/>
-			</refsDecl>
-		</encodingDesc>
-		
-		<!-- 		<encodingDesc>
+                  <editor role="editor">Albert Clark</editor>
+                  <imprint>
+                     <pubPlace>Oxonii</pubPlace>
+                     <publisher>e Typographeo Clarendoniano</publisher>
+                     <date>1909</date>
+                  </imprint>
+               </monogr>
+               <series>
+                  <title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
+               </series>
+            </biblStruct>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <refsDecl n="CTS">
+            <cRefPattern n="section"
+                         matchPattern="(\w+)"
+                         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+               <p>This pointer pattern extracts section</p>
+            </cRefPattern>
+         </refsDecl>
+         <refsDecl>
+            <refState unit="section"/>
+         </refsDecl>
+      </encodingDesc>
+      <!-- 		<encodingDesc>
 			<refsDecl>
 				<refState delim=" " unit="text"/>
 				<refState unit="section"/>
@@ -73,1865 +71,2480 @@
 				<refState unit="section"/>
 			</refsDecl>
 		</encodingDesc> -->
-		
-		<profileDesc>
-			<langUsage>
-				<language ident="lat">Latin</language>
-				<language ident="grc">Greek</language>
-			</langUsage>
-		</profileDesc>
-		
-		<revisionDesc>
-			<change when="2016-04-20" who="Lisa Cerrato">Minor edits and review of CTS and EpiDoc work.</change>
-			<change when="2016-03-15" who="Zach Himes">Changed section milestones to divs.</change>
-			<change when="2015-12-17" who="Zach Himes">Cleaned up teiHeader.</change>
-			<change when="2014-08-01" who="Stella Dee">edited markup</change>
-			<change when="2014-07-01" who="Stella Dee">split composite text and converted to unicode</change>
-			<change when="2013-09-13" who="balmas01">reverting texts back to pre_cts_reorg tagged version</change>
-			<change when="2011-07-19" who="gcrane">removed the earlier persName/placeName tags</change>
-			<change when="2011-01-15" who="gcrane">base SDL file</change>
-			<change when="2009-10-09" who="rsingh04">more reorganizing of texts module by collection</change>
-			<change when="2006-08-11" who="gcrane">small mods</change>
-			<change when="2006-04-21" who="gcrane">these now have the app crit entered as notes</change>
-			<change when="2005-08-01" who="packel">removed stray item tags</change>
-			<change when="2005-07-25" who="packel">Converted to XML</change>
-			<change when="2005-04-08" who="mimno">added default chunks</change>
-			<change when="2003-07-01" who="yorkc">Updated texts to TEI P4 and Perseus P4 extensions; minor cleanup (esp. character encodings and typos.)</change>
-			<change when="2002-12-02" who="amahoney">correct spelling of Quirites, improperly 'regularized'</change>
-			<change when="2000-03-04" who="dasmith">Added separate funder entity to TEI header.</change>
-			<change when="1999-10-14" who="dasmith">Added explanatory subtitles to titleStmt</change>
-			<change when="1999-08-12" who="dasmith">Fixed refsDecl</change>
-			<change when="1999-08-04" who="textgod">Random changes over a period of months.</change>
-			<change when="1997-10-17" who="textgod">Added CVS log.</change>
-			<change when="1997-03-26" who="DAS">ed.</change>
-		</revisionDesc>
-	</teiHeader>
-	
-	<text xml:lang="lat">
-		<body>
-			<div type="edition" xml:lang="lat" n="urn:cts:latinLit:phi0474.phi015.perseus-lat2" subtype="edition">
-			<head>PRO P. SVLLA ORATIO</head>
-				<milestone unit="para"/>
-				<milestone n="1" unit="chapter"/>
-			<div type="textpart" subtype="section" n="1"><p>
-			<reg>maxime</reg> vellem, iudices, ut P. Sulla et antea dignitatis suae splendorem
+      <profileDesc>
+         <langUsage>
+            <language ident="lat">Latin</language>
+            <language ident="grc">Greek</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2016-04-20" who="Lisa Cerrato">Minor edits and review of CTS and EpiDoc work.</change>
+         <change when="2016-03-15" who="Zach Himes">Changed section milestones to divs.</change>
+         <change when="2015-12-17" who="Zach Himes">Cleaned up teiHeader.</change>
+         <change when="2014-08-01" who="Stella Dee">edited markup</change>
+         <change when="2014-07-01" who="Stella Dee">split composite text and converted to unicode</change>
+         <change when="2013-09-13" who="balmas01">reverting texts back to pre_cts_reorg tagged version</change>
+         <change when="2011-07-19" who="gcrane">removed the earlier persName/placeName tags</change>
+         <change when="2011-01-15" who="gcrane">base SDL file</change>
+         <change when="2009-10-09" who="rsingh04">more reorganizing of texts module by collection</change>
+         <change when="2006-08-11" who="gcrane">small mods</change>
+         <change when="2006-04-21" who="gcrane">these now have the app crit entered as notes</change>
+         <change when="2005-08-01" who="packel">removed stray item tags</change>
+         <change when="2005-07-25" who="packel">Converted to XML</change>
+         <change when="2005-04-08" who="mimno">added default chunks</change>
+         <change when="2003-07-01" who="yorkc">Updated texts to TEI P4 and Perseus P4 extensions; minor cleanup (esp. character encodings and typos.)</change>
+         <change when="2002-12-02" who="amahoney">correct spelling of Quirites, improperly 'regularized'</change>
+         <change when="2000-03-04" who="dasmith">Added separate funder entity to TEI header.</change>
+         <change when="1999-10-14" who="dasmith">Added explanatory subtitles to titleStmt</change>
+         <change when="1999-08-12" who="dasmith">Fixed refsDecl</change>
+         <change when="1999-08-04" who="textgod">Random changes over a period of months.</change>
+         <change when="1997-10-17" who="textgod">Added CVS log.</change>
+         <change when="1997-03-26" who="DAS">ed.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text xml:lang="lat">
+      <body>
+         <div type="edition"
+              xml:lang="lat"
+              n="urn:cts:latinLit:phi0474.phi015.perseus-lat2"
+              subtype="edition">
+            <head>PRO P. SVLLA ORATIO</head>
+            <milestone unit="para"/>
+            <milestone n="1" unit="chapter"/>
+            <div type="textpart" subtype="section" n="1">
+               <p>
+                  <reg>maxime</reg> vellem, iudices, ut P. Sulla et antea dignitatis suae splendorem
 				obtinere et<note>obtineret <hi rend="italic">codd.</hi>: <hi rend="italic">corr.
 						Naugerius</hi> (1)</note> post calamitatem acceptam modestiae fructum
 				aliquem percipere potuisset<note>percipere potuisset <hi rend="italic">TEc</hi>:
-					potuisset percipere <hi rend="italic">cett.</hi></note>. <reg>sed</reg> quoniam
-				ita tulit casus infestus ut in<note><app><lem>in</lem></app> et in <hi rend="italic"
-						>e</hi>: et <hi rend="italic">Halm</hi></note> amplissimo honore cum
+					potuisset percipere <hi rend="italic">cett.</hi>
+                  </note>. <reg>sed</reg> quoniam
+				ita tulit casus infestus ut in<note>
+                     <app>
+                        <lem>in</lem>
+                     </app> et in <hi rend="italic">e</hi>: et <hi rend="italic">Halm</hi>
+                  </note> amplissimo honore cum
 				communi ambitionis invidia tum singulari Autroni odio everteretur, et in his
 				pristinae fortunae reliquiis miseris et adflictis tamen haberet quosdam quorum
 				animos ne supplicio quidem suo satiare posset, quamquam ex huius incommodis magnam
 				animo molestiam capio, tamen in ceteris malis facile patior oblatum mihi tempus
-					esse<note>esse <hi rend="italic">Te<foreign xml:lang="grc">p</foreign></hi>:
-						<hi rend="italic">om. cett.</hi></note> in quo boni viri lenitatem meam
-				misericordiamque, notam quondam omnibus<note>quondam omnibus <hi rend="italic"
-						>Te</hi>: omnibus quondam <hi rend="italic">cett.</hi></note>, nunc quasi
-				intermissam agnoscerent, improbi ac perditi cives domiti<note>domiti <hi
-						rend="italic">scripsi</hi>: re domiti <hi rend="italic">T</hi>: redomiti
-						<hi rend="italic">cett.</hi> (re <hi rend="italic">ex</hi> re p. <hi
-						rend="italic">geminatum puto</hi>)</note> atque victi<note>revicti <hi
-						rend="italic">b2, Reid</hi></note> praecipitante re publica vehementem me
-				fuisse atque fortem, conservata mitem ac misericordem faterentur. </p></div>
-			<div type="textpart" subtype="section" n="2"><p>
-				<reg>et</reg> quoniam L. Torquatus, meus familiaris ac
+					esse<note>esse <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>:
+						<hi rend="italic">om. cett.</hi>
+                  </note> in quo boni viri lenitatem meam
+				misericordiamque, notam quondam omnibus<note>quondam omnibus <hi rend="italic">Te</hi>: omnibus quondam <hi rend="italic">cett.</hi>
+                  </note>, nunc quasi
+				intermissam agnoscerent, improbi ac perditi cives domiti<note>domiti <hi rend="italic">scripsi</hi>: re domiti <hi rend="italic">T</hi>: redomiti
+						<hi rend="italic">cett.</hi> (re <hi rend="italic">ex</hi> re p. <hi rend="italic">geminatum puto</hi>)</note> atque victi<note>revicti <hi rend="italic">b2, Reid</hi>
+                  </note> praecipitante re publica vehementem me
+				fuisse atque fortem, conservata mitem ac misericordem faterentur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="2">
+               <p>
+                  <reg>et</reg> quoniam L. Torquatus, meus familiaris ac
 				necessarius, iudices, existimavit, si nostram in accusatione sua
-					necessitudinem<note>necessitudinem <hi rend="italic">Tek</hi>: necessitatem <hi
-						rend="italic">cett.</hi></note> familiaritatemque violasset, aliquid se de
+					necessitudinem<note>necessitudinem <hi rend="italic">Tek</hi>: necessitatem <hi rend="italic">cett.</hi>
+                  </note> familiaritatemque violasset, aliquid se de
 				auctoritate meae defensionis posse detrahere, cum huius periculi propulsatione
 				coniungam defensionem offici mei. <reg>quo</reg> quidem genere non uterer
-					orationis<note>orationis non uterer <hi rend="italic">e<foreign xml:lang="grc"
-							>p</foreign></hi></note>, iudices, hoc tempore, si mea solum interesset;
+					orationis<note>orationis non uterer <hi rend="italic">e<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note>, iudices, hoc tempore, si mea solum interesset;
 				multis enim locis mihi<note>mihi <hi rend="italic">hoc loco hab. T, post</hi> data
-						<hi rend="italic">e, ante</hi> locis <hi rend="italic">cett.</hi></note>
+						<hi rend="italic">e, ante</hi> locis <hi rend="italic">cett.</hi>
+                  </note>
 				et data facultas est et saepe dabitur de mea laude dicendi; sed, ut ille
-					vidit<note>vidit <hi rend="italic">Te<foreign xml:lang="grc">p</foreign></hi>:
-					iudices <hi rend="italic">cett.</hi></note>, quantum de mea auctoritate
+					vidit<note>vidit <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>:
+					iudices <hi rend="italic">cett.</hi>
+                  </note>, quantum de mea auctoritate
 				deripuisset, tantum se de huius praesidiis
-						deminuturum<note><app><lem>deminuturum</lem></app> speravit <hi rend="italic">add.
-							<foreign xml:lang="grc">S</foreign> mg.</hi>: putavit (-tat <foreign
-						xml:lang="grc">sy1</foreign>) <hi rend="italic">add. b2<foreign
-							xml:lang="grc">y2s</foreign></hi></note>, sic hoc ego sentio, si mei
+						deminuturum<note>
+                     <app>
+                        <lem>deminuturum</lem>
+                     </app> speravit <hi rend="italic">add.
+							<foreign xml:lang="grc">ς</foreign> mg.</hi>: putavit (-tat <foreign xml:lang="grc">σψ1</foreign>) <hi rend="italic">add. b2<foreign xml:lang="grc">ψ2ς</foreign>
+                     </hi>
+                  </note>, sic hoc ego sentio, si mei
 				facti rationem vobis constantiamque huius offici ac defensionis
-					probaro<note>probavero <hi rend="italic">e<foreign xml:lang="grc"
-						>p</foreign></hi></note>, causam quoque me P. Sullae probaturum. </p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="3"><p>
-			<reg>ac</reg> primum abs te illud, L. Torquate, quaero, cur me a ceteris clarissimis
+					probaro<note>probavero <hi rend="italic">e<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note>, causam quoque me P. Sullae probaturum. </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="3">
+               <p>
+                  <reg>ac</reg> primum abs te illud, L. Torquate, quaero, cur me a ceteris clarissimis
 				viris ac principibus civitatis in hoc officio atque in defensionis iure secernas.
 					<reg>quid</reg> enim est quam ob rem abs te Q. Hortensi factum, clarissimi viri
-				atque ornatissimi, non reprehendatur<note>reprehendatur (<hi rend="italic"
-						>semel</hi>) <hi rend="italic">ea</hi></note>, reprehendatur meum?
+				atque ornatissimi, non reprehendatur<note>reprehendatur (<hi rend="italic">semel</hi>) <hi rend="italic">ea</hi>
+                  </note>, reprehendatur meum?
 					<reg>nam</reg>, si est initum a P. Sulla consilium inflammandae huius
-					urbis<note>huius urbis <hi rend="italic">Halm</hi>: huius urbis huius <hi
-						rend="italic">e</hi>: huius civitatis <hi rend="italic">T</hi>: civitatis
-					huius <hi rend="italic">cett.</hi></note>, exstinguendi imperi, delendae
-					civitatis<note>civitatis <hi rend="italic">e</hi>: urbis <hi rend="italic"
-						>cett.</hi></note>, mihi<note>michi me <hi rend="italic">e</hi>: mihine <hi
-						rend="italic">Halm</hi></note> maiorem hae res dolorem quam Q. Hortensio,
+					urbis<note>huius urbis <hi rend="italic">Halm</hi>: huius urbis huius <hi rend="italic">e</hi>: huius civitatis <hi rend="italic">T</hi>: civitatis
+					huius <hi rend="italic">cett.</hi>
+                  </note>, exstinguendi imperi, delendae
+					civitatis<note>civitatis <hi rend="italic">e</hi>: urbis <hi rend="italic">cett.</hi>
+                  </note>, mihi<note>michi me <hi rend="italic">e</hi>: mihine <hi rend="italic">Halm</hi>
+                  </note> maiorem hae res dolorem quam Q. Hortensio,
 				mihi maius odium adferre debent, meum denique gravius esse iudicium, qui adiuvandus
 				in his causis, qui oppugnandus, qui defendendus, qui deserendus esse
-					videatur<note>videtur <hi rend="italic">e</hi></note>? '<reg>ita</reg>,'
-				inquit; 'tu enim investigasti, tu patefecisti coniurationem.' </p></div><milestone n="2" unit="chapter"/>
-			<div type="textpart" subtype="section" n="4"><p><reg>quod</reg> cum dicit,non attendit eum qui patefecerit hoc curasse, ut id omnes viderent quod antea fuisset
+					videatur<note>videtur <hi rend="italic">e</hi>
+                  </note>? '<reg>ita</reg>,'
+				inquit; 'tu enim investigasti, tu patefecisti coniurationem.' </p>
+            </div>
+            <milestone n="2" unit="chapter"/>
+            <div type="textpart" subtype="section" n="4">
+               <p>
+                  <reg>quod</reg> cum dicit,non attendit eum qui patefecerit hoc curasse, ut id omnes viderent quod antea fuisset
 				occultum. <reg>qua</reg> re ista coniuratio, si patefacta per me est, tam patet
-				Hortensio quam mihi. <reg>quem</reg> cum videas hoc honore<note>hoc honore <hi
-						rend="italic">Te</hi>: honore hoc <hi rend="italic">cett.</hi></note>,
+				Hortensio quam mihi. <reg>quem</reg> cum videas hoc honore<note>hoc honore <hi rend="italic">Te</hi>: honore hoc <hi rend="italic">cett.</hi>
+                  </note>,
 				auctoritate, virtute, consilio praeditum non dubitasse quin innocentiam P.
 					Sullae<note>innocentiam P. Sillae <hi rend="italic">e</hi>: innocentem P.
-					sillam (syllo <hi rend="italic">T</hi>) <hi rend="italic">cett.</hi></note>
+					sillam (syllo <hi rend="italic">T</hi>) <hi rend="italic">cett.</hi>
+                  </note>
 				defenderet, quaero cur qui aditus ad causam Hortensio patuerit mihi interclusus esse
 				debuerit; quaero illud etiam, si me, qui defendo, reprehendendum putas esse, quid
 				tandem de his existimes summis viris et clarissimis civibus, quorum studio et
 				dignitate celebrari hoc iudicium, ornari causam, defendi huius innocentiam vides.
 					<reg>non</reg> enim una ratio est<note>est <hi rend="italic">hoc loco hab. T,
-						ante</hi> una <hi rend="italic">e, post</hi> una <hi rend="italic"
-						>cett.</hi></note> defensionis ea quae posita est in oratione; omnes qui
-					adsunt<note>adsunt <hi rend="italic">edd. VR</hi>: assunt <hi rend="italic"
-						>codd.</hi></note>, qui laborant, qui salvum volunt, pro sua parte atque
-				auctoritate defendunt. </p></div>
-			<div type="textpart" subtype="section" n="5"><p><reg>an</reg> vero, in
+						ante</hi> una <hi rend="italic">e, post</hi> una <hi rend="italic">cett.</hi>
+                  </note> defensionis ea quae posita est in oratione; omnes qui
+					adsunt<note>adsunt <hi rend="italic">edd. VR</hi>: assunt <hi rend="italic">codd.</hi>
+                  </note>, qui laborant, qui salvum volunt, pro sua parte atque
+				auctoritate defendunt. </p>
+            </div>
+            <div type="textpart" subtype="section" n="5">
+               <p>
+                  <reg>an</reg> vero, in
 				quibus subselliis haec ornamenta ac lumina rei publicae viderem, in his me apparere
 				nollem, cum ego<note>cum ego <hi rend="italic">cod. Halmii</hi>: quorum ego (ope
-						<hi rend="italic">add. <foreign xml:lang="grc">S</foreign> mg.,</hi>
-					auxilio <hi rend="italic">add. b2<foreign xml:lang="grc">ys</foreign></hi>) <hi
-						rend="italic">mei</hi></note> illum in locum atque in hanc
-					excelsissimam<note>excelsissimam <hi rend="italic">e</hi>: celsissimam <hi
-						rend="italic">cett.</hi></note> sedem dignitatis
-						atque<note><app><lem>atque</lem></app> et <hi rend="italic">e</hi></note> honoris
-				multis meis ac<note><app><lem>ac</lem></app> et <hi rend="italic">T</hi></note> magnis
+						<hi rend="italic">add. <foreign xml:lang="grc">ς</foreign> mg.,</hi>
+					auxilio <hi rend="italic">add. b2<foreign xml:lang="grc">ψς</foreign>
+                     </hi>) <hi rend="italic">mei</hi>
+                  </note> illum in locum atque in hanc
+					excelsissimam<note>excelsissimam <hi rend="italic">e</hi>: celsissimam <hi rend="italic">cett.</hi>
+                  </note> sedem dignitatis
+						atque<note>
+                     <app>
+                        <lem>atque</lem>
+                     </app> et <hi rend="italic">e</hi>
+                  </note> honoris
+				multis meis ac<note>
+                     <app>
+                        <lem>ac</lem>
+                     </app> et <hi rend="italic">T</hi>
+                  </note> magnis
 				laboribus et periculis ascendissem? <reg>atque</reg> ut intellegas, Torquate, quem
 				accuses, si te forte<note>forte <hi rend="italic">e</hi>: <hi rend="italic">om.
-						cett.</hi></note> id offendit quod ego, qui in<note>in <hi rend="italic"
-						>e</hi>: <hi rend="italic">om. cett.</hi></note> hoc genere quaestionis
+						cett.</hi>
+                  </note> id offendit quod ego, qui in<note>in <hi rend="italic">e</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> hoc genere quaestionis
 				defenderim neminem, non desim P. Sullae, recordare de ceteris quos adesse huic
 				vides; intelleges et de hoc et de aliis<note>aliis <hi rend="italic">Te</hi>:
-					ceteris <hi rend="italic">cett.</hi></note> iudicium meum et horum par atque
-				unum fuisse. </p></div>
-			<div type="textpart" subtype="section" n="6"><p><reg>quis</reg> nostrum adfuit
-				Vargunteio? <reg>nemo</reg>, ne hic quidem Q. Hortensius<note>Q. <hi rend="italic"
-						>om. e</hi></note>, praesertim qui illum solus antea de ambitu defendisset.
+					ceteris <hi rend="italic">cett.</hi>
+                  </note> iudicium meum et horum par atque
+				unum fuisse. </p>
+            </div>
+            <div type="textpart" subtype="section" n="6">
+               <p>
+                  <reg>quis</reg> nostrum adfuit
+				Vargunteio? <reg>nemo</reg>, ne hic quidem Q. Hortensius<note>Q. <hi rend="italic">om. e</hi>
+                  </note>, praesertim qui illum solus antea de ambitu defendisset.
 					<reg>non</reg> enim iam se ullo officio cum illo coniunctum arbitrabatur, cum
 				ille tanto scelere commisso omnium officiorum societatem diremisset. <reg>quis</reg>
-				nostrum Serv. Sullam, quis Publium<note><app><lem>Publium</lem></app> P. Lentulum <foreign
-						xml:lang="grc">s</foreign></note>, quis M. Laecam, quis
-					<add>C.</add><note>C. <hi rend="italic">suppl. Manutius</hi></note> Cornelium
+				nostrum Serv. Sullam, quis Publium<note>
+                     <app>
+                        <lem>Publium</lem>
+                     </app> P. Lentulum <foreign xml:lang="grc">ς</foreign>
+                  </note>, quis M. Laecam, quis
+					<add>C.</add>
+                  <note>C. <hi rend="italic">suppl. Manutius</hi>
+                  </note> Cornelium
 				defendendum putavit, quis eis horum<note>iis horum <hi rend="italic">Garatoni</hi>:
-					horum iis <hi rend="italic"><foreign xml:lang="grc">p</foreign>k</hi>: his
-					horum <hi rend="italic">cett.</hi></note> adfuit? <reg>nemo</reg>.
-					<reg>quid</reg> ita? <reg>quia</reg> ceteris in<note>in ceteris <hi
-						rend="italic">e</hi></note> causis etiam nocentis viri boni, si necessarii
-				sunt, deserendos<note>deserendos <hi rend="italic">e</hi>: defendendos <hi
-						rend="italic">cett.</hi></note> esse non putant; in hoc crimine non solum
-				levitatis est culpa<note>culpa est <hi rend="italic">Tk</hi>: culpa <hi
-						rend="italic">e</hi></note> verum etiam quaedam contagio sceleris, si
-				defendas eum<note>eum <hi rend="italic">om. T</hi></note> quem obstrictum esse
-				patriae parricidio<note>parricidio <hi rend="italic">TEea<foreign xml:lang="grc"
-							>p</foreign></hi>: <hi rend="italic">om. cett.</hi></note> suspicere.
-					</p></div>
-			<div type="textpart" subtype="section" n="7"><p><reg>quid</reg>? Autronio nonne sodales, non
+					horum iis <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>k</hi>: his
+					horum <hi rend="italic">cett.</hi>
+                  </note> adfuit? <reg>nemo</reg>.
+					<reg>quid</reg> ita? <reg>quia</reg> ceteris in<note>in ceteris <hi rend="italic">e</hi>
+                  </note> causis etiam nocentis viri boni, si necessarii
+				sunt, deserendos<note>deserendos <hi rend="italic">e</hi>: defendendos <hi rend="italic">cett.</hi>
+                  </note> esse non putant; in hoc crimine non solum
+				levitatis est culpa<note>culpa est <hi rend="italic">Tk</hi>: culpa <hi rend="italic">e</hi>
+                  </note> verum etiam quaedam contagio sceleris, si
+				defendas eum<note>eum <hi rend="italic">om. T</hi>
+                  </note> quem obstrictum esse
+				patriae parricidio<note>parricidio <hi rend="italic">TEea<foreign xml:lang="grc">π</foreign>
+                     </hi>: <hi rend="italic">om. cett.</hi>
+                  </note> suspicere.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="7">
+               <p>
+                  <reg>quid</reg>? Autronio nonne sodales, non
 				conlegae sui, non veteres amici, quorum ille copia quondam abundarat, non hi omnes
 				qui sunt in re publica principes defuerunt? <reg>immo</reg> etiam testimonio
-				plerique laeserunt. <reg>statuerant</reg> tantum illud<note>illud tantum <hi
-						rend="italic">T</hi></note> esse maleficium quod non modo
-						non<note><app><lem>modo non</lem></app> modo <hi rend="italic">e</hi></note>
-				occultari per se sed etiam aperiri inlustrarique deberet<note>debet <hi
-						rend="italic">e</hi></note>. <milestone n="3" unit="chapter"
-					/><reg>quam</reg> ob rem quid est quod mirere, si cum isdem me in hac causa
-				vides adesse cum quibus in ceteris intellegis afuisse<note>afuisse <hi
-						rend="italic">Lambinus</hi>: affuisse (abf. <hi rend="italic">b2c<foreign
-							xml:lang="grc">x</foreign></hi>) <hi rend="italic">codd.</hi></note>?
+				plerique laeserunt. <reg>statuerant</reg> tantum illud<note>illud tantum <hi rend="italic">T</hi>
+                  </note> esse maleficium quod non modo
+						non<note>
+                     <app>
+                        <lem>modo non</lem>
+                     </app> modo <hi rend="italic">e</hi>
+                  </note>
+				occultari per se sed etiam aperiri inlustrarique deberet<note>debet <hi rend="italic">e</hi>
+                  </note>. <milestone n="3" unit="chapter"/>
+                  <reg>quam</reg> ob rem quid est quod mirere, si cum isdem me in hac causa
+				vides adesse cum quibus in ceteris intellegis afuisse<note>afuisse <hi rend="italic">Lambinus</hi>: affuisse (abf. <hi rend="italic">b2c<foreign xml:lang="grc">χ</foreign>
+                     </hi>) <hi rend="italic">codd.</hi>
+                  </note>?
 				Nisi vero me unum vis ferum praeter ceteros, me asperum, me inhumanum existimari, me
-				singulari immanitate et crudelitate praeditum. </p></div>
-			<div type="textpart" subtype="section" n="8"><p>
-				<reg>hanc</reg> mihi tu si propter meas res<note>meas res <hi rend="italic"
-						>Te</hi>: res meas <hi rend="italic">cett.</hi></note> gestas imponis in
-				omni vita mea<note>mea vita <hi rend="italic">T</hi></note>, Torquate,
-					personam<note>Torq. personam <hi rend="italic">Te</hi>: personam Torq. <hi
-						rend="italic">cett.</hi></note>, vehementer erras. <reg>me</reg> natura
+				singulari immanitate et crudelitate praeditum. </p>
+            </div>
+            <div type="textpart" subtype="section" n="8">
+               <p>
+                  <reg>hanc</reg> mihi tu si propter meas res<note>meas res <hi rend="italic">Te</hi>: res meas <hi rend="italic">cett.</hi>
+                  </note> gestas imponis in
+				omni vita mea<note>mea vita <hi rend="italic">T</hi>
+                  </note>, Torquate,
+					personam<note>Torq. personam <hi rend="italic">Te</hi>: personam Torq. <hi rend="italic">cett.</hi>
+                  </note>, vehementer erras. <reg>me</reg> natura
 				misericordem, patria severum, crudelem nec patria nec natura<note>nec natura nec
-					patria <hi rend="italic">e</hi></note> esse voluit; denique istam ipsam
+					patria <hi rend="italic">e</hi>
+                  </note> esse voluit; denique istam ipsam
 				personam vehementem et acrem quam mihi tum tempus et res publica imposuit iam
 				voluntas et natura ipsa detraxit. <reg>illa</reg> enim ad breve tempus severitatem
-				postulavit, haec in omni vita misericordiam lenitatemque desiderat. </p></div>
-			<div type="textpart" subtype="section" n="9"><p>
-				<reg>qua</reg> re nihil est quod ex tanto comitatu virorum
+				postulavit, haec in omni vita misericordiam lenitatemque desiderat. </p>
+            </div>
+            <div type="textpart" subtype="section" n="9">
+               <p>
+                  <reg>qua</reg> re nihil est quod ex tanto comitatu virorum
 				amplissimorum me unum abstrahas; simplex officium atque una bonorum est<note>bonorum
 					est <hi rend="italic">T</hi>: bonorum <hi rend="italic">e</hi>: est bonorum
-						<hi rend="italic">cett.</hi></note> omnium causa. <reg>nihil</reg>
-						erit<note><app><lem>erit</lem></app> est <hi rend="italic">eb1k</hi></note> quod
+						<hi rend="italic">cett.</hi>
+                  </note> omnium causa. <reg>nihil</reg>
+						erit<note>
+                     <app>
+                        <lem>erit</lem>
+                     </app> est <hi rend="italic">eb1k</hi>
+                  </note> quod
 				admirere posthac, si in ea parte in qua hos animum adverteris me videbis.
-					<reg>nulla</reg> est enim in re publica mea causa<note>mea causa <hi
-						rend="italic">Te</hi>: causa mea <hi rend="italic">cett.</hi></note>
+					<reg>nulla</reg> est enim in re publica mea causa<note>mea causa <hi rend="italic">Te</hi>: causa mea <hi rend="italic">cett.</hi>
+                  </note>
 				propria; tempus agendi fuit mihi magis<note>mihi magis <hi rend="italic">Tb1</hi>:
-					magis mihi <hi rend="italic">cett.</hi></note> proprium quam ceteris, doloris
-				vero et timoris et periculi fuit illa causa communis; neque enim ego<note>ego <hi
-						rend="italic">Te</hi>: <hi rend="italic">om. cett.</hi></note> tunc
-					princeps<note>tunc princeps <hi rend="italic">Te<foreign xml:lang="grc"
-							>p</foreign>k</hi>: princeps tunc <hi rend="italic">cett.</hi></note>
+					magis mihi <hi rend="italic">cett.</hi>
+                  </note> proprium quam ceteris, doloris
+				vero et timoris et periculi fuit illa causa communis; neque enim ego<note>ego <hi rend="italic">Te</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> tunc
+					princeps<note>tunc princeps <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>k</hi>: princeps tunc <hi rend="italic">cett.</hi>
+                  </note>
 				ad salutem esse potuissem, si esse alii comites noluissent. <reg>qua</reg> re
 				necesse est, quod mihi consuli praecipuum fuit praeter alios, id iam privato cum
 				ceteris esse commune. <reg>neque</reg> ego hoc partiendae invidiae, sed
 				communicandae laudis causa loquor; oneris mei partem nemini impertio, gloriae bonis
-				omnibus. </p></div>
-			<div type="textpart" subtype="section" n="10"><p>'<reg>in</reg> Autronium testimonium
+				omnibus. </p>
+            </div>
+            <div type="textpart" subtype="section" n="10">
+               <p>'<reg>in</reg> Autronium testimonium
 				dixisti,' inquit; 'Sullam defendis.' <reg>hoc</reg> totum eius modi est, iudices,
-				ut, si ego sum<note>sum <hi rend="italic">Teb1</hi>: sim <hi rend="italic"
-						>cett.</hi></note> inconstans ac levis, nec testimonio fidem tribui
+				ut, si ego sum<note>sum <hi rend="italic">Teb1</hi>: sim <hi rend="italic">cett.</hi>
+                  </note> inconstans ac levis, nec testimonio fidem tribui
 				convenerit nec defensioni auctoritatem; sin est in me ratio rei publicae, religio
 				privati offici, studium retinendae voluntatis bonorum, nihil minus accusator debet
 				dicere quam a me defendi Sullam, testimonio<note>testimonio <hi rend="italic">fort.
-						delendum</hi></note> laesum esse Autronium. <reg>videor</reg> enim
-					iam<note>iam <hi rend="italic">Tea<foreign xml:lang="grc">p</foreign>,
-						Schol.</hi>: <hi rend="italic">om. cett.</hi></note> non solum studium ad
-				defendendas causas verum etiam<note>etiam <hi rend="italic">Te<foreign
-							xml:lang="grc">p</foreign>, Schol.</hi>: <hi rend="italic">om.
-						cett.</hi></note> opinionis aliquid et auctoritatis adferre; qua ego et
-					moderate<note>ego et moderate <hi rend="italic">Te</hi>: et moderate ego <hi
-						rend="italic">cett.</hi></note> utar, iudices, et omnino non uterer, si
-				ille me non coegisset. </p></div><milestone n="4" unit="chapter"/>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="11"><p>
-			<reg>duae</reg> coniurationes abs<note>ab <hi rend="italic">e</hi></note> te,
+						delendum</hi>
+                  </note> laesum esse Autronium. <reg>videor</reg> enim
+					iam<note>iam <hi rend="italic">Tea<foreign xml:lang="grc">π</foreign>,
+						Schol.</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> non solum studium ad
+				defendendas causas verum etiam<note>etiam <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>, Schol.</hi>: <hi rend="italic">om.
+						cett.</hi>
+                  </note> opinionis aliquid et auctoritatis adferre; qua ego et
+					moderate<note>ego et moderate <hi rend="italic">Te</hi>: et moderate ego <hi rend="italic">cett.</hi>
+                  </note> utar, iudices, et omnino non uterer, si
+				ille me non coegisset. </p>
+            </div>
+            <milestone n="4" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="11">
+               <p>
+                  <reg>duae</reg> coniurationes abs<note>ab <hi rend="italic">e</hi>
+                  </note> te,
 				Torquate, constituuntur, una quae Lepido et Volcatio consulibus patre tuo consule
 				designato facta esse dicitur, altera quae me consule; harum in utraque Sullam dicis
 				fuisse. Patris tui, fortissimi viri atque optimi consulis, scis me consiliis non
-						interfuisse<note><app><lem>non interfuisse</lem></app> interfuisse dicis <hi
-						rend="italic">e</hi></note>; scis me, cum mihi summus tecum usus esset,
+						interfuisse<note>
+                     <app>
+                        <lem>non interfuisse</lem>
+                     </app> interfuisse dicis <hi rend="italic">e</hi>
+                  </note>; scis me, cum mihi summus tecum usus esset,
 				tamen illorum expertem temporum et sermonum fuisse, credo quod nondum penitus in re
-				publica versabar, quod nondum ad propositum<note>praepositum <hi rend="italic"
-						>e</hi></note> mihi finem honoris perveneram, quod me<note>me <hi
-						rend="italic">Te<foreign xml:lang="grc">p</foreign>b2</hi>: mea <hi
-						rend="italic">cett.</hi></note> ambitio et forensis labor ab omni illa
-				cogitatione abstrahebat. </p></div>
-			<div type="textpart" subtype="section" n="12"><p><reg>quis</reg> ergo
+				publica versabar, quod nondum ad propositum<note>praepositum <hi rend="italic">e</hi>
+                  </note> mihi finem honoris perveneram, quod me<note>me <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>b2</hi>: mea <hi rend="italic">cett.</hi>
+                  </note> ambitio et forensis labor ab omni illa
+				cogitatione abstrahebat. </p>
+            </div>
+            <div type="textpart" subtype="section" n="12">
+               <p>
+                  <reg>quis</reg> ergo
 				intererat vestris consiliis? <reg>omnes</reg> hi quos vides huic adesse et in primis
 				Q. Hortensius; qui cum propter honorem ac dignitatem atque animum eximium in rem
-					publicam<note>atque dignitatem ac animum extimumque in rem p. <hi rend="italic"
-						>e</hi></note>, tum propter summam familiaritatem summumque
-					amorem<note>amorem <hi rend="italic">ec</hi>: honorem <hi rend="italic"
-						>cett.</hi></note> in patrem tuum cum<note><app><lem>cum</lem></app> tum <hi
-						rend="italic"><foreign xml:lang="grc">p</foreign>b<foreign xml:lang="grc"
-							>s</foreign></hi></note> communibus tum praecipuis patris tui periculis
+					publicam<note>atque dignitatem ac animum extimumque in rem p. <hi rend="italic">e</hi>
+                  </note>, tum propter summam familiaritatem summumque
+					amorem<note>amorem <hi rend="italic">ec</hi>: honorem <hi rend="italic">cett.</hi>
+                  </note> in patrem tuum cum<note>
+                     <app>
+                        <lem>cum</lem>
+                     </app> tum <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>b<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> communibus tum praecipuis patris tui periculis
 				commovebatur. <reg>ergo</reg> istius coniurationis crimen defensum ab eo est qui
 				interfuit, qui cognovit, qui particeps et consili vestri fuit et timoris; cuius in
 				hoc crimine propulsando cum esset copiosissima atque ornatissima oratio, tamen non
-				minus inerat auctoritatis<note>auctoritatis inerat <hi rend="italic">eb</hi></note>
+				minus inerat auctoritatis<note>auctoritatis inerat <hi rend="italic">eb</hi>
+                  </note>
 				in ea quam facultatis. <reg>illius</reg> igitur coniurationis quae facta contra vos,
 				delata ad vos, a vobis prolata esse dicitur, ego testis esse non potui; non modo
-					animo<note>animo <hi rend="italic">Tea<foreign xml:lang="grc">p</foreign>,
-						Schol.</hi>: enim <hi rend="italic">cett.</hi></note> nihil comperi, sed
-					vix<note>vix <hi rend="italic">om. Schol.</hi></note> ad auris meas istius
-				suspicionis fama<note>famam <hi rend="italic">Schol.</hi>: fama non <hi
-						rend="italic">Mai</hi></note> pervenit. </p></div>
-			<div type="textpart" subtype="section" n="13"><p>
-				<reg>qui</reg> vobis<note><app><lem>vobis</lem></app> vobiscum (nob. <hi
-						rend="italic">e</hi>) <hi rend="italic">eb<foreign xml:lang="grc"
-							>s</foreign></hi></note> in consilio fuerunt, qui vobiscum illa
+					animo<note>animo <hi rend="italic">Tea<foreign xml:lang="grc">π</foreign>,
+						Schol.</hi>: enim <hi rend="italic">cett.</hi>
+                  </note> nihil comperi, sed
+					vix<note>vix <hi rend="italic">om. Schol.</hi>
+                  </note> ad auris meas istius
+				suspicionis fama<note>famam <hi rend="italic">Schol.</hi>: fama non <hi rend="italic">Mai</hi>
+                  </note> pervenit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="13">
+               <p>
+                  <reg>qui</reg> vobis<note>
+                     <app>
+                        <lem>vobis</lem>
+                     </app> vobiscum (nob. <hi rend="italic">e</hi>) <hi rend="italic">eb<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> in consilio fuerunt, qui vobiscum illa
 				cognorunt, quibus ipsis periculum tum conflari putabatur, qui Autronio non
 				adfuerunt, qui in illum testimonia gravia dixerunt, hunc defendunt, huic
-					adsunt<note>assunt <hi rend="italic">Tea<foreign xml:lang="grc"
-						>p</foreign></hi></note>, in huius periculo declarant se non crimine
+					adsunt<note>assunt <hi rend="italic">Tea<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note>, in huius periculo declarant se non crimine
 				coniurationis, ne adessent ceteris, sed hominum maleficio deterritos esse.
 					<reg>mei</reg> consulatus autem tempus et crimen maximae coniurationis a me
-				defendetur. <reg>atque</reg> haec<note>haec (hic <hi rend="italic">e</hi>) <hi
-						rend="italic">Te<foreign xml:lang="grc">p</foreign>k</hi>: <hi
-						rend="italic">om. cett.</hi></note> inter nos partitio
-					defensionis<note>defensionis <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign></hi>: <hi rend="italic">om. cett.</hi></note> non est
+				defendetur. <reg>atque</reg> haec<note>haec (hic <hi rend="italic">e</hi>) <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>k</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> inter nos partitio
+					defensionis<note>defensionis <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: <hi rend="italic">om. cett.</hi>
+                  </note> non est
 				fortuito, iudices, nec temere facta; sed cum videremus eorum criminum nos patronos
 				adhiberi quorum testes esse possemus, uterque nostrum id sibi suscipiendum putavit
-				de quo aliquid scire ipse atque existimare potuisset. <milestone n="5"
-					unit="chapter"/></p></div>
-			<div type="textpart" subtype="section" n="14"><p><reg>et</reg> quoniam de
+				de quo aliquid scire ipse atque existimare potuisset. <milestone n="5" unit="chapter"/>
+               </p>
+            </div>
+            <div type="textpart" subtype="section" n="14">
+               <p>
+                  <reg>et</reg> quoniam de
 				criminibus superioris coniurationis Hortensium diligenter audistis, de hac
 				coniuratione quae me consule facta est hoc primum attendite. 
-			<milestone unit="para"/><reg>multa</reg>, cum essem consul, de summis<note>summae <hi rend="italic"
-						>Lambinus</hi></note> rei publicae periculis audivi, multa quaesivi, multa
-				cognovi; nullus umquam de Sulla nuntius ad me, nullum indicium<note>indicium <hi
-						rend="italic">ab2<foreign xml:lang="grc">xy1</foreign></hi>: iudicium <hi
-						rend="italic">cett.</hi></note>, nullae litterae pervenerunt, nulla
-					suspicio<note>nulla suspicio <hi rend="italic">del. Mommsen</hi> (<hi
-						rend="italic">cf.</hi> § 20)</note>. <reg>multum</reg> haec vox fortasse
-				valere deberet<note>valere deberet <hi rend="italic">Tea</hi>: deberet valere <hi
-						rend="italic">cett.</hi></note> eius hominis qui consul insidias rei
+			<milestone unit="para"/>
+                  <reg>multa</reg>, cum essem consul, de summis<note>summae <hi rend="italic">Lambinus</hi>
+                  </note> rei publicae periculis audivi, multa quaesivi, multa
+				cognovi; nullus umquam de Sulla nuntius ad me, nullum indicium<note>indicium <hi rend="italic">ab2<foreign xml:lang="grc">χψ1</foreign>
+                     </hi>: iudicium <hi rend="italic">cett.</hi>
+                  </note>, nullae litterae pervenerunt, nulla
+					suspicio<note>nulla suspicio <hi rend="italic">del. Mommsen</hi> (<hi rend="italic">cf.</hi> § 20)</note>. <reg>multum</reg> haec vox fortasse
+				valere deberet<note>valere deberet <hi rend="italic">Tea</hi>: deberet valere <hi rend="italic">cett.</hi>
+                  </note> eius hominis qui consul insidias rei
 				publicae consilio investigasset, veritate aperuisset, magnitudine animi vindicasset,
-				cum is se<note>is se <hi rend="italic">Te</hi>: ipse <hi rend="italic"
-					>cett.</hi></note> nihil audisse de P. Sulla, nihil suspicatum esse diceret.
-					<reg>sed</reg> ego nondum utor<note>utar <hi rend="italic">Te<foreign
-							xml:lang="grc">p</foreign></hi>: utor <hi rend="italic"
-					>cett.</hi></note> hac voce ad hunc defendendum; ad purgandum me potius utar, ut
-				mirari Torquatus desinat me qui Autronio non adfuerim<note>non affuerim <hi
-						rend="italic">Te<foreign xml:lang="grc">p</foreign></hi>: affuerim <hi
-						rend="italic">ab1</hi>: abfuerim <hi rend="italic">cett.</hi></note>
-				Sullam defendere. </p></div>
-			<div type="textpart" subtype="section" n="15"><p><reg>quae</reg> enim Autroni
-					fuit<note>fuit Autronii <hi rend="italic">Schol.</hi></note> causa, quae Sullae
+				cum is se<note>is se <hi rend="italic">Te</hi>: ipse <hi rend="italic">cett.</hi>
+                  </note> nihil audisse de P. Sulla, nihil suspicatum esse diceret.
+					<reg>sed</reg> ego nondum utor<note>utar <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>: utor <hi rend="italic">cett.</hi>
+                  </note> hac voce ad hunc defendendum; ad purgandum me potius utar, ut
+				mirari Torquatus desinat me qui Autronio non adfuerim<note>non affuerim <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>: affuerim <hi rend="italic">ab1</hi>: abfuerim <hi rend="italic">cett.</hi>
+                  </note>
+				Sullam defendere. </p>
+            </div>
+            <div type="textpart" subtype="section" n="15">
+               <p>
+                  <reg>quae</reg> enim Autroni
+					fuit<note>fuit Autronii <hi rend="italic">Schol.</hi>
+                  </note> causa, quae Sullae
 				est? <reg>ille</reg> ambitus iudicium tollere ac disturbare primum conflato voluit
 				gladiatorum ac fugitivorum tumultu, deinde, id quod vidimus omnes, lapidatione atque
 				concursu; Sulla, si sibi suus pudor ac dignitas non prodesset, nullum auxilium
 				requisivit. <reg>ille</reg> damnatus ita se gerebat non solum consiliis et
-				sermonibus verum etiam aspectu atque<note><app><lem>atque</lem></app> et <hi rend="italic"
-						>ec</hi></note> voltu ut inimicus esse amplissimis ordinibus, infestus bonis
+				sermonibus verum etiam aspectu atque<note>
+                     <app>
+                        <lem>atque</lem>
+                     </app> et <hi rend="italic">ec</hi>
+                  </note> voltu ut inimicus esse amplissimis ordinibus, infestus bonis
 				omnibus, hostis patriae videretur; hic se ita fractum illa calamitate atque
 				adflictum putavit ut nihil sibi ex pristina dignitate superesse arbitraretur, nisi
-				quod modestia retinuisset. </p></div>
-			<div type="textpart" subtype="section" n="16"><p><reg>hac</reg> vero in
+				quod modestia retinuisset. </p>
+            </div>
+            <div type="textpart" subtype="section" n="16">
+               <p>
+                  <reg>hac</reg> vero in
 				coniuratione quid tam coniunctum quam ille cum Catilina, cum Lentulo? quae tanta
 				societas ullis inter se rerum optimarum quanta ei cum illis sceleris, libidinis,
 				audaciae? quod flagitium Lentulus non cum Autronio concepit? quod sine eodem illo
 				Catilina facinus admisit? cum interim Sulla cum isdem illis non modo noctem
-				solitudinemque non quaereret sed ne mediocri<note>mediocriter <hi rend="italic"
-						>Reid</hi></note> quidem sermone et congressu coniungeretur. </p></div>
-			<div type="textpart" subtype="section" n="17"><p>
-				<reg>illum</reg> Allobroges, maximarum rerum verissimi
-					indices<note>iudices <hi rend="italic">ea<foreign xml:lang="grc"
-						>pS</foreign>b1</hi></note>, illum multorum litterae ac nuntii coarguerunt;
+				solitudinemque non quaereret sed ne mediocri<note>mediocriter <hi rend="italic">Reid</hi>
+                  </note> quidem sermone et congressu coniungeretur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="17">
+               <p>
+                  <reg>illum</reg> Allobroges, maximarum rerum verissimi
+					indices<note>iudices <hi rend="italic">ea<foreign xml:lang="grc">πς</foreign>b1</hi>
+                  </note>, illum multorum litterae ac nuntii coarguerunt;
 				Sullam interea nemo insimulavit, nemo nominavit. <reg>postremo</reg> eiecto sive
-				emisso iam ex urbe Catilina ille arma misit, cornua, tubas<note>tubes <hi
-						rend="italic">Tb1</hi>: tube <hi rend="italic">e</hi></note>,
-					fascis<note>fasces <hi rend="italic">e</hi>: falces <hi rend="italic"
-						>cett.</hi></note>, signa, legiones<note><app><lem>legiones</lem></app>
-					<hi rend="italic">del. Wolff</hi> (<hi rend="italic">malo numero</hi>):
+				emisso iam ex urbe Catilina ille arma misit, cornua, tubas<note>tubes <hi rend="italic">Tb1</hi>: tube <hi rend="italic">e</hi>
+                  </note>,
+					fascis<note>fasces <hi rend="italic">e</hi>: falces <hi rend="italic">cett.</hi>
+                  </note>, signa, legiones<note>
+                     <app>
+                        <lem>legiones</lem>
+                     </app>
+                     <hi rend="italic">del. Wolff</hi> (<hi rend="italic">malo numero</hi>):
 					legionis <hi rend="italic">A. Augustinus</hi>: <hi rend="italic">fort.</hi>
 					legionum</note>, ille relictus intus, exspectatus foris, Lentuli poena
 				compressus convertit se aliquando ad timorem, numquam ad sanitatem; hic contra ita
 				quievit ut eo tempore omni Neapoli fuerit, ubi neque homines fuisse
-					putantur<note>putant <hi rend="italic">e</hi></note> huius adfines suspicionis
-				et locus est ipse non tam ad inflammandos<note>flammandos <hi rend="italic"
-					>e</hi></note> calamitosorum animos quam ad consolandos accommodatus. 
-				<milestone unit="para"/><milestone n="6" unit="chapter"/>
-				<reg>propter</reg> hanc igitur tantam dissimilitudinem hominum atque causarum
-				dissimilem me in utroque praebui.</p></div>
-			<div type="textpart" subtype="section" n="18"><p>
-				<reg>veniebat</reg> enim<note>enim <hi rend="italic">om.
-						Schol.</hi></note> ad me et saepe veniebat Autronius multis cum lacrimis
-				supplex ut se defenderem, et se meum condiscipulum<note>discipulum <hi
-						rend="italic">e</hi></note> in pueritia, familiarem in adulescentia,
+					putantur<note>putant <hi rend="italic">e</hi>
+                  </note> huius adfines suspicionis
+				et locus est ipse non tam ad inflammandos<note>flammandos <hi rend="italic">e</hi>
+                  </note> calamitosorum animos quam ad consolandos accommodatus. 
+				<milestone unit="para"/>
+                  <milestone n="6" unit="chapter"/>
+                  <reg>propter</reg> hanc igitur tantam dissimilitudinem hominum atque causarum
+				dissimilem me in utroque praebui.</p>
+            </div>
+            <div type="textpart" subtype="section" n="18">
+               <p>
+                  <reg>veniebat</reg> enim<note>enim <hi rend="italic">om.
+						Schol.</hi>
+                  </note> ad me et saepe veniebat Autronius multis cum lacrimis
+				supplex ut se defenderem, et se meum condiscipulum<note>discipulum <hi rend="italic">e</hi>
+                  </note> in pueritia, familiarem in adulescentia,
 				conlegam in quaestura commemorabat fuisse; multa mea in se, non nulla etiam sua in
-					me<note>sua in me etiam <hi rend="italic">e</hi></note> proferebat officia.
+					me<note>sua in me etiam <hi rend="italic">e</hi>
+                  </note> proferebat officia.
 					<reg>quibus</reg> ego rebus, iudices, ita flectebar animo atque frangebar ut
-					iam<note>iam <hi rend="italic">Te</hi>: etiam <hi rend="italic"
-					>cett.</hi></note> ex memoria quas mihi ipsi<note>ipse <hi rend="italic"
-						>T1b</hi></note> fecerat insidias deponerem, ut iam immissum esse ab eo C.
+					iam<note>iam <hi rend="italic">Te</hi>: etiam <hi rend="italic">cett.</hi>
+                  </note> ex memoria quas mihi ipsi<note>ipse <hi rend="italic">T1b</hi>
+                  </note> fecerat insidias deponerem, ut iam immissum esse ab eo C.
 				Cornelium qui me in meis sedibus<note>meis sedibus <hi rend="italic">e</hi>:
-					sedibus meis <hi rend="italic">cett.</hi>: meis aedibus <hi rend="italic"
-						>Lambinus</hi></note>, in conspectu uxoris<note>uxoris <hi rend="italic"
-						>Te</hi>: uxoris meae <hi rend="italic">cett.</hi></note> ac liberorum
+					sedibus meis <hi rend="italic">cett.</hi>: meis aedibus <hi rend="italic">Lambinus</hi>
+                  </note>, in conspectu uxoris<note>uxoris <hi rend="italic">Te</hi>: uxoris meae <hi rend="italic">cett.</hi>
+                  </note> ac liberorum
 				meorum trucidaret obliviscerer. <reg>quae</reg> si de uno me cogitasset, qua
-				mollitia sum animi ac lenitate<note>lenitate <hi rend="italic">a<foreign
-							xml:lang="grc">p</foreign>b2<foreign xml:lang="grc">xy</foreign>k</hi>:
-					levitate <hi rend="italic">cett.</hi></note>, numquam me hercule illius
-				lacrimis ac precibus restitissem; sed cum mihi patriae, </p></div>
-			<div type="textpart" subtype="section" n="19"><p>
+				mollitia sum animi ac lenitate<note>lenitate <hi rend="italic">a<foreign xml:lang="grc">π</foreign>b2<foreign xml:lang="grc">χψ</foreign>k</hi>:
+					levitate <hi rend="italic">cett.</hi>
+                  </note>, numquam me hercule illius
+				lacrimis ac precibus restitissem; sed cum mihi patriae, </p>
+            </div>
+            <div type="textpart" subtype="section" n="19">
+               <p>
 				cum vestrorum periculorum, cum huius urbis, cum illorum
 				delubrorum atque templorum, cum puerorum infantium, cum matronarum ac virginum
 				veniebat in mentem, et cum illae infestae ac funestae faces universumque totius
-				urbis incendium, cum tela<note>cum tela <hi rend="italic">om. T</hi></note>, cum
+				urbis incendium, cum tela<note>cum tela <hi rend="italic">om. T</hi>
+                  </note>, cum
 				caedes, cum civium cruor, cum cinis patriae versari ante oculos atque animum memoria
 				refricare coeperat, tum denique ei resistebam, neque solum illi hosti ac parricidae
 				sed his etiam propinquis illius, Marcellis, patri et filio, quorum alter apud me
 				parentis gravitatem, alter fili suavitatem obtinebat; neque me<note>neque enim me
-						<hi rend="italic">Müller</hi></note> arbitrabar sine summo scelere posse,
+						<hi rend="italic">Müller</hi>
+                  </note> arbitrabar sine summo scelere posse,
 				quod maleficium in aliis vindicassem, idem in illorum socio, cum scirem, defendere.
-					</p></div>
-			<div type="textpart" subtype="section" n="20"><p><reg>atque</reg> idem ego neque P. Sullam
-				supplicem ferre, neque eosdem<note><app><lem>eosdem</lem></app> hos <hi rend="italic"
-						>T</hi></note> Marcellos pro huius<note>pro huius <hi rend="italic"
-							>Eea<foreign xml:lang="grc">p</foreign></hi>: pro <hi rend="italic"
-						>T</hi>: <hi rend="italic">om. cett.</hi></note> periculis lacrimantis
-					aspicere<note>periculis lacrim. aspicere <hi rend="italic">TEe</hi>: <hi
-						rend="italic">om. cett.</hi></note>, neque huius<note>neque huius <hi
-						rend="italic">om. a<foreign xml:lang="grc">p</foreign></hi></note> M.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="20">
+               <p>
+                  <reg>atque</reg> idem ego neque P. Sullam
+				supplicem ferre, neque eosdem<note>
+                     <app>
+                        <lem>eosdem</lem>
+                     </app> hos <hi rend="italic">T</hi>
+                  </note> Marcellos pro huius<note>pro huius <hi rend="italic">Eea<foreign xml:lang="grc">π</foreign>
+                     </hi>: pro <hi rend="italic">T</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> periculis lacrimantis
+					aspicere<note>periculis lacrim. aspicere <hi rend="italic">TEe</hi>: <hi rend="italic">om. cett.</hi>
+                  </note>, neque huius<note>neque huius <hi rend="italic">om. a<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note> M.
 					Messalae<note>Messallae <hi rend="italic">Lambinus</hi> (<hi rend="italic">cf.
 						Sex. Rosc.</hi> 149)</note>, hominis necessarii, preces sustinere potui;
-				neque enim est<note>est <hi rend="italic">om. Te</hi> (causae adv. naturae est <hi
-						rend="italic">Madvig</hi>)</note> causa adversata naturae, nec homo nec
-					res<note>nec res nec homo <hi rend="italic">c</hi></note> misericordiae meae
+				neque enim est<note>est <hi rend="italic">om. Te</hi> (causae adv. naturae est <hi rend="italic">Madvig</hi>)</note> causa adversata naturae, nec homo nec
+					res<note>nec res nec homo <hi rend="italic">c</hi>
+                  </note> misericordiae meae
 				repugnavit. <reg>nusquam</reg> nomen, nusquam vestigium fuerat, nullum crimen,
-				nullum indicium, nulla suspicio<note>nulla suspicio <hi rend="italic">Ee</hi>: <hi
-						rend="italic">om. cett.</hi></note>. <reg>suscepi</reg> causam, Torquate,
+				nullum indicium, nulla suspicio<note>nulla suspicio <hi rend="italic">Ee</hi>: <hi rend="italic">om. cett.</hi>
+                  </note>. <reg>suscepi</reg> causam, Torquate,
 				suscepi, et feci libenter ut me, quem boni constantem, ut spero, semper
-				existimassent, eundem ne improbi quidem crudelem dicerent. <milestone n="7"
-					unit="chapter"/></p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="21"><p>
-			<reg>hic</reg> ait se ille, iudices, regnum meum ferre non posse. <reg>quod</reg>
+				existimassent, eundem ne improbi quidem crudelem dicerent. <milestone n="7" unit="chapter"/>
+               </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="21">
+               <p>
+                  <reg>hic</reg> ait se ille, iudices, regnum meum ferre non posse. <reg>quod</reg>
 				tandem, Torquate, regnum? <reg>consulatus</reg>, credo, mei; in quo ego imperavi
-				nihil et<note><app><lem>et</lem></app> sed <hi rend="italic">b2</hi></note> contra
+				nihil et<note>
+                     <app>
+                        <lem>et</lem>
+                     </app> sed <hi rend="italic">b2</hi>
+                  </note> contra
 				patribus conscriptis et bonis omnibus parui; quo in magistratu non institutum est
-				videlicet a me<note>videlicet a me <hi rend="italic">e</hi>: a me iudices <hi
-						rend="italic">cett.</hi></note> regnum, sed repressum<note>repressum <hi
-						rend="italic">e</hi>: repulsum <hi rend="italic">b2<foreign xml:lang="grc"
-							>y2</foreign></hi>: non permissum <hi rend="italic"><foreign
-							xml:lang="grc">S</foreign>b1k, p. mg.</hi>: promissum <hi rend="italic"
-						>cett.</hi></note>. <reg>an</reg> tum<note><app><lem>tum</lem></app> tu <hi
-						rend="italic"><foreign xml:lang="grc">p</foreign>e, Schol.</hi></note> in
-				tanto imperio, tanta<note>tanta <hi rend="italic">mei, Schol.</hi>: tantaque <hi
-						rend="italic">Mai</hi> (<hi rend="italic">sil.</hi>) dices <hi
-						rend="italic">Schol.</hi></note> potestate non dicis me<note>me <hi
-						rend="italic">Te<foreign xml:lang="grc">p</foreign>, Schol.</hi>: <hi
-						rend="italic">om. cett.</hi></note> fuisse regem, nunc privatum regnare
-					dicis<note>dices <hi rend="italic">Stangl</hi></note>? quo tandem nomine?
+				videlicet a me<note>videlicet a me <hi rend="italic">e</hi>: a me iudices <hi rend="italic">cett.</hi>
+                  </note> regnum, sed repressum<note>repressum <hi rend="italic">e</hi>: repulsum <hi rend="italic">b2<foreign xml:lang="grc">ψ2</foreign>
+                     </hi>: non permissum <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>b1k, p. mg.</hi>: promissum <hi rend="italic">cett.</hi>
+                  </note>. <reg>an</reg> tum<note>
+                     <app>
+                        <lem>tum</lem>
+                     </app> tu <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>e, Schol.</hi>
+                  </note> in
+				tanto imperio, tanta<note>tanta <hi rend="italic">mei, Schol.</hi>: tantaque <hi rend="italic">Mai</hi> (<hi rend="italic">sil.</hi>) dices <hi rend="italic">Schol.</hi>
+                  </note> potestate non dicis me<note>me <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>, Schol.</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> fuisse regem, nunc privatum regnare
+					dicis<note>dices <hi rend="italic">Stangl</hi>
+                  </note>? quo tandem nomine?
 					'<reg>quod</reg>, in quos testimonia dixisti,' inquit, 'damnati sunt; quem
 				defendis, sperat se absolutum iri.' <reg>hic</reg> tibi ego de testimoniis meis hoc
-					respondeo<note>respondebo <hi rend="italic">T</hi></note>, si falsum dixerim,
-				te in eosdem<note>eosdem <hi rend="italic">e, Schol.</hi>: eos <hi rend="italic"
-						>cett.</hi></note> dixisse; sin verum, non esse hoc regnare, cum verum
-					iuratus<note>iuratus <hi rend="italic">Teb1, Schol.</hi>: iuratos <hi
-						rend="italic">cett.</hi></note> dicas, probare. <reg>de</reg> huius spe
+					respondeo<note>respondebo <hi rend="italic">T</hi>
+                  </note>, si falsum dixerim,
+				te in eosdem<note>eosdem <hi rend="italic">e, Schol.</hi>: eos <hi rend="italic">cett.</hi>
+                  </note> dixisse; sin verum, non esse hoc regnare, cum verum
+					iuratus<note>iuratus <hi rend="italic">Teb1, Schol.</hi>: iuratos <hi rend="italic">cett.</hi>
+                  </note> dicas, probare. <reg>de</reg> huius spe
 				tantum dico, nullas a me opes P. Sullam, nullam<note>nullam <hi rend="italic">om.
-						Tea</hi></note> potentiam, nihil denique praeter<note><app><lem>praeter</lem></app>
-					propter <hi rend="italic">T</hi></note> fidem defensionis exspectare.
-					</p></div>
-			<div type="textpart" subtype="section" n="22"><p>'Nisi tu,' inquit, 'causam recepisses, numquam
+						Tea</hi>
+                  </note> potentiam, nihil denique praeter<note>
+                     <app>
+                        <lem>praeter</lem>
+                     </app>
+					propter <hi rend="italic">T</hi>
+                  </note> fidem defensionis exspectare.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="22">
+               <p>'Nisi tu,' inquit, 'causam recepisses, numquam
 				mihi restitisset, sed indicta causa profugisset.' <reg>si</reg> iam hoc
-					tibi<note>iam tibi hoc <hi rend="italic">e<foreign xml:lang="grc"
-						>p</foreign></hi></note> concedam, Q. Hortensium, tanta
-					gravitate<note>gravitate tanta <hi rend="italic">e</hi></note> hominem, si hos
-				talis viros non suo stare iudicio, sed meo; si hoc tibi dem<note>dem <hi
-						rend="italic">Naugerius</hi> (1): idem <hi rend="italic">codd.</hi></note>
+					tibi<note>iam tibi hoc <hi rend="italic">e<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note> concedam, Q. Hortensium, tanta
+					gravitate<note>gravitate tanta <hi rend="italic">e</hi>
+                  </note> hominem, si hos
+				talis viros non suo stare iudicio, sed meo; si hoc tibi dem<note>dem <hi rend="italic">Naugerius</hi> (1): idem <hi rend="italic">codd.</hi>
+                  </note>
 				quod credi non potest, nisi ego huic adessem, hos adfuturos non fuisse, uter tandem
 				rex est, isne cui innocentes homines non resistunt, an is qui calamitosos non
 				deserit? <reg>at</reg> hic etiam, id quod tibi necesse minime<note>minime tibi
-					necesse <hi rend="italic">e</hi></note> fuit, facetus esse voluisti, cum
+					necesse <hi rend="italic">e</hi>
+                  </note> fuit, facetus esse voluisti, cum
 				Tarquinium et Numam et me tertium peregrinum regem esse dixisti. Mitto iam de rege
 				quaerere; illud quaero peregrinum cur me esse dixeris. <reg>nam</reg> si ita sum,
-				non tam est admirandum regem esse me<note>me esse <hi rend="italic">e</hi></note>,
-					quoniam<note>quoniam <hi rend="italic">Te</hi>: quia <hi rend="italic"
-						>cett.</hi></note>, ut tu ais<note>ais <hi rend="italic">T</hi>: agis <hi
-						rend="italic">e</hi>: vis <hi rend="italic">cett.</hi></note>, duo
-					iam<note>duo iam <hi rend="italic">scripsi</hi>: etiam (<hi rend="italic"
-						>ex</hi> .11. iam <hi rend="italic">credo, cf. Font.</hi> 24, <hi
-						rend="italic">Rab. Post.</hi> 31) <hi rend="italic">codd.</hi>: iam <hi
-						rend="italic">Müller</hi></note> peregrini reges Romae fuerunt, quam
+				non tam est admirandum regem esse me<note>me esse <hi rend="italic">e</hi>
+                  </note>,
+					quoniam<note>quoniam <hi rend="italic">Te</hi>: quia <hi rend="italic">cett.</hi>
+                  </note>, ut tu ais<note>ais <hi rend="italic">T</hi>: agis <hi rend="italic">e</hi>: vis <hi rend="italic">cett.</hi>
+                  </note>, duo
+					iam<note>duo iam <hi rend="italic">scripsi</hi>: etiam (<hi rend="italic">ex</hi> .11. iam <hi rend="italic">credo, cf. Font.</hi> 24, <hi rend="italic">Rab. Post.</hi> 31) <hi rend="italic">codd.</hi>: iam <hi rend="italic">Müller</hi>
+                  </note> peregrini reges Romae fuerunt, quam
 				consulem Romae fuisse peregrinum. '<reg>hoc</reg> dico,' inquit, 'te esse<note>esse
-					e <hi rend="italic">Schol.</hi></note> ex municipio.'</p></div>
-			<div type="textpart" subtype="section" n="23"><p><reg>fateor</reg> et addo etiam:ex eo<note>eo <hi rend="italic">om.
-						Tb1</hi></note> municipio unde iterum iam salus huic urbi imperioque missa
+					e <hi rend="italic">Schol.</hi>
+                  </note> ex municipio.'</p>
+            </div>
+            <div type="textpart" subtype="section" n="23">
+               <p>
+                  <reg>fateor</reg> et addo etiam:ex eo<note>eo <hi rend="italic">om.
+						Tb1</hi>
+                  </note> municipio unde iterum iam salus huic urbi imperioque missa
 				est. <reg>sed</reg> scire ex te pervelim quam ob rem qui ex municipiis veniant
-				peregrini tibi esse videantur. <reg>nemo</reg><note>nemo <hi rend="italic">e,
-						Schol.</hi>: nemo enim <hi rend="italic">cett.</hi></note> istuc M.
-					illi<note>illi <hi rend="italic">om. Schol.</hi></note> Catoni seni, cum
+				peregrini tibi esse videantur. <reg>nemo</reg>
+                  <note>nemo <hi rend="italic">e,
+						Schol.</hi>: nemo enim <hi rend="italic">cett.</hi>
+                  </note> istuc M.
+					illi<note>illi <hi rend="italic">om. Schol.</hi>
+                  </note> Catoni seni, cum
 				plurimos haberet inimicos, nemo Ti. Coruncanio<note>Ti. <hi rend="italic">Teag,
-						Schol.</hi>: T. <hi rend="italic">cett.</hi></note>, nemo M'. Curio<note>M'
-					Curio <hi rend="italic">Schol., Manutius</hi>: Curio <hi rend="italic"
-							><foreign xml:lang="grc">p</foreign>c, ed. V</hi>: Curioni <hi
-						rend="italic">cett.</hi></note>, nemo huic ipsi nostro C. Mario, cum ei
+						Schol.</hi>: T. <hi rend="italic">cett.</hi>
+                  </note>, nemo M'. Curio<note>M'
+					Curio <hi rend="italic">Schol., Manutius</hi>: Curio <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>c, ed. V</hi>: Curioni <hi rend="italic">cett.</hi>
+                  </note>, nemo huic ipsi nostro C. Mario, cum ei
 				multi inviderent, obiecit umquam. <reg>equidem</reg> vehementer laetor eum esse me
 				in quem tu, cum cuperes, nullam contumeliam iacere potueris quae non ad maximam
-				partem civium conveniret<note>pertineret <hi rend="italic"><foreign xml:lang="grc"
-							>p</foreign>b2c</hi></note>. <milestone n="8" unit="chapter"
-					/><reg>sed</reg> tamen te a me pro magnis causis nostrae necessitudinis monendum
+				partem civium conveniret<note>pertineret <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>b2c</hi>
+                  </note>. <milestone n="8" unit="chapter"/>
+                  <reg>sed</reg> tamen te a me pro magnis causis nostrae necessitudinis monendum
 				esse etiam atque etiam puto. <reg>non</reg> possunt omnes esse patricii; si verum
 				quaeris, ne curant quidem; nec se aequales tui propter istam causam abs te anteiri
-				putant. </p></div>
-			<div type="textpart" subtype="section" n="24"><p><reg>ac</reg><note>at <hi rend="italic"
-						>b1c</hi></note> si tibi nos peregrini videmur, quorum iam
-						et<note><app><lem>iam et</lem></app> iam <hi rend="italic">ec</hi></note> nomen et
+				putant. </p>
+            </div>
+            <div type="textpart" subtype="section" n="24">
+               <p>
+                  <reg>ac</reg>
+                  <note>at <hi rend="italic">b1c</hi>
+                  </note> si tibi nos peregrini videmur, quorum iam
+						et<note>
+                     <app>
+                        <lem>iam et</lem>
+                     </app> iam <hi rend="italic">ec</hi>
+                  </note> nomen et
 				honos inveteravit et urbi huic<note>urbi huic <hi rend="italic">Te</hi>: huic urbi
-						<hi rend="italic">cett.</hi> hominum <hi rend="italic">om. e</hi></note>
+						<hi rend="italic">cett.</hi> hominum <hi rend="italic">om. e</hi>
+                  </note>
 				et hominum famae ac sermonibus, quam tibi illos competitores tuos peregrinos videri
-				necesse erit qui iam ex tota Italia delecti tecum de honore ac de<note>ac de <hi
-						rend="italic">Te</hi>: et de <hi rend="italic">cett.</hi></note> omni
-				dignitate contendent<note>contendent <hi rend="italic">Te</hi>: certabunt <hi
-						rend="italic">c</hi>: contendunt <hi rend="italic">cett.</hi></note>!
-					<reg>quorum</reg> cave tu<note>tu cave <hi rend="italic">e</hi></note> quemquam
+				necesse erit qui iam ex tota Italia delecti tecum de honore ac de<note>ac de <hi rend="italic">Te</hi>: et de <hi rend="italic">cett.</hi>
+                  </note> omni
+				dignitate contendent<note>contendent <hi rend="italic">Te</hi>: certabunt <hi rend="italic">c</hi>: contendunt <hi rend="italic">cett.</hi>
+                  </note>!
+					<reg>quorum</reg> cave tu<note>tu cave <hi rend="italic">e</hi>
+                  </note> quemquam
 				peregrinum appelles, ne peregrinorum suffragiis obruare. <reg>qui</reg>
-						si<note><app><lem>si</lem></app> si ita <hi rend="italic">e</hi></note> attulerint
+						si<note>
+                     <app>
+                        <lem>si</lem>
+                     </app> si ita <hi rend="italic">e</hi>
+                  </note> attulerint
 				nervos et industriam, mihi crede, excutient tibi istam verborum iactationem et te ex
 				somno saepe excitabunt nec patientur se abs te, nisi virtute vincentur, honore
-				superari. </p></div>
-			<div type="textpart" subtype="section" n="25"><p><reg>ac</reg><note><app><lem>ac</lem></app> at
-						<hi rend="italic">eb1c, ed. V</hi></note> si, iudices, ceteris<note>ceteris
-						<hi rend="italic">om. e</hi></note> patriciis me et vos peregrinos videri
-				oporteret, a Torquato tamen hoc vitium<note>hoc convicium <hi rend="italic"
-						>Gulielmius</hi></note> sileretur; est enim ipse a<note>a <hi rend="italic"
-						>om. Schol.</hi></note> materno genere municipalis, honestissimi ac
+				superari. </p>
+            </div>
+            <div type="textpart" subtype="section" n="25">
+               <p>
+                  <reg>ac</reg>
+                  <note>
+                     <app>
+                        <lem>ac</lem>
+                     </app> at
+						<hi rend="italic">eb1c, ed. V</hi>
+                  </note> si, iudices, ceteris<note>ceteris
+						<hi rend="italic">om. e</hi>
+                  </note> patriciis me et vos peregrinos videri
+				oporteret, a Torquato tamen hoc vitium<note>hoc convicium <hi rend="italic">Gulielmius</hi>
+                  </note> sileretur; est enim ipse a<note>a <hi rend="italic">om. Schol.</hi>
+                  </note> materno genere municipalis, honestissimi ac
 				nobilissimi generis, sed tamen Asculani. <reg>aut</reg> igitur doceat Picentis solos
-				non esse<note>esse non <hi rend="italic">e</hi></note> peregrinos aut gaudeat suo
-				generi me meum non anteponere<note>non anteponere <hi rend="italic">Te<foreign
-							xml:lang="grc">p</foreign></hi>: ante non ponere (<hi rend="italic">cf.
+				non esse<note>esse non <hi rend="italic">e</hi>
+                  </note> peregrinos aut gaudeat suo
+				generi me meum non anteponere<note>non anteponere <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>: ante non ponere (<hi rend="italic">cf.
 						Off.</hi> iii. 71) <hi rend="italic">cett.</hi> (<hi rend="italic">meliore
 						numero</hi>)</note>. <reg>qua</reg> re neque tu me peregrinum posthac
 				dixeris, ne gravius refutere, neque regem, ne derideare. Nisi forte regium tibi
 				videtur ita vivere ut non modo homini nemini sed ne cupiditati quidem ulli servias,
 				contemnere omnis libidines, non auri, non argenti, non ceterarum rerum indigere, in
-				senatu sentire libere, populi utilitati magis<note>magis utilitati <hi
-						rend="italic">e</hi></note> consulere quam voluntati, nemini cedere, multis
-				obsistere. <reg>si</reg> hoc putas esse regium<note><app><lem>regium</lem></app> regnum <hi
-						rend="italic"><foreign xml:lang="grc">p</foreign>b1gc2k</hi></note>, regem
-				me esse<note>regem me esse <hi rend="italic">T</hi>: me regem esse <hi
-						rend="italic">cett.</hi></note> confiteor; sin te potentia mea, si
+				senatu sentire libere, populi utilitati magis<note>magis utilitati <hi rend="italic">e</hi>
+                  </note> consulere quam voluntati, nemini cedere, multis
+				obsistere. <reg>si</reg> hoc putas esse regium<note>
+                     <app>
+                        <lem>regium</lem>
+                     </app> regnum <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>b1gc2k</hi>
+                  </note>, regem
+				me esse<note>regem me esse <hi rend="italic">T</hi>: me regem esse <hi rend="italic">cett.</hi>
+                  </note> confiteor; sin te potentia mea, si
 				dominatio, si denique aliquod dictum adrogans aut superbum movet, quin tu id potius
-				profers quam verbi invidiam contumeliamque maledicti? <milestone n="9"
-					unit="chapter"/></p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="26"><p>
-			<reg>ego</reg>, tantis a me beneficiis in re publica positis, si nullum aliud mihi
-				praemium ab<note>ab <hi rend="italic">Te, Schol.</hi>: a <hi rend="italic"
-						>cett.</hi></note> senatu populoque Romano nisi honestum otium postularem,
-				quis non concederet? <add><reg>ceteri</reg></add><note>ceteri <hi rend="italic"
-						>supplevi</hi></note> sibi haberent<note><app><lem>haberent</lem></app> haberent
-					alii <hi rend="italic">Sylvius</hi></note> honores, sibi imperia, sibi
+				profers quam verbi invidiam contumeliamque maledicti? <milestone n="9" unit="chapter"/>
+               </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="26">
+               <p>
+                  <reg>ego</reg>, tantis a me beneficiis in re publica positis, si nullum aliud mihi
+				praemium ab<note>ab <hi rend="italic">Te, Schol.</hi>: a <hi rend="italic">cett.</hi>
+                  </note> senatu populoque Romano nisi honestum otium postularem,
+				quis non concederet? <add>
+                     <reg>ceteri</reg>
+                  </add>
+                  <note>ceteri <hi rend="italic">supplevi</hi>
+                  </note> sibi haberent<note>
+                     <app>
+                        <lem>haberent</lem>
+                     </app> haberent
+					alii <hi rend="italic">Sylvius</hi>
+                  </note> honores, sibi imperia, sibi
 				provincias, sibi triumphos, sibi alia praeclarae laudis insignia; mihi liceret eius
 				urbis quam conservassem conspectu tranquillo animo et quieto frui. <reg>quid</reg>
 				si hoc non postulo? si ille labor meus pristinus, si sollicitudo, si officia, si
 				operae, si vigiliae deserviunt amicis, praesto sunt omnibus; si neque amici in foro
 				requirunt studium meum neque res publica in curia; si me non modo
-						non<note><app><lem>modo non</lem></app> modo <foreign xml:lang="grc">s</foreign>
-					vocatio <hi rend="italic">ea</hi></note> rerum gestarum vacatio sed neque
+						non<note>
+                     <app>
+                        <lem>modo non</lem>
+                     </app> modo <foreign xml:lang="grc">ς</foreign>
+					vocatio <hi rend="italic">ea</hi>
+                  </note> rerum gestarum vacatio sed neque
 				honoris neque aetatis excusatio vindicat a labore; si voluntas mea, si industria, si
 				domus, si animus, si aures patent omnibus; si mihi ne ad ea quidem quae pro salute
 				omnium gessi recordanda et cogitanda quicquam relinquitur temporis: tamen hoc regnum
-				appellabitur, cuius vicarius qui velit esse inveniri nemo potest? </p></div>
-			<div type="textpart" subtype="section" n="27"><p>
-				<reg>longe</reg> abest a me<note>a me <hi rend="italic"
-					>Ee</hi>: <hi rend="italic">om. cett.</hi></note> regni suspicio; si quaeris
-				qui sint<note>sin <hi rend="italic">e</hi></note> Romae regnum occupare conati, ut
+				appellabitur, cuius vicarius qui velit esse inveniri nemo potest? </p>
+            </div>
+            <div type="textpart" subtype="section" n="27">
+               <p>
+                  <reg>longe</reg> abest a me<note>a me <hi rend="italic">Ee</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> regni suspicio; si quaeris
+				qui sint<note>sin <hi rend="italic">e</hi>
+                  </note> Romae regnum occupare conati, ut
 				ne replices annalium memoriam, ex domesticis imaginibus invenies. <reg>res</reg>
 				enim gestae, credo, meae me nimis extulerunt ac mihi nescio quos spiritus
 				attulerunt. <reg>quibus</reg> de rebus tam claris, tam immortalibus, iudices, hoc
-				possum dicere, me qui ex summis periculis eripuerim<note>periculis erip. <hi
-						rend="italic">Te</hi>: erip. periculis <hi rend="italic">cett.</hi></note>
+				possum dicere, me qui ex summis periculis eripuerim<note>periculis erip. <hi rend="italic">Te</hi>: erip. periculis <hi rend="italic">cett.</hi>
+                  </note>
 				urbem hanc et vitam omnium civium satis adeptum fore, si ex hoc tanto in omnis
-				mortalis beneficio nullum in me<note><app><lem>me</lem></app> me ipsum <hi rend="italic"
-						>e</hi></note> periculum redundarit<note>redundarit <hi rend="italic"
-						>TEe</hi>: redundabit <hi rend="italic">cett.</hi></note>. </p></div>
-			<div type="textpart" subtype="section" n="28"><p>
-				<reg>etenim</reg> in qua civitate res tantas<note>rem
-					tantam <hi rend="italic">Schol.</hi></note> gesserim memini, in qua<note>in qua
-						<hi rend="italic">b1k, Schol.</hi>: et in qua (qua in <hi rend="italic"
-						>T</hi>) <hi rend="italic">cett.</hi></note> urbe verser<note>verser (-or
-						<foreign xml:lang="grc">p</foreign>) <hi rend="italic">TEe<foreign
-							xml:lang="grc">p</foreign>, Schol.</hi>: <hi rend="italic">om.
-						cett.</hi></note> intellego. <reg>plenum</reg> forum est eorum hominum quos
-				ego a vestris cervicibus depuli<note>repuli <hi rend="italic">e<foreign
-							xml:lang="grc">y2</foreign>c</hi></note>, iudices, a meis non removi.
+				mortalis beneficio nullum in me<note>
+                     <app>
+                        <lem>me</lem>
+                     </app> me ipsum <hi rend="italic">e</hi>
+                  </note> periculum redundarit<note>redundarit <hi rend="italic">TEe</hi>: redundabit <hi rend="italic">cett.</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="28">
+               <p>
+                  <reg>etenim</reg> in qua civitate res tantas<note>rem
+					tantam <hi rend="italic">Schol.</hi>
+                  </note> gesserim memini, in qua<note>in qua
+						<hi rend="italic">b1k, Schol.</hi>: et in qua (qua in <hi rend="italic">T</hi>) <hi rend="italic">cett.</hi>
+                  </note> urbe verser<note>verser (-or
+						<foreign xml:lang="grc">π</foreign>) <hi rend="italic">TEe<foreign xml:lang="grc">π</foreign>, Schol.</hi>: <hi rend="italic">om.
+						cett.</hi>
+                  </note> intellego. <reg>plenum</reg> forum est eorum hominum quos
+				ego a vestris cervicibus depuli<note>repuli <hi rend="italic">e<foreign xml:lang="grc">ψ2</foreign>c</hi>
+                  </note>, iudices, a meis non removi.
 				Nisi vero paucos fuisse arbitramini qui conari aut sperare possent se tantum
 				imperium posse delere. Horum ego faces eripere de manibus et gladios extorquere
-				potui, sicuti<note>sicuti <hi rend="italic">Te</hi>: sicut <hi rend="italic"
-						>cett.</hi></note> feci, voluntates vero consceleratas ac nefarias nec
+				potui, sicuti<note>sicuti <hi rend="italic">Te</hi>: sicut <hi rend="italic">cett.</hi>
+                  </note> feci, voluntates vero consceleratas ac nefarias nec
 				sanare potui nec tollere. <reg>qua</reg> re non sum nescius quanto periculo vivam in
 				tanta multitudine improborum, cum mihi uni cum omnibus improbis aeternum videam
 				bellum esse susceptum<note>esse bellum susceptum <hi rend="italic">T</hi>: bellum
-					susceptum esse <hi rend="italic">e</hi></note>. <milestone n="10"
-					unit="chapter"/></p></div>
-			<div type="textpart" subtype="section" n="29"><p><reg>quod</reg> si illis meis
+					susceptum esse <hi rend="italic">e</hi>
+                  </note>. <milestone n="10" unit="chapter"/>
+               </p>
+            </div>
+            <div type="textpart" subtype="section" n="29">
+               <p>
+                  <reg>quod</reg> si illis meis
 				praesidiis forte invides, et si ea tibi regia videntur quod omnes boni omnium
 				generum atque ordinum suam salutem cum mea coniungunt, consolare te quod omnium
 				mentes improborum mihi uni maxime sunt infensae et adversae; qui me non
-					modo<note>non modo <foreign xml:lang="grc">y2</foreign>: non solum <foreign
-						xml:lang="grc">pxy1s</foreign>: non modo solum <hi rend="italic">cett.</hi>
+					modo<note>non modo <foreign xml:lang="grc">ψ2</foreign>: non solum <foreign xml:lang="grc">πχψ1ς</foreign>: non modo solum <hi rend="italic">cett.</hi>
 					(mõ <hi rend="italic">post</hi> nõ <hi rend="italic">omissum turbas
 					dedit</hi>)</note> idcirco oderunt quod eorum conatus impios et furorem
-				consceleratum repressi, sed eo etiam magis<note>magis etiam <hi rend="italic"
-						>e</hi></note> quod nihil iam<note>iam <hi rend="italic">om. e</hi></note>
-				se simile me vivo conari posse arbitrantur. </p></div>
-			<div type="textpart" subtype="section" n="30"><p>
-				<reg>at</reg><note>ac <hi rend="italic">T</hi></note> vero quid ego
-					mirer<note>mirer <hi rend="italic">Te</hi>: miror <hi rend="italic"
-					>cett.</hi></note>, si quid ab improbis de me improbe dicitur, cum L. Torquatus
-				primum ipse his fundamentis<note>his fund. ipse <hi rend="italic">e</hi></note>
+				consceleratum repressi, sed eo etiam magis<note>magis etiam <hi rend="italic">e</hi>
+                  </note> quod nihil iam<note>iam <hi rend="italic">om. e</hi>
+                  </note>
+				se simile me vivo conari posse arbitrantur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="30">
+               <p>
+                  <reg>at</reg>
+                  <note>ac <hi rend="italic">T</hi>
+                  </note> vero quid ego
+					mirer<note>mirer <hi rend="italic">Te</hi>: miror <hi rend="italic">cett.</hi>
+                  </note>, si quid ab improbis de me improbe dicitur, cum L. Torquatus
+				primum ipse his fundamentis<note>his fund. ipse <hi rend="italic">e</hi>
+                  </note>
 				adulescentiae iactis, ea spe proposita amplissimae dignitatis, deinde L. Torquati,
 				fortissimi consulis, constantissimi senatoris, semper optimi civis filius, interdum
 				efferatur immoderatione verborum? <reg>qui</reg> cum suppressa voce de scelere P.
-					Lentuli<note>P. Lentuli <hi rend="italic">del. Garatoni</hi></note>, de audacia
+					Lentuli<note>P. Lentuli <hi rend="italic">del. Garatoni</hi>
+                  </note>, de audacia
 				coniuratorum omnium dixisset, tantum modo ut vos qui ea probatis exaudire possetis,
-				de supplicio<note><app><lem>supplicio</lem></app> de Lentulo <hi rend="italic">add.
+				de supplicio<note>
+                     <app>
+                        <lem>supplicio</lem>
+                     </app> de Lentulo <hi rend="italic">add.
 						Tea</hi>: P. Lentuli <hi rend="italic">add. cett., del. Halm</hi> (de
 					laqueo <hi rend="italic">Reid</hi>)</note>, de carcere magna et queribunda voce
-				dicebat. </p></div>
-			<div type="textpart" subtype="section" n="31"><p><reg>in</reg> quo primum illud
-					erat<note>erat illud <hi rend="italic">T</hi></note> absurdum quod, cum ea quae
-					leviter<note>leniter <hi rend="italic">Sylvius</hi></note> dixerat vobis
-				probare volebat, eos autem<note>autem <hi rend="italic">om. T</hi></note> qui
+				dicebat. </p>
+            </div>
+            <div type="textpart" subtype="section" n="31">
+               <p>
+                  <reg>in</reg> quo primum illud
+					erat<note>erat illud <hi rend="italic">T</hi>
+                  </note> absurdum quod, cum ea quae
+					leviter<note>leniter <hi rend="italic">Sylvius</hi>
+                  </note> dixerat vobis
+				probare volebat, eos autem<note>autem <hi rend="italic">om. T</hi>
+                  </note> qui
 				circum iudicium stabant audire nolebat, non intellegebat ea quae clare diceret ita
 				illos audituros quibus se venditabat ut vos quoque audiretis, qui id non
-					probabatis<note>probabitis <hi rend="italic">Ta<foreign xml:lang="grc"
-							>p</foreign></hi></note>. <reg>deinde</reg> alterum iam oratoris
-					<add>est</add><note>est <hi rend="italic">suppl. Reid</hi></note> vitium non
-				videre quid<note>quod <hi rend="italic">T</hi></note> quaeque causa postulet.
+					probabatis<note>probabitis <hi rend="italic">Ta<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note>. <reg>deinde</reg> alterum iam oratoris
+					<add>est</add>
+                  <note>est <hi rend="italic">suppl. Reid</hi>
+                  </note> vitium non
+				videre quid<note>quod <hi rend="italic">T</hi>
+                  </note> quaeque causa postulet.
 					<reg>nihil</reg> est enim tam alienum ab eo qui alterum coniurationis accuset
 				quam videri coniuratorum poenam mortemque lugere. <reg>quod</reg> cum is tribunus
 				pl. facit qui unus videtur ex illis ad lugendos coniuratos relictus,
-					nemini<note>nemini <hi rend="italic">Te, Schol.</hi>: re ... <hi rend="italic"
-						>a <foreign xml:lang="grc">S</foreign>gp</hi>: vere <foreign xml:lang="grc"
-						>p</foreign>: nec ... <hi rend="italic"><foreign xml:lang="grc"
-							>x1</foreign>c</hi>: nec (neque <hi rend="italic">k</hi>) hoc <hi
-						rend="italic"><foreign xml:lang="grc">x2</foreign>c2k</hi></note> mirum
+					nemini<note>nemini <hi rend="italic">Te, Schol.</hi>: re ... <hi rend="italic">a <foreign xml:lang="grc">ς</foreign>gp</hi>: vere <foreign xml:lang="grc">π</foreign>: nec ... <hi rend="italic">
+                        <foreign xml:lang="grc">χ1</foreign>c</hi>: nec (neque <hi rend="italic">k</hi>) hoc <hi rend="italic">
+                        <foreign xml:lang="grc">χ2</foreign>c2k</hi>
+                  </note> mirum
 				est; difficile est enim tacere, cum doleas; te, si quid eius modi facis<note>facis
-					eius modi <hi rend="italic">e</hi></note>, non modo talem adulescentem sed in
-				ea causa in qua te vindicem coniurationis velis esse vehementer admiror. </p></div>
-			<div type="textpart" subtype="section" n="32"><p>
-				<reg>sed</reg> reprehendo tamen illud maxime quod isto
+					eius modi <hi rend="italic">e</hi>
+                  </note>, non modo talem adulescentem sed in
+				ea causa in qua te vindicem coniurationis velis esse vehementer admiror. </p>
+            </div>
+            <div type="textpart" subtype="section" n="32">
+               <p>
+                  <reg>sed</reg> reprehendo tamen illud maxime quod isto
 				ingenio et prudentia praeditus causam rei publicae non tenes, qui arbitrere plebi
 				Romanae res eas non probari quas me consule omnes boni pro communi salute<note>comm.
-					salute <hi rend="italic">c, Lag.</hi> 9: salute comm. <hi rend="italic"
-						>cett.</hi></note> gesserunt. <milestone n="11" unit="chapter"
-					/><reg>ecquem</reg><note>et quem <hi rend="italic">codd.</hi>: <hi
-						rend="italic">corr. ed. Crat.</hi></note> tu horum qui adsunt<note>adsunt
-						<hi rend="italic">b<foreign xml:lang="grc">x</foreign>c</hi>: assunt <hi
-						rend="italic">cett.</hi></note>, quibus te contra ipsorum voluntatem
+					salute <hi rend="italic">c, Lag.</hi> 9: salute comm. <hi rend="italic">cett.</hi>
+                  </note> gesserunt. <milestone n="11" unit="chapter"/>
+                  <reg>ecquem</reg>
+                  <note>et quem <hi rend="italic">codd.</hi>: <hi rend="italic">corr. ed. Crat.</hi>
+                  </note> tu horum qui adsunt<note>adsunt
+						<hi rend="italic">b<foreign xml:lang="grc">χ</foreign>c</hi>: assunt <hi rend="italic">cett.</hi>
+                  </note>, quibus te contra ipsorum voluntatem
 				venditabas, aut tam sceleratum statuis fuisse ut haec
-						omnia<note><app><lem>omnia</lem></app> omni <hi rend="italic">T</hi>: <hi
-						rend="italic">om. e</hi></note> perire
-						voluerit<note><app><lem>voluerit</lem></app>
-					<hi rend="italic">fort.</hi> se salvo voluerit (<hi rend="italic">colon numero
+						omnia<note>
+                     <app>
+                        <lem>omnia</lem>
+                     </app> omni <hi rend="italic">T</hi>: <hi rend="italic">om. e</hi>
+                  </note> perire
+						voluerit<note>
+                     <app>
+                        <lem>voluerit</lem>
+                     </app>
+                     <hi rend="italic">fort.</hi> se salvo voluerit (<hi rend="italic">colon numero
 						caret</hi>)</note>, aut tam miserum ut et se perire cuperet et nihil haberet
 				quod salvum esse vellet? <reg>an</reg> vero clarissimum virum generis vestri ac
 				nominis nemo reprehendit, qui filium suum vita privavit ut in ceteros<note>ceteros
-						<hi rend="italic">e, Schol.</hi>: ceteris <hi rend="italic"
-					>cett.</hi></note> firmaret imperium; tu rem publicam reprehendis, quae
-				domesticos hostis, ne ab eis<note>iis <hi rend="italic">k</hi>: his <hi
-						rend="italic">cett.</hi></note> ipsa necaretur, necavit? </p></div>
-			<div type="textpart" subtype="section" n="33"><p>
-				<reg>itaque</reg> attende<note>attende <hi rend="italic"
-						>Te</hi>: attende iam <hi rend="italic">cett.</hi></note>, Torquate, quam
+						<hi rend="italic">e, Schol.</hi>: ceteris <hi rend="italic">cett.</hi>
+                  </note> firmaret imperium; tu rem publicam reprehendis, quae
+				domesticos hostis, ne ab eis<note>iis <hi rend="italic">k</hi>: his <hi rend="italic">cett.</hi>
+                  </note> ipsa necaretur, necavit? </p>
+            </div>
+            <div type="textpart" subtype="section" n="33">
+               <p>
+                  <reg>itaque</reg> attende<note>attende <hi rend="italic">Te</hi>: attende iam <hi rend="italic">cett.</hi>
+                  </note>, Torquate, quam
 				ego defugiam auctoritatem consulatus mei! <reg>maxima</reg> voce ut omnes exaudire
-				possint dico semperque dicam. <reg>adeste</reg><note>adeste <hi rend="italic"
-							>Te<foreign xml:lang="grc">p</foreign></hi>: adestote <hi rend="italic"
-						>cett.</hi></note> omnes animis, Quirites<note>Quirites <hi rend="italic"
-						>scripsi</hi>: qui adestis (corpore <hi rend="italic">add. p. mg.,</hi>
-					corporibus <hi rend="italic">add. <foreign xml:lang="grc">S</foreign> mg.,
-						b1k</hi>) <hi rend="italic">codd.</hi>: qui adstatis <hi rend="italic"
-						>Reid</hi> (<hi rend="italic">nota q~ turbas dedit, cf. Phil.</hi> iv.
+				possint dico semperque dicam. <reg>adeste</reg>
+                  <note>adeste <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>: adestote <hi rend="italic">cett.</hi>
+                  </note> omnes animis, Quirites<note>Quirites <hi rend="italic">scripsi</hi>: qui adestis (corpore <hi rend="italic">add. p. mg.,</hi>
+					corporibus <hi rend="italic">add. <foreign xml:lang="grc">ς</foreign> mg.,
+						b1k</hi>) <hi rend="italic">codd.</hi>: qui adstatis <hi rend="italic">Reid</hi> (<hi rend="italic">nota q~ turbas dedit, cf. Phil.</hi> iv.
 					1)</note>, quorum ego frequentia magno opere laetor; erigite mentis aurisque
 				vestras et me de invidiosis rebus, ut ille putat, dicentem attendite! <reg>ego</reg>
 				consul, cum exercitus perditorum civium clandestino scelere conflatus crudelissimum
 				et luctuosissimum exitium patriae comparasset, cum ad occasum interitumque rei
-				publicae Catilina in castris, in his autem templis atque<note><app><lem>atque</lem></app>
-					ac <hi rend="italic">e</hi></note> tectis dux Lentulus esset constitutus, meis
+				publicae Catilina in castris, in his autem templis atque<note>
+                     <app>
+                        <lem>atque</lem>
+                     </app>
+					ac <hi rend="italic">e</hi>
+                  </note> tectis dux Lentulus esset constitutus, meis
 				consiliis, meis laboribus, mei capitis periculis, sine tumultu, sine
-					dilectu<note>dilectu <hi rend="italic">e<foreign xml:lang="grc"
-						>p</foreign></hi>: delectu <hi rend="italic">cett.</hi></note>, sine armis,
-				sine exercitu, quinque hominibus comprehensis atque confessis<note>confessis <hi
-						rend="italic">Tea<foreign xml:lang="grc">p</foreign></hi>: confossis <hi
-						rend="italic">cett.</hi></note> incensione urbem, internicione civis,
+					dilectu<note>dilectu <hi rend="italic">e<foreign xml:lang="grc">π</foreign>
+                     </hi>: delectu <hi rend="italic">cett.</hi>
+                  </note>, sine armis,
+				sine exercitu, quinque hominibus comprehensis atque confessis<note>confessis <hi rend="italic">Tea<foreign xml:lang="grc">π</foreign>
+                     </hi>: confossis <hi rend="italic">cett.</hi>
+                  </note> incensione urbem, internicione civis,
 				vastitate Italiam, interitu rem publicam liberavi; ego vitam omnium civium, statum
 				orbis terrae, urbem hanc denique, sedem omnium nostrum, arcem regum ac nationum
 				exterarum, lumen gentium, domicilium imperi, quinque hominum amentium ac perditorum
-				poena redemi. </p></div>
-			<div type="textpart" subtype="section" n="34"><p>
-				<reg>an</reg> me existimasti haec iniuratum in iudicio non esse dicturum quae
-				iuratus in maxima contione dixissem? <milestone n="12" unit="chapter"
-					/><reg>atque</reg> etiam illud addam, ne qui forte incipiat improbus subito te
-				amare, Torquate, et aliquid sperare de te, atque ut idem<note>ut id <hi
-						rend="italic">Reid</hi></note> omnes exaudiant clarissima voce dicam.
+				poena redemi. </p>
+            </div>
+            <div type="textpart" subtype="section" n="34">
+               <p>
+                  <reg>an</reg> me existimasti haec iniuratum in iudicio non esse dicturum quae
+				iuratus in maxima contione dixissem? <milestone n="12" unit="chapter"/>
+                  <reg>atque</reg> etiam illud addam, ne qui forte incipiat improbus subito te
+				amare, Torquate, et aliquid sperare de te, atque ut idem<note>ut id <hi rend="italic">Reid</hi>
+                  </note> omnes exaudiant clarissima voce dicam.
 					<reg>harum</reg> omnium rerum quas ego in consulatu pro salute rei
-					publicae<note>salute rei p. <hi rend="italic">Te</hi>: communi salute <foreign
-						xml:lang="grc">S</foreign>: salute <hi rend="italic">ag<foreign
-							xml:lang="grc">x</foreign>c</hi>: salute communi <hi rend="italic"
-						>bpk</hi></note> suscepi atque<note>atque <hi rend="italic">Teg</hi>: et
-						<hi rend="italic">cett.</hi></note> gessi L. ille Torquatus, cum esset meus
-				contubernalis in consulatu<note>in consulatu <hi rend="italic">e</hi>: <hi
-						rend="italic">post</hi> consulatu <hi rend="italic">colon</hi> pro salute
+					publicae<note>salute rei p. <hi rend="italic">Te</hi>: communi salute <foreign xml:lang="grc">ς</foreign>: salute <hi rend="italic">ag<foreign xml:lang="grc">χ</foreign>c</hi>: salute communi <hi rend="italic">bpk</hi>
+                  </note> suscepi atque<note>atque <hi rend="italic">Teg</hi>: et
+						<hi rend="italic">cett.</hi>
+                  </note> gessi L. ille Torquatus, cum esset meus
+				contubernalis in consulatu<note>in consulatu <hi rend="italic">e</hi>: <hi rend="italic">post</hi> consulatu <hi rend="italic">colon</hi> pro salute
 					... consulatu <hi rend="italic">repetit T</hi>: in consulatu cum signifer esset
-					iuventutis <hi rend="italic">cett.</hi></note> atque etiam in praetura fuisset,
+					iuventutis <hi rend="italic">cett.</hi>
+                  </note> atque etiam in praetura fuisset,
 				cum princeps, cum auctor, cum signifer esset iuventutis<note>cum princeps ...
 					iuventutis <hi rend="italic">post</hi> exstitit <hi rend="italic">hab.
-						codd.</hi>: <hi rend="italic">huc transtuli</hi></note>, actor<note>actor
-						<hi rend="italic">Orelli</hi>: auctor <hi rend="italic">codd.</hi> (<hi
-						rend="italic">cf. Sest.</hi> 61)</note>, adiutor, particeps exstitit;
+						codd.</hi>: <hi rend="italic">huc transtuli</hi>
+                  </note>, actor<note>actor
+						<hi rend="italic">Orelli</hi>: auctor <hi rend="italic">codd.</hi> (<hi rend="italic">cf. Sest.</hi> 61)</note>, adiutor, particeps exstitit;
 				parens eius, homo amantissimus patriae, maximi animi, summi consili, singularis
 				constantiae, cum esset aeger, tamen omnibus rebus illis interfuit,
-					nusquam<note>nusquam <hi rend="italic">Te</hi>: numquam <hi rend="italic"
-						>cett.</hi></note> est a me digressus, studio, consilio, auctoritate unus
-				adiuvit plurimum, cum infirmitatem corporis animi virtute<note>virtute animi <hi
-						rend="italic">e</hi></note> superaret. </p></div>
-			<div type="textpart" subtype="section" n="35"><p>
-				<reg>videsne</reg> ut eripiam te ex improborum subita gratia et reconciliem
+					nusquam<note>nusquam <hi rend="italic">Te</hi>: numquam <hi rend="italic">cett.</hi>
+                  </note> est a me digressus, studio, consilio, auctoritate unus
+				adiuvit plurimum, cum infirmitatem corporis animi virtute<note>virtute animi <hi rend="italic">e</hi>
+                  </note> superaret. </p>
+            </div>
+            <div type="textpart" subtype="section" n="35">
+               <p>
+                  <reg>videsne</reg> ut eripiam te ex improborum subita gratia et reconciliem
 				bonis omnibus? qui te et diligunt et retinent retinebuntque semper nec, si a me
-					forte<note>forte a me <hi rend="italic">e<foreign xml:lang="grc"
-						>p</foreign></hi></note> desciveris, idcirco te a se et a re publica et a
-						tua<note><app><lem>tua</lem></app> sua <hi rend="italic">Tea<foreign
-							xml:lang="grc">p</foreign>gb1</hi></note> dignitate deficere patientur.
+					forte<note>forte a me <hi rend="italic">e<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note> desciveris, idcirco te a se et a re publica et a
+						tua<note>
+                     <app>
+                        <lem>tua</lem>
+                     </app> sua <hi rend="italic">Tea<foreign xml:lang="grc">π</foreign>gb1</hi>
+                  </note> dignitate deficere patientur.
 					<reg>sed</reg> iam redeo ad causam atque hoc vos, iudices, testor: mihi de memet
 				ipso tam multa dicendi necessitas quaedam imposita est ab illo. <reg>nam</reg> si
 				Torquatus Sullam solum accusasset, ego quoque hoc tempore nihil aliud agerem nisi
 				eum qui accusatus esset defenderem; sed cum ille tota illa oratione<note>orat. illa
-						<hi rend="italic">e</hi></note> in me esset invectus et cum, ut
-					initio<note>ut initio <hi rend="italic">Te</hi>: initio ut <hi rend="italic"
-						>cett.</hi></note> dixi, defensionem meam spoliare auctoritate<note>spoliare
-					auct <hi rend="italic">Te</hi>: auct. spoliare <hi rend="italic"
-					>cett.</hi></note> voluisset, etiam si dolor meus<note>meus dolor <hi
-						rend="italic">e</hi>: dolor me meus <hi rend="italic">Orelli</hi></note>
+						<hi rend="italic">e</hi>
+                  </note> in me esset invectus et cum, ut
+					initio<note>ut initio <hi rend="italic">Te</hi>: initio ut <hi rend="italic">cett.</hi>
+                  </note> dixi, defensionem meam spoliare auctoritate<note>spoliare
+					auct <hi rend="italic">Te</hi>: auct. spoliare <hi rend="italic">cett.</hi>
+                  </note> voluisset, etiam si dolor meus<note>meus dolor <hi rend="italic">e</hi>: dolor me meus <hi rend="italic">Orelli</hi>
+                  </note>
 				respondere non cogeret, tamen ipsa causa hanc a me orationem
-					flagitavisset<note>flagitavisset <hi rend="italic">Te<foreign xml:lang="grc"
-							>p</foreign></hi>: flagitasset <hi rend="italic">cett.</hi></note>.
-					</p></div><milestone n="13" unit="chapter"/>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="36"><p>
-			<reg>ab</reg><note>ab <hi rend="italic">ec2, Schol.</hi>: <hi rend="italic">om.
-						cett.</hi></note> Allobrogibus nominatum Sullam esse dicis. <reg>quis</reg>
-				negat? <reg>sed</reg> lege<note>sed lege <hi rend="italic">TEe</hi>: Sullae <hi
-						rend="italic">cett.</hi></note> indicium<note>indic. <hi rend="italic"
-							>Ta<foreign xml:lang="grc">x</foreign>c</hi>: iudic. <hi rend="italic"
-						>cett.</hi></note> et vide quem ad modum nominatus sit. L. Cassium dixerunt
+					flagitavisset<note>flagitavisset <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>: flagitasset <hi rend="italic">cett.</hi>
+                  </note>.
+					</p>
+            </div>
+            <milestone n="13" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="36">
+               <p>
+                  <reg>ab</reg>
+                  <note>ab <hi rend="italic">ec2, Schol.</hi>: <hi rend="italic">om.
+						cett.</hi>
+                  </note> Allobrogibus nominatum Sullam esse dicis. <reg>quis</reg>
+				negat? <reg>sed</reg> lege<note>sed lege <hi rend="italic">TEe</hi>: Sullae <hi rend="italic">cett.</hi>
+                  </note> indicium<note>indic. <hi rend="italic">Ta<foreign xml:lang="grc">χ</foreign>c</hi>: iudic. <hi rend="italic">cett.</hi>
+                  </note> et vide quem ad modum nominatus sit. L. Cassium dixerunt
 				commemorasse cum ceteris Autronium secum facere. <reg>quaero</reg> num Sullam
 				dixerit Cassius. <reg>nusquam</reg>. <reg>sese</reg> aiunt quaesisse de Cassio quid
 				Sulla sentiret. <reg>videte</reg> diligentiam Gallorum; qui vitam hominum naturamque
-				non nossent ac tantum audissent<note>audivissent <hi rend="italic">e</hi></note>
+				non nossent ac tantum audissent<note>audivissent <hi rend="italic">e</hi>
+                  </note>
 				eos pari calamitate esse, quaesiverunt essentne eadem<note>esse quaesiverunt
-					essentne eadem <hi rend="italic">TEe<foreign xml:lang="grc">p</foreign></hi>:
-					qui fuerant (-unt <hi rend="italic">a</hi>) esse (-ent <hi rend="italic"
-						>a</hi>) in eodem <hi rend="italic">cett.</hi></note> voluntate.
+					essentne eadem <hi rend="italic">TEe<foreign xml:lang="grc">π</foreign>
+                     </hi>:
+					qui fuerant (-unt <hi rend="italic">a</hi>) esse (-ent <hi rend="italic">a</hi>) in eodem <hi rend="italic">cett.</hi>
+                  </note> voluntate.
 					<reg>quid</reg> tum Cassius? <reg>si</reg> respondisset idem sentire et secum
 				facere Sullam, tamen mihi non videretur in hunc id criminosum esse debere.
 					<reg>quid</reg> ita? <reg>quia</reg>, qui barbaros homines ad bellum impelleret,
 				non debebat minuere illorum suspicionem et purgare eos de quibus illi aliquid
 				suspicari viderentur<note>suspicari viderentur <hi rend="italic">TEe</hi>:
-					suspicarentur <hi rend="italic">cett.</hi></note>. </p></div>
-			<div type="textpart" subtype="section" n="37"><p>
-				<reg>non</reg> respondit tamen una facere Sullam.
+					suspicarentur <hi rend="italic">cett.</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="37">
+               <p>
+                  <reg>non</reg> respondit tamen una facere Sullam.
 					<reg>etenim</reg> esset absurdum, cum ceteros sua sponte nominasset, mentionem
-				facere Sullae<note>Sullae <hi rend="italic">ante</hi> nullam <hi rend="italic"
-						>hab. e, <foreign xml:lang="grc">S</foreign> mg., ante</hi> facere <hi
-						rend="italic">T</hi>: <hi rend="italic">om. cett.</hi></note> nullam nisi
+				facere Sullae<note>Sullae <hi rend="italic">ante</hi> nullam <hi rend="italic">hab. e, <foreign xml:lang="grc">ς</foreign> mg., ante</hi> facere <hi rend="italic">T</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> nullam nisi
 				admonitum et interrogatum; nisi forte veri simile est P. Sullae nomen in memoria
-				Cassio non fuisse. <reg>si</reg> nobilitas hominis, si adflicta<note>afflicta <hi
-						rend="italic">eb1c2k, p mg.</hi>: afflata <hi rend="italic"
-					>cett.</hi></note> fortuna, si reliquiae pristinae dignitatis non tam inlustres
+				Cassio non fuisse. <reg>si</reg> nobilitas hominis, si adflicta<note>afflicta <hi rend="italic">eb1c2k, p mg.</hi>: afflata <hi rend="italic">cett.</hi>
+                  </note> fortuna, si reliquiae pristinae dignitatis non tam inlustres
 				fuissent, tamen Autroni commemoratio memoriam Sullae rettulisset; etiam, ut
 				arbitror, cum auctoritates principum coniurationis ad incitandos animos Allobrogum
 				conligeret Cassius, et cum sciret exteras nationes maxime nobilitate moveri, non
-				prius Autronium quam Sullam nominavisset<note>nominavisset <hi rend="italic"
-						>Te</hi>: nominasset <hi rend="italic">cett.</hi></note>. </p></div>
-			<div type="textpart" subtype="section" n="38"><p>
-				<reg>iam</reg> vero illud minime probari<note>minime probari <hi
-						rend="italic">e</hi>: probari minime <hi rend="italic">cett.</hi></note>
+				prius Autronium quam Sullam nominavisset<note>nominavisset <hi rend="italic">Te</hi>: nominasset <hi rend="italic">cett.</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="38">
+               <p>
+                  <reg>iam</reg> vero illud minime probari<note>minime probari <hi rend="italic">e</hi>: probari minime <hi rend="italic">cett.</hi>
+                  </note>
 				potest, Gallos Autronio nominato putasse propter calamitatis similitudinem sibi
 				aliquid de Sulla esse quaerendum, Cassio, si hic esset in eodem scelere, ne cum
 				appellasset quidem Autronium, huius in mentem venire potuisse. <reg>sed</reg> tamen
-						quid<note><app><lem>quid</lem></app> quod <hi rend="italic">T</hi></note>
-					respondit<note>responderit <hi rend="italic">Tg</hi></note> de Sulla Cassius?
+						quid<note>
+                     <app>
+                        <lem>quid</lem>
+                     </app> quod <hi rend="italic">T</hi>
+                  </note>
+					respondit<note>responderit <hi rend="italic">Tg</hi>
+                  </note> de Sulla Cassius?
 					<reg>se</reg> nescire certum. '<reg>non</reg> purgat,' inquit. <reg>dixi</reg>
 				antea: ne si argueret quidem tum denique, cum esset interrogatus, id mihi<note>mihi
-						<hi rend="italic">om. e</hi></note> criminosum videretur. </p></div>
-			<div type="textpart" subtype="section" n="39"><p>
-				<reg>sed</reg> ego in iudiciis et in<note>et in <hi
-						rend="italic">Te</hi>: et <hi rend="italic">cett.</hi></note>
-					quaestionibus<note>in quaestionibus et indiciis <hi rend="italic"
-					>Schol.</hi></note> non hoc quaerendum arbitror, num purgetur
-					aliquis<note>aliqui <hi rend="italic">Schol.</hi></note>, sed<note>sed <foreign
-						xml:lang="grc">S</foreign>, <hi rend="italic">Schol.</hi>: et <hi
-						rend="italic">cett.</hi></note> num arguatur. <reg>etenim</reg> cum se
-					negat<note>se negat <hi rend="italic">Te<foreign xml:lang="grc"
-						>p</foreign></hi>: negat se <hi rend="italic">cett.</hi></note> scire
+						<hi rend="italic">om. e</hi>
+                  </note> criminosum videretur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="39">
+               <p>
+                  <reg>sed</reg> ego in iudiciis et in<note>et in <hi rend="italic">Te</hi>: et <hi rend="italic">cett.</hi>
+                  </note>
+					quaestionibus<note>in quaestionibus et indiciis <hi rend="italic">Schol.</hi>
+                  </note> non hoc quaerendum arbitror, num purgetur
+					aliquis<note>aliqui <hi rend="italic">Schol.</hi>
+                  </note>, sed<note>sed <foreign xml:lang="grc">ς</foreign>, <hi rend="italic">Schol.</hi>: et <hi rend="italic">cett.</hi>
+                  </note> num arguatur. <reg>etenim</reg> cum se
+					negat<note>se negat <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>: negat se <hi rend="italic">cett.</hi>
+                  </note> scire
 				Cassius, utrum sublevat Sullam an satis probat se nescire? '<reg>sublevat</reg> apud
-				Gallos.' <reg>quid</reg> ita? '<reg>ne</reg> indicent.' <reg>quid</reg><note>quod
-						<hi rend="italic">Te</hi></note>? si periculum esse putasset ne illi umquam
-				indicarent, de se<note>se <hi rend="italic">om. e</hi></note> ipse<note>ipse <hi
-						rend="italic">T, Ernesti</hi>: ipso <hi rend="italic">cett.</hi></note>
-				confessus esset? '<reg>nesciit</reg><note>nescit <hi rend="italic">T</hi> videlicet
-						<hi rend="italic">Ta<foreign xml:lang="grc">p</foreign></hi>: <hi
-						rend="italic">om. e</hi>: iudices <hi rend="italic">cett.</hi></note>
+				Gallos.' <reg>quid</reg> ita? '<reg>ne</reg> indicent.' <reg>quid</reg>
+                  <note>quod
+						<hi rend="italic">Te</hi>
+                  </note>? si periculum esse putasset ne illi umquam
+				indicarent, de se<note>se <hi rend="italic">om. e</hi>
+                  </note> ipse<note>ipse <hi rend="italic">T, Ernesti</hi>: ipso <hi rend="italic">cett.</hi>
+                  </note>
+				confessus esset? '<reg>nesciit</reg>
+                  <note>nescit <hi rend="italic">T</hi> videlicet
+						<hi rend="italic">Ta<foreign xml:lang="grc">π</foreign>
+                     </hi>: <hi rend="italic">om. e</hi>: iudices <hi rend="italic">cett.</hi>
+                  </note>
 				videlicet.' <reg>credo</reg> celatum esse Cassium de Sulla uno; nam de ceteris certe
-				sciebat; etenim<note>etenim <hi rend="italic">Tea<foreign xml:lang="grc"
-							>p</foreign></hi>: et ea <hi rend="italic">cett.</hi></note> domi eius
-				pleraque conflata esse constabat. <reg>qui</reg><note><app><lem>qui</lem></app> quia <hi
-						rend="italic">Madvig</hi></note> negare noluit esse in eo numero Sullam quo
-				plus spei Gallis daret, dicere autem falsum non ausus est, se<note>se <foreign
-						xml:lang="grc">p</foreign>: <hi rend="italic">om. cett.</hi> (<hi
-						rend="italic">post</hi> nescire <hi rend="italic">suppl.
-					Lambinus</hi>)</note> nescire dixit. <reg>atque</reg><note>atque <hi
-						rend="italic">Tea<foreign xml:lang="grc">p</foreign>b1</hi>: atqui <hi
-						rend="italic">cett.</hi></note> hoc perspicuum est, cum is qui de omnibus
-				scierit de Sulla se scire negarit, eandem vim esse<note>esse vim <hi rend="italic"
-						>ec</hi></note> negationis huius quam si<note>quam tum si <hi rend="italic"
-						>c2</hi></note> extra coniurationem hunc esse se scire dixisset.
+				sciebat; etenim<note>etenim <hi rend="italic">Tea<foreign xml:lang="grc">π</foreign>
+                     </hi>: et ea <hi rend="italic">cett.</hi>
+                  </note> domi eius
+				pleraque conflata esse constabat. <reg>qui</reg>
+                  <note>
+                     <app>
+                        <lem>qui</lem>
+                     </app> quia <hi rend="italic">Madvig</hi>
+                  </note> negare noluit esse in eo numero Sullam quo
+				plus spei Gallis daret, dicere autem falsum non ausus est, se<note>se <foreign xml:lang="grc">π</foreign>: <hi rend="italic">om. cett.</hi> (<hi rend="italic">post</hi> nescire <hi rend="italic">suppl.
+					Lambinus</hi>)</note> nescire dixit. <reg>atque</reg>
+                  <note>atque <hi rend="italic">Tea<foreign xml:lang="grc">π</foreign>b1</hi>: atqui <hi rend="italic">cett.</hi>
+                  </note> hoc perspicuum est, cum is qui de omnibus
+				scierit de Sulla se scire negarit, eandem vim esse<note>esse vim <hi rend="italic">ec</hi>
+                  </note> negationis huius quam si<note>quam tum si <hi rend="italic">c2</hi>
+                  </note> extra coniurationem hunc esse se scire dixisset.
 					<reg>nam</reg> cuius scientiam de omnibus constat fuisse, eius ignoratio de
 				aliquo purgatio debet videri. <reg>sed</reg> iam non quaero purgetne Cassius Sullam;
-				illud mihi tantum satis est contra Sullam nihil esse in indicio<note>indicio <hi
-						rend="italic">Te</hi>: iudicio <hi rend="italic">cett.</hi></note>.
-					</p></div><milestone n="14" unit="chapter"/>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="40"><p>
-			<reg>exclusus</reg> hac criminatione Torquatus rursus in me inruit, me accusat; ait
-				me aliter ac dictum sit<note>sit <hi rend="italic">Te, Schol.</hi>: est <hi
-						rend="italic">cett.</hi></note> in tabulas publicas rettulisse. O di
-				immortales!—vobis enim tribuo<note>tribuo <hi rend="italic">T</hi>: tribuam <hi
-						rend="italic">cett.</hi></note> quae vestra sunt, nec vero possum meo
-					tantum<note>tantum meo <hi rend="italic">e</hi></note> ingenio dare ut tot res
+				illud mihi tantum satis est contra Sullam nihil esse in indicio<note>indicio <hi rend="italic">Te</hi>: iudicio <hi rend="italic">cett.</hi>
+                  </note>.
+					</p>
+            </div>
+            <milestone n="14" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="40">
+               <p>
+                  <reg>exclusus</reg> hac criminatione Torquatus rursus in me inruit, me accusat; ait
+				me aliter ac dictum sit<note>sit <hi rend="italic">Te, Schol.</hi>: est <hi rend="italic">cett.</hi>
+                  </note> in tabulas publicas rettulisse. O di
+				immortales!—vobis enim tribuo<note>tribuo <hi rend="italic">T</hi>: tribuam <hi rend="italic">cett.</hi>
+                  </note> quae vestra sunt, nec vero possum meo
+					tantum<note>tantum meo <hi rend="italic">e</hi>
+                  </note> ingenio dare ut tot res
 				tantas, tam varias, tam repentinas in illa turbulentissima tempestate rei publicae
-				mea sponte dispexerim<note>dispex. <hi rend="italic">ea<foreign xml:lang="grc"
-							>S</foreign>b2k</hi>: despex. <hi rend="italic">cett.</hi></note>—vos
+				mea sponte dispexerim<note>dispex. <hi rend="italic">ea<foreign xml:lang="grc">ς</foreign>b2k</hi>: despex. <hi rend="italic">cett.</hi>
+                  </note>—vos
 				profecto animum meum tum conservandae patriae cupiditate incendistis, vos me ab
 				omnibus ceteris cogitationibus ad unam salutem rei publicae
-					convertistis<note>convertistis <hi rend="italic">Te</hi>: contulistis <hi
-						rend="italic">cett.</hi></note>, vos denique in tantis tenebris erroris et
-				inscientiae clarissimum lumen menti meae praetulistis<note>menti meae praetul. <hi
-						rend="italic">Te</hi>: praetul. menti meae <hi rend="italic"
-					>cett.</hi></note>. </p></div>
-			<div type="textpart" subtype="section" n="41"><p><reg>vidi</reg> ego hoc,
-						iudices<note><app><lem>iudices</lem></app> vidi <hi rend="italic">Ta</hi>: <hi
-						rend="italic">om. e</hi></note>, nisi recenti memoria senatus auctoritatem
+					convertistis<note>convertistis <hi rend="italic">Te</hi>: contulistis <hi rend="italic">cett.</hi>
+                  </note>, vos denique in tantis tenebris erroris et
+				inscientiae clarissimum lumen menti meae praetulistis<note>menti meae praetul. <hi rend="italic">Te</hi>: praetul. menti meae <hi rend="italic">cett.</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="41">
+               <p>
+                  <reg>vidi</reg> ego hoc,
+						iudices<note>
+                     <app>
+                        <lem>iudices</lem>
+                     </app> vidi <hi rend="italic">Ta</hi>: <hi rend="italic">om. e</hi>
+                  </note>, nisi recenti memoria senatus auctoritatem
 				huius indici monumentis publicis testatus essem, fore ut aliquando non Torquatus
 				neque Torquati quispiam similis—nam id me multum fefellit—sed ut aliquis
-					patrimoni<note>patrimonii <hi rend="italic">Te, Schol.</hi>: patrimonio <hi
-						rend="italic">cett.</hi></note> naufragus, inimicus oti, bonorum hostis,
-				aliter indicata<note>indic. <hi rend="italic">Ta</hi>: iudic. <hi rend="italic"
-						>cett.</hi></note> haec esse diceret, quo facilius vento aliquo in optimum
-				quemque excitato posset in malis rei publicae portum aliquem<note>aliquem <hi
-						rend="italic">hoc loco hab. Tec, post</hi> malorum <hi rend="italic"
-						>cett.</hi></note> suorum malorum invenire. <reg>itaque</reg> introductis in
-				senatum indicibus constitui<note>institui <hi rend="italic">Schol.</hi></note>
-				senatores qui omnia indicum dicta, interrogata, responsa perscriberent. </p></div>
-			<div type="textpart" subtype="section" n="42"><p>
-			    <reg>at</reg> quos viros! non solum summa virtute et
-				fide, cuius generis erat<note>erat <hi rend="italic">Te<foreign xml:lang="grc"
-							>p</foreign></hi>: <hi rend="italic">om. cett.</hi></note> in senatu
-				facultas maxima, sed etiam quos sciebam memoria, scientia<note>scientia <hi
-						rend="italic">e, Schol.</hi>: consuetudine et <hi rend="italic">add.
-						cett.</hi></note>, celeritate scribendi facillime quae dicerentur persequi
+					patrimoni<note>patrimonii <hi rend="italic">Te, Schol.</hi>: patrimonio <hi rend="italic">cett.</hi>
+                  </note> naufragus, inimicus oti, bonorum hostis,
+				aliter indicata<note>indic. <hi rend="italic">Ta</hi>: iudic. <hi rend="italic">cett.</hi>
+                  </note> haec esse diceret, quo facilius vento aliquo in optimum
+				quemque excitato posset in malis rei publicae portum aliquem<note>aliquem <hi rend="italic">hoc loco hab. Tec, post</hi> malorum <hi rend="italic">cett.</hi>
+                  </note> suorum malorum invenire. <reg>itaque</reg> introductis in
+				senatum indicibus constitui<note>institui <hi rend="italic">Schol.</hi>
+                  </note>
+				senatores qui omnia indicum dicta, interrogata, responsa perscriberent. </p>
+            </div>
+            <div type="textpart" subtype="section" n="42">
+               <p>
+                  <reg>at</reg> quos viros! non solum summa virtute et
+				fide, cuius generis erat<note>erat <hi rend="italic">Te<foreign xml:lang="grc">π</foreign>
+                     </hi>: <hi rend="italic">om. cett.</hi>
+                  </note> in senatu
+				facultas maxima, sed etiam quos sciebam memoria, scientia<note>scientia <hi rend="italic">e, Schol.</hi>: consuetudine et <hi rend="italic">add.
+						cett.</hi>
+                  </note>, celeritate scribendi facillime quae dicerentur persequi
 				posse, C. Cosconium, qui tum erat praetor, M. Messalam, qui tum praeturam petebat,
 				P. Nigidium, App. Claudium. <reg>credo</reg> esse neminem qui his
-					hominibus<note>hominibus <hi rend="italic">TEe<foreign xml:lang="grc"
-							>p</foreign></hi>: omnibus <hi rend="italic">cett.</hi> ad ...
-					referendum <hi rend="italic">TEe</hi>: aut ... referendis <hi rend="italic"
-						>cett.</hi></note> ad vere referendum aut fidem putet aut ingenium defuisse.
-					<milestone n="15" unit="chapter"/><reg>quid</reg> deinde? quid feci? Cum scirem
+					hominibus<note>hominibus <hi rend="italic">TEe<foreign xml:lang="grc">π</foreign>
+                     </hi>: omnibus <hi rend="italic">cett.</hi> ad ...
+					referendum <hi rend="italic">TEe</hi>: aut ... referendis <hi rend="italic">cett.</hi>
+                  </note> ad vere referendum aut fidem putet aut ingenium defuisse.
+					<milestone n="15" unit="chapter"/>
+                  <reg>quid</reg> deinde? quid feci? Cum scirem
 				ita esse<note>esse <hi rend="italic">Te</hi>: <hi rend="italic">om.
-					cett.</hi></note> indicium relatum<note>relatum <hi rend="italic">Tea<foreign
-							xml:lang="grc">p</foreign></hi>: <hi rend="italic">om.
-					cett.</hi></note> in tabulas publicas ut illae tabulae privata tamen custodia
+					cett.</hi>
+                  </note> indicium relatum<note>relatum <hi rend="italic">Tea<foreign xml:lang="grc">π</foreign>
+                     </hi>: <hi rend="italic">om.
+					cett.</hi>
+                  </note> in tabulas publicas ut illae tabulae privata tamen custodia
 				more maiorum continerentur, non occultavi, non continui domi, sed statim<note>statim
-						<hi rend="italic">hoc loco hab. Te, post</hi> describi <foreign
-						xml:lang="grc">ps</foreign>, <hi rend="italic">post</hi> omnibus <hi
-						rend="italic">cett.</hi></note> describi ab omnibus librariis, dividi
+						<hi rend="italic">hoc loco hab. Te, post</hi> describi <foreign xml:lang="grc">πς</foreign>, <hi rend="italic">post</hi> omnibus <hi rend="italic">cett.</hi>
+                  </note> describi ab omnibus librariis, dividi
 				passim et pervolgari atque edi populo Romano imperavi. <reg>divisi</reg>
-					tota<note>toti (-ae <hi rend="italic">e</hi>) Italiae <hi rend="italic"
-						>codd.</hi>: <hi rend="italic">corr. Madvig</hi></note> Italia,
-					emisi<note>emisi <hi rend="italic">E</hi>: dimisi <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign></hi>: divisi <hi rend="italic"
-					>cett.</hi></note> in omnis provincias; eius indici ex<note>ex (et <hi
-						rend="italic">e</hi>) <hi rend="italic">Te</hi>: e <hi rend="italic"
-						>cett.</hi></note> quo oblata salus<note>obl. salus <hi rend="italic"
-						>Te</hi>: salus obl. <hi rend="italic">cett.</hi></note> esset omnibus
-				expertem esse neminem volui. </p></div>
-			<div type="textpart" subtype="section" n="43"><p><reg>itaque</reg>
+					tota<note>toti (-ae <hi rend="italic">e</hi>) Italiae <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Madvig</hi>
+                  </note> Italia,
+					emisi<note>emisi <hi rend="italic">E</hi>: dimisi <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: divisi <hi rend="italic">cett.</hi>
+                  </note> in omnis provincias; eius indici ex<note>ex (et <hi rend="italic">e</hi>) <hi rend="italic">Te</hi>: e <hi rend="italic">cett.</hi>
+                  </note> quo oblata salus<note>obl. salus <hi rend="italic">Te</hi>: salus obl. <hi rend="italic">cett.</hi>
+                  </note> esset omnibus
+				expertem esse neminem volui. </p>
+            </div>
+            <div type="textpart" subtype="section" n="43">
+               <p>
+                  <reg>itaque</reg>
 				dico locum in orbe terrarum esse nullum, quo in loco populi Romani nomen sit, quin
-				eodem perscriptum hoc indicium pervenerit. <reg>in</reg> quo ego tam<note>tam <hi
-						rend="italic">g<foreign xml:lang="grc">s</foreign></hi>: tum <hi
-						rend="italic">cett.</hi></note> subito et exiguo et turbido tempore multa
-				divinitus, ita ut dixi, non mea sponte providi, primum ne quis<note>qui <hi
-						rend="italic">Reid</hi></note> posset tantum aut de rei publicae aut de
-				alicuius periculo meminisse<note><app><lem>meminisse</lem></app>
-					<hi rend="italic">hic desinit e</hi></note> quantum vellet; deinde ne cui
+				eodem perscriptum hoc indicium pervenerit. <reg>in</reg> quo ego tam<note>tam <hi rend="italic">g<foreign xml:lang="grc">ς</foreign>
+                     </hi>: tum <hi rend="italic">cett.</hi>
+                  </note> subito et exiguo et turbido tempore multa
+				divinitus, ita ut dixi, non mea sponte providi, primum ne quis<note>qui <hi rend="italic">Reid</hi>
+                  </note> posset tantum aut de rei publicae aut de
+				alicuius periculo meminisse<note>
+                     <app>
+                        <lem>meminisse</lem>
+                     </app>
+                     <hi rend="italic">hic desinit e</hi>
+                  </note> quantum vellet; deinde ne cui
 				liceret umquam reprehendere illud indicium aut temere creditum criminari; postremo
 				ne quid iam a me, ne quid ex meis commentariis quaereretur, ne aut oblivio mea aut
-				memoria nimia videretur<note>nimia vid. <hi rend="italic">T</hi>: vid. nimia <hi
-						rend="italic">cett.</hi></note>, ne denique aut neglegentia turpis aut
-				diligentia crudelis putaretur. </p></div>
-			<div type="textpart" subtype="section" n="44"><p><reg>sed</reg>
+				memoria nimia videretur<note>nimia vid. <hi rend="italic">T</hi>: vid. nimia <hi rend="italic">cett.</hi>
+                  </note>, ne denique aut neglegentia turpis aut
+				diligentia crudelis putaretur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="44">
+               <p>
+                  <reg>sed</reg>
 				tamen abs te, Torquate, quaero: cum indicatus tuus esset inimicus<note>esset inim.
-						<hi rend="italic">T</hi>: inim. esset <hi rend="italic">cett.</hi></note>
+						<hi rend="italic">T</hi>: inim. esset <hi rend="italic">cett.</hi>
+                  </note>
 				et esset eius rei frequens senatus et recens memoria testis, <add>et</add>
-					tibi<note>et tibi <hi rend="italic">Halm</hi>: tibi <hi rend="italic"
-						>codd.</hi>: tibique <hi rend="italic">Meerdervoort</hi></note>, meo
+					tibi<note>et tibi <hi rend="italic">Halm</hi>: tibi <hi rend="italic">codd.</hi>: tibique <hi rend="italic">Meerdervoort</hi>
+                  </note>, meo
 				familiari et contubernali, prius etiam edituri indicium fuerint scribae mei, si
-				voluisses, quam in codicem rettulissent, <add>cur</add> cum<note>cur cum <hi
-						rend="italic">Nohl</hi>: cum <hi rend="italic">codd.</hi></note> videres
-				aliter fieri<note>ferri <hi rend="italic">T</hi>: referri <hi rend="italic"
-						>Orelli</hi></note>, tacuisti<note>cur tacisti <foreign xml:lang="grc"
-						>S</foreign>
-					<hi rend="italic">mg., <foreign xml:lang="grc">p</foreign>b1c2k, ed.
-					V</hi></note>, passus es, non mecum aut <add>ut</add><note>ut <hi rend="italic"
-						>supplevi</hi></note> cum familiarissimo<note>familiarissimo <hi
-						rend="italic">scripsi</hi>: familiari meo <hi rend="italic">codd.</hi>:
-					familiari tuo <hi rend="italic">Richter</hi></note> questus es aut, quoniam tam
-				facile inveheris in amicos, iracundius et<note>et <foreign xml:lang="grc"
-						>p</foreign>: aut <hi rend="italic">cett.</hi></note> vehementius
+				voluisses, quam in codicem rettulissent, <add>cur</add> cum<note>cur cum <hi rend="italic">Nohl</hi>: cum <hi rend="italic">codd.</hi>
+                  </note> videres
+				aliter fieri<note>ferri <hi rend="italic">T</hi>: referri <hi rend="italic">Orelli</hi>
+                  </note>, tacuisti<note>cur tacisti <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italic">mg., <foreign xml:lang="grc">π</foreign>b1c2k, ed.
+					V</hi>
+                  </note>, passus es, non mecum aut <add>ut</add>
+                  <note>ut <hi rend="italic">supplevi</hi>
+                  </note> cum familiarissimo<note>familiarissimo <hi rend="italic">scripsi</hi>: familiari meo <hi rend="italic">codd.</hi>:
+					familiari tuo <hi rend="italic">Richter</hi>
+                  </note> questus es aut, quoniam tam
+				facile inveheris in amicos, iracundius et<note>et <foreign xml:lang="grc">π</foreign>: aut <hi rend="italic">cett.</hi>
+                  </note> vehementius
 				expostulasti? <reg>tu</reg>, cum tua vox numquam sit audita, cum indicio lecto,
 				descripto, divolgato quieveris, tacueris, repente tantam rem
-					ementiare<note>ementiare <hi rend="italic">T</hi>: enuntiare (audeas <hi
-						rend="italic">add. <foreign xml:lang="grc">S</foreign> mg., bc2k</hi>) <hi
-						rend="italic">cett.</hi></note> et in eum locum te deducas ut, ante quam me
+					ementiare<note>ementiare <hi rend="italic">T</hi>: enuntiare (audeas <hi rend="italic">add. <foreign xml:lang="grc">ς</foreign> mg., bc2k</hi>) <hi rend="italic">cett.</hi>
+                  </note> et in eum locum te deducas ut, ante quam me
 				commutati indici coargueris, te summae neglegentiae tuo iudicio<note>indicio
-						<foreign xml:lang="grc">s</foreign></note> convictum esse fateare?
-					</p></div><milestone n="16" unit="chapter"/>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="45"><p>
-			<reg>mihi</reg> cuiusquam salus tanti fuisset ut meam neglegerem? per me ego
+						<foreign xml:lang="grc">ς</foreign>
+                  </note> convictum esse fateare?
+					</p>
+            </div>
+            <milestone n="16" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="45">
+               <p>
+                  <reg>mihi</reg> cuiusquam salus tanti fuisset ut meam neglegerem? per me ego
 				veritatem patefactam contaminarem aliquo mendacio? quemquam denique ego iuvarem, a
-				quo et tam<note>et tam <hi rend="italic">Garatoni</hi>: etiam <hi rend="italic"
-						>Ta</hi>: et <hi rend="italic">cett.</hi></note> crudelis insidias rei
-					publicae<note>rei p. <hi rend="italic">T<foreign xml:lang="grc"
-						>p</foreign></hi>: in rem p. <hi rend="italic">cett.</hi> me ... consule
-						<hi rend="italic">Ta</hi>: me ... consulem <hi rend="italic"
-					>cett.</hi></note> factas et me potissimum consule constitutas<note>constitutas
-						<hi rend="italic">E</hi>: <hi rend="italic">om. cett.</hi></note> putarem?
+				quo et tam<note>et tam <hi rend="italic">Garatoni</hi>: etiam <hi rend="italic">Ta</hi>: et <hi rend="italic">cett.</hi>
+                  </note> crudelis insidias rei
+					publicae<note>rei p. <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: in rem p. <hi rend="italic">cett.</hi> me ... consule
+						<hi rend="italic">Ta</hi>: me ... consulem <hi rend="italic">cett.</hi>
+                  </note> factas et me potissimum consule constitutas<note>constitutas
+						<hi rend="italic">E</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> putarem?
 					<reg>quod</reg> si iam essem oblitus severitatis et constantiae meae, tamne
 				amens eram ut, cum litterae posteritatis causa repertae sint, quae subsidio
-				oblivioni esse possent<note>possint <foreign xml:lang="grc">ps</foreign></note>, ego
-				recentem putarem memoriam cuncti senatus commentario meo posse superari? </p></div>
-			<div type="textpart" subtype="section" n="46"><p>
-				<reg>fero</reg> ego te, Torquate, iam dudum fero<note>iam
+				oblivioni esse possent<note>possint <foreign xml:lang="grc">πς</foreign>
+                  </note>, ego
+				recentem putarem memoriam cuncti senatus commentario meo posse superari? </p>
+            </div>
+            <div type="textpart" subtype="section" n="46">
+               <p>
+                  <reg>fero</reg> ego te, Torquate, iam dudum fero<note>iam
 					dudum, fero <hi rend="italic">Naugerius</hi> (i)</note>, et non numquam animum
 				incitatum ad ulciscendam orationem tuam revoco ipse et reflecto, permitto aliquid
 				iracundiae tuae, do adulescentiae, cedo amicitiae, tribuo parenti. <reg>sed</reg>
-				nisi tibi aliquem modum tute<note>tute <hi rend="italic">TE<foreign xml:lang="grc"
-							>p</foreign></hi>: vitae <hi rend="italic">cett.</hi></note>
-				constitueris, coges oblitum me<note>me oblitum <hi rend="italic"><foreign
-							xml:lang="grc">p</foreign>k</hi>: oblitum <hi rend="italic">om.
-					T</hi></note> nostrae amicitiae habere rationem meae dignitatis. <reg>nemo</reg>
-				umquam me tenuissima suspicione perstrinxit<note>perstrinxerit <hi rend="italic"
-						>T</hi></note> quem non perverterim<note>praeverterim <hi rend="italic"
-						>E</hi>: perculerim <foreign xml:lang="grc">p</foreign></note> ac<note>ac
+				nisi tibi aliquem modum tute<note>tute <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: vitae <hi rend="italic">cett.</hi>
+                  </note>
+				constitueris, coges oblitum me<note>me oblitum <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>k</hi>: oblitum <hi rend="italic">om.
+					T</hi>
+                  </note> nostrae amicitiae habere rationem meae dignitatis. <reg>nemo</reg>
+				umquam me tenuissima suspicione perstrinxit<note>perstrinxerit <hi rend="italic">T</hi>
+                  </note> quem non perverterim<note>praeverterim <hi rend="italic">E</hi>: perculerim <foreign xml:lang="grc">π</foreign>
+                  </note> ac<note>ac
 					(aut <hi rend="italic">T</hi>: <hi rend="italic">fort.</hi> atque) perfregerim
-						<hi rend="italic">TE<foreign xml:lang="grc">p</foreign></hi>: <hi
-						rend="italic">om. cett.</hi></note> perfregerim. <reg>sed</reg> mihi hoc
+						<hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: <hi rend="italic">om. cett.</hi>
+                  </note> perfregerim. <reg>sed</reg> mihi hoc
 				credas velim: non eis libentissime soleo respondere quos mihi videor facillime posse
-				superare. </p></div>
-			<div type="textpart" subtype="section" n="47"><p><reg>tu</reg> quoniam minime ignoras
-				consuetudinem dicendi meam, noli hac nova lenitate<note>lenitate nova <hi
-						rend="italic">T</hi></note> abuti mea, noli aculeos orationis meae, qui
+				superare. </p>
+            </div>
+            <div type="textpart" subtype="section" n="47">
+               <p>
+                  <reg>tu</reg> quoniam minime ignoras
+				consuetudinem dicendi meam, noli hac nova lenitate<note>lenitate nova <hi rend="italic">T</hi>
+                  </note> abuti mea, noli aculeos orationis meae, qui
 				reconditi sunt, excussos arbitrari, noli id omnino a me putare<note>omnino a me put.
-						<hi rend="italic">T</hi>: put. omnino a me <hi rend="italic"
-					>cett.</hi></note> esse amissum<note>amissum <hi rend="italic">TEa<foreign
-							xml:lang="grc">p</foreign></hi>: omissum <hi rend="italic"
-					>cett.</hi></note> si quid est tibi remissum atque concessum. Cum illae valent
+						<hi rend="italic">T</hi>: put. omnino a me <hi rend="italic">cett.</hi>
+                  </note> esse amissum<note>amissum <hi rend="italic">TEa<foreign xml:lang="grc">π</foreign>
+                     </hi>: omissum <hi rend="italic">cett.</hi>
+                  </note> si quid est tibi remissum atque concessum. Cum illae valent
 				apud me excusationes iniuriae tuae, iratus animus tuus, aetas, amicitia nostra, tum
 				nondum statuo te virium satis habere ut ego tecum luctari et congredi debeam.
-					<reg>quod</reg> si esses usu<note>usu <hi rend="italic">om. T</hi></note> atque
+					<reg>quod</reg> si esses usu<note>usu <hi rend="italic">om. T</hi>
+                  </note> atque
 				aetate robustior, essem idem qui soleo cum sum lacessitus; nunc tecum sic agam
-				tulisse ut potius iniuriam quam rettulisse gratiam videar. <milestone n="17"
-					unit="chapter"/></p></div>
-			<div type="textpart" subtype="section" n="48"><p><reg>neque</reg> vero quid
+				tulisse ut potius iniuriam quam rettulisse gratiam videar. <milestone n="17" unit="chapter"/>
+               </p>
+            </div>
+            <div type="textpart" subtype="section" n="48">
+               <p>
+                  <reg>neque</reg> vero quid
 				mihi irascare intellegere possum. <reg>si</reg>, quod eum defendo quem tu accusas,
-				cur tibi ego<note>ego <hi rend="italic">T</hi>: quoque ipse <hi rend="italic"
-						>cett.</hi></note> non suscenseo, quod<note>quod <hi rend="italic"
-							>T<foreign xml:lang="grc">p</foreign></hi>: qui <hi rend="italic"
-						>cett.</hi></note> accusas<note>accusas <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign>abc</hi>: accuses <hi rend="italic"
-						>cett.</hi></note> eum quem ego defendo? '<reg>inimicum</reg>
-					ego<note>inimicum ego <hi rend="italic">T</hi>: inimicum <hi rend="italic"
-						>cett.</hi></note>,' inquis, 'accuso meum.' <reg>et</reg> amicum ego defendo
-				meum. '<reg>non</reg> debes tu<note>tu <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign></hi>: tamen <hi rend="italic">cett.</hi></note> quemquam
-					in<note>in <hi rend="italic">om. T<foreign xml:lang="grc">p</foreign>ac<foreign
-							xml:lang="grc">y</foreign></hi></note> coniurationis quaestione
+				cur tibi ego<note>ego <hi rend="italic">T</hi>: quoque ipse <hi rend="italic">cett.</hi>
+                  </note> non suscenseo, quod<note>quod <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: qui <hi rend="italic">cett.</hi>
+                  </note> accusas<note>accusas <hi rend="italic">T<foreign xml:lang="grc">π</foreign>abc</hi>: accuses <hi rend="italic">cett.</hi>
+                  </note> eum quem ego defendo? '<reg>inimicum</reg>
+					ego<note>inimicum ego <hi rend="italic">T</hi>: inimicum <hi rend="italic">cett.</hi>
+                  </note>,' inquis, 'accuso meum.' <reg>et</reg> amicum ego defendo
+				meum. '<reg>non</reg> debes tu<note>tu <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: tamen <hi rend="italic">cett.</hi>
+                  </note> quemquam
+					in<note>in <hi rend="italic">om. T<foreign xml:lang="grc">π</foreign>ac<foreign xml:lang="grc">ψ</foreign>
+                     </hi>
+                  </note> coniurationis quaestione
 				defendere.' <reg>immo</reg> nemo magis eum de quo nihil umquam est<note>umquam est
-						<hi rend="italic">T</hi>: est umquam <hi rend="italic">E</hi>: est <hi
-						rend="italic">cett.</hi></note> suspicatus quam is qui de aliis multa
-					cognovit<note>cognovit <hi rend="italic">ac1, Lambinus</hi>: cogitavit <hi
-						rend="italic">cett.</hi></note>. '<reg>cur</reg> dixisti testimonium in
-				alios?' <reg>quia</reg> coactus sum<note>sum <foreign xml:lang="grc"
-					>p</foreign></note>. '<reg>cur</reg> damnati sunt?' <reg>quia</reg> creditum
-				est. '<reg>regnum</reg> est dicere in quem velis et<note>et <hi rend="italic"
-						>Tg</hi>: ac <hi rend="italic">cett.</hi></note> defendere quem velis.'
+						<hi rend="italic">T</hi>: est umquam <hi rend="italic">E</hi>: est <hi rend="italic">cett.</hi>
+                  </note> suspicatus quam is qui de aliis multa
+					cognovit<note>cognovit <hi rend="italic">ac1, Lambinus</hi>: cogitavit <hi rend="italic">cett.</hi>
+                  </note>. '<reg>cur</reg> dixisti testimonium in
+				alios?' <reg>quia</reg> coactus sum<note>sum <foreign xml:lang="grc">π</foreign>
+                  </note>. '<reg>cur</reg> damnati sunt?' <reg>quia</reg> creditum
+				est. '<reg>regnum</reg> est dicere in quem velis et<note>et <hi rend="italic">Tg</hi>: ac <hi rend="italic">cett.</hi>
+                  </note> defendere quem velis.'
 					<reg>immo</reg> servitus est non dicere in quem velis et non<note>et non
-						<foreign xml:lang="grc">p</foreign>: nec <hi rend="italic">k</hi>: et <hi
-						rend="italic">cett.</hi></note> defendere quem velis. <reg>ac</reg> si
+						<foreign xml:lang="grc">π</foreign>: nec <hi rend="italic">k</hi>: et <hi rend="italic">cett.</hi>
+                  </note> defendere quem velis. <reg>ac</reg> si
 				considerare coeperis utrum magis mihi hoc necesse fuerit facere an istud<note>istud
-						<hi rend="italic">TE<foreign xml:lang="grc">p</foreign></hi>: <hi
-						rend="italic">om. cett.</hi></note> tibi, intelleges honestius te
-				inimicitiarum modum statuere potuisse quam me humanitatis. </p></div>
-			<div type="textpart" subtype="section" n="49"><p>
-				<reg>at</reg><note>at <hi rend="italic">Lambinus</hi>: aut <hi
-						rend="italic">T</hi>: an <hi rend="italic">cett.</hi></note> vero, cum
+						<hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: <hi rend="italic">om. cett.</hi>
+                  </note> tibi, intelleges honestius te
+				inimicitiarum modum statuere potuisse quam me humanitatis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="49">
+               <p>
+                  <reg>at</reg>
+                  <note>at <hi rend="italic">Lambinus</hi>: aut <hi rend="italic">T</hi>: an <hi rend="italic">cett.</hi>
+                  </note> vero, cum
 				honos agebatur familiae vestrae amplissimus<note>amplissimus <hi rend="italic">hoc
-						loco hab. T, ante</hi> fam. <hi rend="italic">cett.</hi></note>, hoc est
-				consulatus parentis tui, sapientissimus vir familiarissimis suis non<note>non <hi
-						rend="italic">om. cod. H. Stephani</hi></note> suscensuit, pater
-					tuus<note>pater tuus <hi rend="italic">del. Rinkes</hi></note>, cum Sullam et
-				defenderent et laudarent? intellegebat hanc<note><app><lem>hanc</lem></app> enim <foreign
-						xml:lang="grc">p</foreign></note> nobis a maioribus esse traditam
-				disciplinam ut nullius amicitia ad pericula propulsanda<note>pericula propuls. <hi
-						rend="italic">T</hi>: propuls. pericula <hi rend="italic"
-					>cett.</hi></note> impediremur. <reg>at</reg> erat<note>at erat <hi
-						rend="italic">Halm</hi>: aderat <hi rend="italic">Ta</hi>: et (<hi
-						rend="italic">om.</hi> et <foreign xml:lang="grc">p</foreign>) erat <hi
-						rend="italic">cett.</hi></note> huic iudicio longe dissimilis illa
+						loco hab. T, ante</hi> fam. <hi rend="italic">cett.</hi>
+                  </note>, hoc est
+				consulatus parentis tui, sapientissimus vir familiarissimis suis non<note>non <hi rend="italic">om. cod. H. Stephani</hi>
+                  </note> suscensuit, pater
+					tuus<note>pater tuus <hi rend="italic">del. Rinkes</hi>
+                  </note>, cum Sullam et
+				defenderent et laudarent? intellegebat hanc<note>
+                     <app>
+                        <lem>hanc</lem>
+                     </app> enim <foreign xml:lang="grc">π</foreign>
+                  </note> nobis a maioribus esse traditam
+				disciplinam ut nullius amicitia ad pericula propulsanda<note>pericula propuls. <hi rend="italic">T</hi>: propuls. pericula <hi rend="italic">cett.</hi>
+                  </note> impediremur. <reg>at</reg> erat<note>at erat <hi rend="italic">Halm</hi>: aderat <hi rend="italic">Ta</hi>: et (<hi rend="italic">om.</hi> et <foreign xml:lang="grc">π</foreign>) erat <hi rend="italic">cett.</hi>
+                  </note> huic iudicio longe dissimilis illa
 				contentio. <reg>tum</reg> adflicto P. Sulla consulatus vobis pariebatur, sicuti
 				partus est; honoris erat certamen; ereptum repetere vos clamitabatis, ut victi in
 				campo in foro vinceretis; tum qui contra vos pro huius salute pugnabant, amicissimi
 				vestri, quibus non irascebamini<note>quibus non irascebamini <hi rend="italic">del.
-						Campe</hi></note>, consulatum vobis eripiebant, honori vestro repugnabant,
+						Campe</hi>
+                  </note>, consulatum vobis eripiebant, honori vestro repugnabant,
 				et tamen id inviolata vestra amicitia, integro officio, vetere<note>vetere
-					(-rẽ <hi rend="italic">a</hi>) <hi rend="italic">Ta</hi>: veteri <hi
-						rend="italic">cett.</hi></note> exemplo atque instituto optimi cuiusque
-				faciebant. </p></div><milestone n="18" unit="chapter"/>
-			<div type="textpart" subtype="section" n="50"><p>
-				<reg>ego</reg> vero quibus ornamentis adversor tuis aut cui dignitati vestrae
-				repugno? <reg>quid</reg> est quod iam ab hoc expetas? <reg>honos</reg><note>honos
-						<hi rend="italic">T</hi>: honor <hi rend="italic">cett.</hi></note> ad
+					(-rẽ <hi rend="italic">a</hi>) <hi rend="italic">Ta</hi>: veteri <hi rend="italic">cett.</hi>
+                  </note> exemplo atque instituto optimi cuiusque
+				faciebant. </p>
+            </div>
+            <milestone n="18" unit="chapter"/>
+            <div type="textpart" subtype="section" n="50">
+               <p>
+                  <reg>ego</reg> vero quibus ornamentis adversor tuis aut cui dignitati vestrae
+				repugno? <reg>quid</reg> est quod iam ab hoc expetas? <reg>honos</reg>
+                  <note>honos
+						<hi rend="italic">T</hi>: honor <hi rend="italic">cett.</hi>
+                  </note> ad
 				patrem, insignia honoris ad te delata sunt. <reg>tu</reg> ornatus<note>ornatus huius
-						<hi rend="italic">c2k</hi></note> exuviis<note>exuviis <hi rend="italic"
-						>TE</hi>: eximiis <foreign xml:lang="grc">p</foreign>: et uiuus <hi
-						rend="italic">a</hi>: eripuis <hi rend="italic">p</hi>: erumnis <hi
-						rend="italic">cett.</hi></note> huius<note>huius <hi rend="italic">E</hi>:
-						<hi rend="italic">om. cett.</hi></note> venis ad eum lacerandum quem
+						<hi rend="italic">c2k</hi>
+                  </note> exuviis<note>exuviis <hi rend="italic">TE</hi>: eximiis <foreign xml:lang="grc">π</foreign>: et uiuus <hi rend="italic">a</hi>: eripuis <hi rend="italic">p</hi>: erumnis <hi rend="italic">cett.</hi>
+                  </note> huius<note>huius <hi rend="italic">E</hi>:
+						<hi rend="italic">om. cett.</hi>
+                  </note> venis ad eum lacerandum quem
 				interemisti, ego iacentem et spoliatum defendo et protego. <reg>atque</reg> hic tu
 				et reprehendis me quia defendam et irasceris; ego autem non modo tibi non irascor
-				sed ne<note>ne <hi rend="italic">T</hi>: neque <hi rend="italic">cett.</hi></note>
+				sed ne<note>ne <hi rend="italic">T</hi>: neque <hi rend="italic">cett.</hi>
+                  </note>
 				reprehendo quidem factum tuum. <reg>te</reg> enim existimo tibi statuisse quid
 				faciendum putares et satis idoneum offici tui<note>tui <hi rend="italic">TE</hi>:
-						<hi rend="italic">om. cett.</hi></note> iudicem <add>esse</add><note>esse
-						<hi rend="italic">suppl. Halm</hi></note> potuisse<note>potuisse <hi
-						rend="italic">T</hi>: posuisse <hi rend="italic">cett.</hi></note>.
-					</p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="51"><p>
-			<reg>at</reg> accusat <add>C.</add><note>C. <hi rend="italic">suppl. ed.
-					V</hi></note> Corneli filius et id aeque<note>et id aeque <hi rend="italic"
-							>T<foreign xml:lang="grc">p</foreign></hi>: et idemque <hi
-						rend="italic">a</hi>: idemque <hi rend="italic">cett.</hi></note> valere
+						<hi rend="italic">om. cett.</hi>
+                  </note> iudicem <add>esse</add>
+                  <note>esse
+						<hi rend="italic">suppl. Halm</hi>
+                  </note> potuisse<note>potuisse <hi rend="italic">T</hi>: posuisse <hi rend="italic">cett.</hi>
+                  </note>.
+					</p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="51">
+               <p>
+                  <reg>at</reg> accusat <add>C.</add>
+                  <note>C. <hi rend="italic">suppl. ed.
+					V</hi>
+                  </note> Corneli filius et id aeque<note>et id aeque <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: et idemque <hi rend="italic">a</hi>: idemque <hi rend="italic">cett.</hi>
+                  </note> valere
 				debet ac si pater indicaret. O patrem Cornelium sapientem qui, quod praemi solet
-				esse in indicio<note>indicio <hi rend="italic">Tc</hi>: iudicio <hi rend="italic"
-						>cett.</hi></note>, reliquerit, quod turpitudinis in confessione, id per
+				esse in indicio<note>indicio <hi rend="italic">Tc</hi>: iudicio <hi rend="italic">cett.</hi>
+                  </note>, reliquerit, quod turpitudinis in confessione, id per
 				accusationem fili susceperit! <reg>sed</reg> quid est tandem quod
-					indicat<note>indicet <hi rend="italic">Ta<foreign xml:lang="grc"
-						>p</foreign></hi></note> per istum puerum Cornelius? <reg>si</reg>
-					vetera<note>si vertera <hi rend="italic">T</hi>: suescã <hi rend="italic"
-						>a</hi>: sin ea <foreign xml:lang="grc">p</foreign>: si est causa <hi
-						rend="italic">cett.</hi></note>, mihi ignota, cum Hortensio communicata,
-					respondit<note>respondit <hi rend="italic">T</hi>: respondet (-eat <foreign
-						xml:lang="grc">p</foreign>) <hi rend="italic">cett.</hi></note> Hortensius;
-				sin, ut ais, illum conatum<note>conatum <hi rend="italic">T</hi>: comitatum <hi
-						rend="italic">cett.</hi></note> Autroni et Catilinae, cum in campo
+					indicat<note>indicet <hi rend="italic">Ta<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note> per istum puerum Cornelius? <reg>si</reg>
+					vetera<note>si vertera <hi rend="italic">T</hi>: suescã <hi rend="italic">a</hi>: sin ea <foreign xml:lang="grc">π</foreign>: si est causa <hi rend="italic">cett.</hi>
+                  </note>, mihi ignota, cum Hortensio communicata,
+					respondit<note>respondit <hi rend="italic">T</hi>: respondet (-eat <foreign xml:lang="grc">π</foreign>) <hi rend="italic">cett.</hi>
+                  </note> Hortensius;
+				sin, ut ais, illum conatum<note>conatum <hi rend="italic">T</hi>: comitatum <hi rend="italic">cett.</hi>
+                  </note> Autroni et Catilinae, cum in campo
 				consularibus comitiis, quae a me habita sunt, caedem facere voluerunt, Autronium tum
-				in campo vidimus —sed<note>sed <hi rend="italic">Madvig</hi>: et <hi rend="italic"
-						>codd.</hi></note> quid dixi vidisse nos? ego vidi; vos enim tum, iudices,
+				in campo vidimus —sed<note>sed <hi rend="italic">Madvig</hi>: et <hi rend="italic">codd.</hi>
+                  </note> quid dixi vidisse nos? ego vidi; vos enim tum, iudices,
 				nihil laborabatis neque suspicabamini, ego tectus praesidio firmo amicorum Catilinae
-				tum et<note>tum et <hi rend="italic">a<foreign xml:lang="grc">p</foreign></hi>: tum
-						<hi rend="italic">T</hi>: tunc et <hi rend="italic">cett.</hi></note>
-				Autroni copias et conatum repressi. </p></div>
-			<div type="textpart" subtype="section" n="52"><p><reg>num</reg>
+				tum et<note>tum et <hi rend="italic">a<foreign xml:lang="grc">π</foreign>
+                     </hi>: tum
+						<hi rend="italic">T</hi>: tunc et <hi rend="italic">cett.</hi>
+                  </note>
+				Autroni copias et conatum repressi. </p>
+            </div>
+            <div type="textpart" subtype="section" n="52">
+               <p>
+                  <reg>num</reg>
 				quis est igitur qui tum dicat in campum aspirasse Sullam? <reg>atqui</reg>, si tum
-				se cum<note>secum <hi rend="italic">Ta<foreign xml:lang="grc">p</foreign></hi>
-					Catilinam <hi rend="italic">T</hi></note> Catilina societate sceleris
+				se cum<note>secum <hi rend="italic">Ta<foreign xml:lang="grc">π</foreign>
+                     </hi>
+					Catilinam <hi rend="italic">T</hi>
+                  </note> Catilina societate sceleris
 				coniunxerat, cur ab eo discedebat, cur cum Autronio non erat, cur
-						in<note><app><lem>in</lem></app> ire <hi rend="italic">T</hi> (<hi rend="italic"
-						>fort.</hi> in re pari <hi rend="italic">sine</hi> causa)</note> pari causa
+						in<note>
+                     <app>
+                        <lem>in</lem>
+                     </app> ire <hi rend="italic">T</hi> (<hi rend="italic">fort.</hi> in re pari <hi rend="italic">sine</hi> causa)</note> pari causa
 				non paria signa criminis reperiuntur? <reg>sed</reg> quoniam Cornelius ipse etiam
-				nunc de indicando dubitat, <add>et<note>et <foreign xml:lang="grc">p</foreign>, <hi
-							rend="italic">Reid</hi>: <hi rend="italic">om.
-					cett.</hi></note>,</add> ut dicitis, informat ad hoc<note>adhuc <hi
-						rend="italic">Ernesti</hi></note> adumbratum indicium filium<note>filium
-						<hi rend="italic">T</hi>: filii <hi rend="italic">cett.</hi></note>, quid
-				tandem de illa nocte dicit, cum inter falcarios ad M. Laecam<note>Laecam <hi
-						rend="italic">T</hi>: Leccam <hi rend="italic">cett.</hi></note> nocte ea
-				quae consecuta est posterum diem Nonarum Novembrium<note>Nonas Novembris <hi
-						rend="italic">bc</hi></note> me consule Catilinae denuntiatione convenit?
+				nunc de indicando dubitat, <add>et<note>et <foreign xml:lang="grc">π</foreign>, <hi rend="italic">Reid</hi>: <hi rend="italic">om.
+					cett.</hi>
+                     </note>,</add> ut dicitis, informat ad hoc<note>adhuc <hi rend="italic">Ernesti</hi>
+                  </note> adumbratum indicium filium<note>filium
+						<hi rend="italic">T</hi>: filii <hi rend="italic">cett.</hi>
+                  </note>, quid
+				tandem de illa nocte dicit, cum inter falcarios ad M. Laecam<note>Laecam <hi rend="italic">T</hi>: Leccam <hi rend="italic">cett.</hi>
+                  </note> nocte ea
+				quae consecuta est posterum diem Nonarum Novembrium<note>Nonas Novembris <hi rend="italic">bc</hi>
+                  </note> me consule Catilinae denuntiatione convenit?
 				quae nox omnium temporum coniurationis acerrima fuit atque acerbissima.
 					<reg>tum</reg> Catilinae dies exeundi, tum ceteris manendi condicio, tum
-					discriptio<note>discr. <hi rend="italic">Bücheler</hi>: descr. <hi
-						rend="italic">codd.</hi></note> totam per urbem caedis atque incendiorum
-				constituta est; tum<note>tum <hi rend="italic">T<foreign xml:lang="grc"
-						>p</foreign>ab</hi>: tunc <hi rend="italic">cett.</hi></note> tuus pater,
+					discriptio<note>discr. <hi rend="italic">Bücheler</hi>: descr. <hi rend="italic">codd.</hi>
+                  </note> totam per urbem caedis atque incendiorum
+				constituta est; tum<note>tum <hi rend="italic">T<foreign xml:lang="grc">π</foreign>ab</hi>: tunc <hi rend="italic">cett.</hi>
+                  </note> tuus pater,
 				Corneli, id quod tandem aliquando confitetur, illam sibi officiosam provinciam
 				depoposcit ut, cum prima luce consulem salutatum veniret, intromissus et
-						meo<note><app><lem>et meo</lem></app> meo <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign></hi></note> more et iure amicitiae me in meo
-					lectulo<note>lectulo <hi rend="italic">T<foreign xml:lang="grc"
-						>p</foreign></hi>: lecto <hi rend="italic">cett.</hi></note> trucidaret.
-					</p></div><milestone n="19" unit="chapter"/>
-			<div type="textpart" subtype="section" n="53"><p>
-				<reg>hoc</reg> tempore, cum arderet acerrime coniuratio, cum Catilina
+						meo<note>
+                     <app>
+                        <lem>et meo</lem>
+                     </app> meo <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note> more et iure amicitiae me in meo
+					lectulo<note>lectulo <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: lecto <hi rend="italic">cett.</hi>
+                  </note> trucidaret.
+					</p>
+            </div>
+            <milestone n="19" unit="chapter"/>
+            <div type="textpart" subtype="section" n="53">
+               <p>
+                  <reg>hoc</reg> tempore, cum arderet acerrime coniuratio, cum Catilina
 				egrederetur ad exercitum, Lentulus in urbe relinqueretur, Cassius incendiis,
 				Cethegus caedi praeponeretur, Autronio ut occuparet Etruriam praescriberetur, cum
-				omnia ornarentur<note>ornarentur <hi rend="italic">Landgraf</hi>: ordinarentur <hi
-						rend="italic">codd.</hi> (<hi rend="italic">cf.</hi> § 75)</note>,
-					instruerentur<note>instruerentur <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign></hi>: instituerentur <hi rend="italic">cett.</hi></note>,
+				omnia ornarentur<note>ornarentur <hi rend="italic">Landgraf</hi>: ordinarentur <hi rend="italic">codd.</hi> (<hi rend="italic">cf.</hi> § 75)</note>,
+					instruerentur<note>instruerentur <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: instituerentur <hi rend="italic">cett.</hi>
+                  </note>,
 				pararentur, ubi fuit Sulla, Corneli? num Romae? <reg>immo</reg> longe
-					afuit<note>affuit <hi rend="italic">Ta</hi>: abfuit <hi rend="italic"
-						>cett.</hi>: <hi rend="italic">corr. Halm</hi></note>. <reg>num</reg>
-					in<note>in <hi rend="italic">om. T</hi></note> eis<note>iis <hi rend="italic"
-						>Tk</hi>: his <hi rend="italic">cett.</hi></note>
-					regionibus<note>regionibus <hi rend="italic">Tc1</hi>: legionibus <hi
-						rend="italic">cett.</hi></note> quo se Catilina inferebat<note>referebat
-						<hi rend="italic">c2</hi></note>? <reg>multo</reg> etiam longius.
-					<reg>num</reg> in agro Camerti, Piceno, Gallico, quas in<note>in <hi
-						rend="italic">Ta</hi>: <hi rend="italic">om. cett.</hi></note> oras maxime
+					afuit<note>affuit <hi rend="italic">Ta</hi>: abfuit <hi rend="italic">cett.</hi>: <hi rend="italic">corr. Halm</hi>
+                  </note>. <reg>num</reg>
+					in<note>in <hi rend="italic">om. T</hi>
+                  </note> eis<note>iis <hi rend="italic">Tk</hi>: his <hi rend="italic">cett.</hi>
+                  </note>
+					regionibus<note>regionibus <hi rend="italic">Tc1</hi>: legionibus <hi rend="italic">cett.</hi>
+                  </note> quo se Catilina inferebat<note>referebat
+						<hi rend="italic">c2</hi>
+                  </note>? <reg>multo</reg> etiam longius.
+					<reg>num</reg> in agro Camerti, Piceno, Gallico, quas in<note>in <hi rend="italic">Ta</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> oras maxime
 				quasi morbus quidam illius furoris pervaserat? <reg>nihil</reg> vero minus.
 					<reg>fuit</reg> enim, ut iam ante dixi, Neapoli, fuit in ea parte Italiae quae
-				maxime ista<note>ista <hi rend="italic">T</hi>: ea <hi rend="italic"
-					>cett.</hi></note> suspicione caruit. </p></div>
-			<div type="textpart" subtype="section" n="54"><p>
-				<reg>quid</reg> ergo indicat aut quid adfert aut ipse Cornelius aut vos qui
-				haec ab illo<note>haec ab illo <hi rend="italic">T</hi>: ab eo haec (<hi
-						rend="italic">om.</hi> haec <hi rend="italic">a</hi>) <hi rend="italic"
-						>cett.</hi></note> mandata defertis? <reg>gladiatores</reg> emptos esse
+				maxime ista<note>ista <hi rend="italic">T</hi>: ea <hi rend="italic">cett.</hi>
+                  </note> suspicione caruit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="54">
+               <p>
+                  <reg>quid</reg> ergo indicat aut quid adfert aut ipse Cornelius aut vos qui
+				haec ab illo<note>haec ab illo <hi rend="italic">T</hi>: ab eo haec (<hi rend="italic">om.</hi> haec <hi rend="italic">a</hi>) <hi rend="italic">cett.</hi>
+                  </note> mandata defertis? <reg>gladiatores</reg> emptos esse
 				Fausti simulatione ad caedem ac tumultum? '<reg>ita</reg> prorsus; interpositi sunt
 				gladiatores.' <reg>quos</reg> testamento patris deberi videmus<note>deberi videmus
-						<hi rend="italic">T<foreign xml:lang="grc">p</foreign>apk</hi>: deberi
-					debemus <hi rend="italic"><foreign xml:lang="grc">S</foreign>g</hi>: videmus
-					deberi <hi rend="italic">bc</hi></note>. '<reg>adrepta</reg> est familia.'
+						<hi rend="italic">T<foreign xml:lang="grc">π</foreign>apk</hi>: deberi
+					debemus <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>g</hi>: videmus
+					deberi <hi rend="italic">bc</hi>
+                  </note>. '<reg>adrepta</reg> est familia.'
 					<reg>quae</reg> si esset praetermissa, posset alia familia Fausti munus
-						praebere<note><hi rend="italic">interpunxit Richter</hi></note>. Vtinam
-				quidem haec ipsa non modo iniquorum invidiae<note>invidiae esset <hi rend="italic"
-						>codd.</hi>: <hi rend="italic">corr. Lambinus</hi></note> sed aequorum
-				exspectationi satis facere posset! '<reg>properatum</reg><note>properatum (-rat <hi
-						rend="italic">b2</hi>) <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign>b2</hi>: praeparant <hi rend="italic">cett.</hi></note>
+						praebere<note>
+                     <hi rend="italic">interpunxit Richter</hi>
+                  </note>. Vtinam
+				quidem haec ipsa non modo iniquorum invidiae<note>invidiae esset <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Lambinus</hi>
+                  </note> sed aequorum
+				exspectationi satis facere posset! '<reg>properatum</reg>
+                  <note>properatum (-rat <hi rend="italic">b2</hi>) <hi rend="italic">T<foreign xml:lang="grc">π</foreign>b2</hi>: praeparant <hi rend="italic">cett.</hi>
+                  </note>
 				vehementer est<note>est <hi rend="italic">T</hi>: <hi rend="italic">om.
-					cett.</hi></note>, cum longe tempus muneris abesset.' <reg>quasi</reg> vero
+					cett.</hi>
+                  </note>, cum longe tempus muneris abesset.' <reg>quasi</reg> vero
 				tempus dandi muneris non valde appropinquaret. '<reg>nec</reg> opinante Fausto, cum
-				is neque sciret neque vellet, familia est comparata.'</p></div>
-			<div type="textpart" subtype="section" n="55"><p><reg>at</reg> litterae sunt Fausti,per quas ille precibus a P. Sulla petit ut
+				is neque sciret neque vellet, familia est comparata.'</p>
+            </div>
+            <div type="textpart" subtype="section" n="55">
+               <p>
+                  <reg>at</reg> litterae sunt Fausti,per quas ille precibus a P. Sulla petit ut
 				emat gladiatores et ut hos ipsos emat, neque solum ad Sullam missae sed ad L.
 				Caesarem, Q. Pompeium, C. Memmium, quorum de sententia tota res gesta est.
-					'<reg>at</reg> praefuit familiae Cornelius<note>Cornelius <hi rend="italic"
-						>del. Manutius</hi></note>, <add>libertus eius</add><note>libertus eius (<hi
-						rend="italic">i. e.</hi> L. eius) <hi rend="italic">supplevi</hi>: <hi
-						rend="italic">notam</hi> L (=libertus) <hi rend="italic">excidisse vidit
-						Orelli, qui</hi> P. L. (<hi rend="italic">i. e.</hi> Publi libertus) <hi
-						rend="italic">coni.</hi></note>.' <reg>iam</reg> si in paranda familia
-				nulla suspicio est, quis<note>quis <hi rend="italic">Ta</hi>: quod <hi
-						rend="italic">cett.</hi></note> praefuerit<note>praefuerit <hi
-						rend="italic">T</hi>: praefuit <hi rend="italic">b2<foreign xml:lang="grc"
-							>y1s</foreign></hi>: profert <hi rend="italic">cett.</hi></note> nihil
-				ad rem pertinet; sed<note><app><lem>sed</lem></app>
-					<hi rend="italic">fort.</hi> is</note> tamen munere servili<note>Servili <hi
-						rend="italic">Lag.</hi> 9, <hi rend="italic">Madvig</hi> (<hi
-						rend="italic">melius esset</hi> Servi, <hi rend="italic">i. e.</hi> Serv.
+					'<reg>at</reg> praefuit familiae Cornelius<note>Cornelius <hi rend="italic">del. Manutius</hi>
+                  </note>, <add>libertus eius</add>
+                  <note>libertus eius (<hi rend="italic">i. e.</hi> L. eius) <hi rend="italic">supplevi</hi>: <hi rend="italic">notam</hi> L (=libertus) <hi rend="italic">excidisse vidit
+						Orelli, qui</hi> P. L. (<hi rend="italic">i. e.</hi> Publi libertus) <hi rend="italic">coni.</hi>
+                  </note>.' <reg>iam</reg> si in paranda familia
+				nulla suspicio est, quis<note>quis <hi rend="italic">Ta</hi>: quod <hi rend="italic">cett.</hi>
+                  </note> praefuerit<note>praefuerit <hi rend="italic">T</hi>: praefuit <hi rend="italic">b2<foreign xml:lang="grc">ψ1ς</foreign>
+                     </hi>: profert <hi rend="italic">cett.</hi>
+                  </note> nihil
+				ad rem pertinet; sed<note>
+                     <app>
+                        <lem>sed</lem>
+                     </app>
+                     <hi rend="italic">fort.</hi> is</note> tamen munere servili<note>Servili <hi rend="italic">Lag.</hi> 9, <hi rend="italic">Madvig</hi> (<hi rend="italic">melius esset</hi> Servi, <hi rend="italic">i. e.</hi> Serv.
 					Sullae, <hi rend="italic">cf.</hi> § 6)</note> obtulit se ad ferramenta
-				prospicienda, praefuit vero numquam, eaque res omni tempore<note>omni tempore <hi
-						rend="italic">hoc loco hab. T. post</hi> libert. <hi rend="italic"
-						>cett.</hi></note> per <reg>bellum</reg><note>Balbum <hi rend="italic"
-						>E</hi></note>, Fausti libertum, administrata est. <milestone n="20"
-					unit="chapter"/></p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="56"><p>
-			<reg>at</reg> enim Sittius<note>Sittius (Sicc. Sic.) <hi rend="italic">TE<foreign
-							xml:lang="grc">p</foreign>ab1</hi>: Cincius <hi rend="italic"
-						>cett.</hi> (<hi rend="italic">ubique</hi>)</note> est ab hoc in ulteriorem
+				prospicienda, praefuit vero numquam, eaque res omni tempore<note>omni tempore <hi rend="italic">hoc loco hab. T. post</hi> libert. <hi rend="italic">cett.</hi>
+                  </note> per <reg>bellum</reg>
+                  <note>Balbum <hi rend="italic">E</hi>
+                  </note>, Fausti libertum, administrata est. <milestone n="20" unit="chapter"/>
+               </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="56">
+               <p>
+                  <reg>at</reg> enim Sittius<note>Sittius (Sicc. Sic.) <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>ab1</hi>: Cincius <hi rend="italic">cett.</hi> (<hi rend="italic">ubique</hi>)</note> est ab hoc in ulteriorem
 				Hispaniam missus ut eam provinciam perturbaret. <reg>primum</reg> Sittius, iudices,
 				L. Iulio C. Figulo consulibus profectus est aliquanto ante furorem Catilinae et
 				suspicionem huius coniurationis; deinde est profectus non tum primum sed cum in
 				isdem locis aliquanto ante eadem de causa aliquot annos fuisset, ac profectus est
-				non modo ob causam sed etiam ob<note>etiam ob<hi rend="italic">Tb2k</hi>: etiam <hi
-						rend="italic">cett.</hi></note> necessariam causam, magna ratione cum
+				non modo ob causam sed etiam ob<note>etiam ob<hi rend="italic">Tb2k</hi>: etiam <hi rend="italic">cett.</hi>
+                  </note> necessariam causam, magna ratione cum
 				Mauretaniae rege contracta. <reg>tum</reg> autem, illo profecto, Sulla procurante
 				eius rem et gerente plurimis et pulcherrimis P. Sitti praediis venditis aes alienum
-				eiusdem dissolutum <add>est</add><note>est <hi rend="italic">suppl.
-					Angelius</hi></note>, ut, quae causa ceteros ad facinus impulit, cupiditas
-				retinendae possessionis, ea Sittio non fuerit praediis deminutis. </p></div>
-			<div type="textpart" subtype="section" n="57"><p>
-				<reg>iam</reg> vero illud quam incredibile, quam absurdum, qui
+				eiusdem dissolutum <add>est</add>
+                  <note>est <hi rend="italic">suppl.
+					Angelius</hi>
+                  </note>, ut, quae causa ceteros ad facinus impulit, cupiditas
+				retinendae possessionis, ea Sittio non fuerit praediis deminutis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="57">
+               <p>
+                  <reg>iam</reg> vero illud quam incredibile, quam absurdum, qui
 				Romae caedem facere, qui hanc urbem inflammare vellet, eum familiarissimum suum
-				dimittere ab se et amandare<note>amandare <hi rend="italic">T</hi>: mandare <hi
-						rend="italic">cett.</hi></note> in ultimas terras! Vtrum<note>utrum <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign>a</hi>: visum <hi
-						rend="italic">cett.</hi></note> quo facilius Romae ea quae conabatur
-				efficeret, si in Hispania turbatum esset<note>Hispaniam turb. isset <foreign
-						xml:lang="grc">S</foreign></note>? <reg>at</reg> haec ipsa per se sine ulla
+				dimittere ab se et amandare<note>amandare <hi rend="italic">T</hi>: mandare <hi rend="italic">cett.</hi>
+                  </note> in ultimas terras! Vtrum<note>utrum <hi rend="italic">T<foreign xml:lang="grc">π</foreign>a</hi>: visum <hi rend="italic">cett.</hi>
+                  </note> quo facilius Romae ea quae conabatur
+				efficeret, si in Hispania turbatum esset<note>Hispaniam turb. isset <foreign xml:lang="grc">ς</foreign>
+                  </note>? <reg>at</reg> haec ipsa per se sine ulla
 				coniunctione agebantur. <reg>an</reg> in tantis rebus, tam novis consiliis, tam
 				periculosis, tam turbulentis hominem amantissimum sui, familiarissimum,
 				coniunctissimum officiis, consuetudine, usu dimittendum esse
-					arbitrabatur<note>arbitrabatur <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign></hi>: arbitratur <hi rend="italic">a</hi>: arbitraretur
-						<hi rend="italic">cett.</hi></note>? <reg>veri</reg> simile non
-					est<note>veri simile non est <hi rend="italic">del. Lambinus</hi></note> ut,
+					arbitrabatur<note>arbitrabatur <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: arbitratur <hi rend="italic">a</hi>: arbitraretur
+						<hi rend="italic">cett.</hi>
+                  </note>? <reg>veri</reg> simile non
+					est<note>veri simile non est <hi rend="italic">del. Lambinus</hi>
+                  </note> ut,
 				quem in secundis rebus, quem in otio secum semper habuisset<note>semper secum hab.
-						<hi rend="italic">T</hi>: semper hab. secum <hi rend="italic"
-					>a</hi></note>, hunc in adversis et in eo tumultu quem ipse comparabat ab se
-				dimitteret. </p></div>
-			<div type="textpart" subtype="section" n="58"><p><reg>ipse</reg> autem Sittius—non enim
+						<hi rend="italic">T</hi>: semper hab. secum <hi rend="italic">a</hi>
+                  </note>, hunc in adversis et in eo tumultu quem ipse comparabat ab se
+				dimitteret. </p>
+            </div>
+            <div type="textpart" subtype="section" n="58">
+               <p>
+                  <reg>ipse</reg> autem Sittius—non enim
 				mihi deserenda est causa amici veteris atque hospitis—is homo est aut ea familia ac
-				disciplina ut hoc credi possit, eum bellum populo Romano<note>populo R. <hi
-						rend="italic">T, Gulielmius</hi>: rei (r. <hi rend="italic">a</hi>) p. <hi
-						rend="italic">cett.</hi></note> facere voluisse? ut, cuius pater, cum
+				disciplina ut hoc credi possit, eum bellum populo Romano<note>populo R. <hi rend="italic">T, Gulielmius</hi>: rei (r. <hi rend="italic">a</hi>) p. <hi rend="italic">cett.</hi>
+                  </note> facere voluisse? ut, cuius pater, cum
 				ceteri deficerent finitimi ac vicini, singulari exstiterit in rem publicam nostram
 				officio et fide, is sibi nefarium bellum contra patriam suscipiendum
-					putaret<note>putarit <hi rend="italic">Hulderich</hi></note>? cuius aes alienum
+					putaret<note>putarit <hi rend="italic">Hulderich</hi>
+                  </note>? cuius aes alienum
 				videmus, iudices, non libidine, sed negoti gerendi studio esse contractum, qui ita
-				Romae debuit ut in provinciis et in regnis ei maximae<note>ei maxime <hi
-						rend="italic">T</hi>: maxime ei <hi rend="italic">cett.</hi></note>
+				Romae debuit ut in provinciis et in regnis ei maximae<note>ei maxime <hi rend="italic">T</hi>: maxime ei <hi rend="italic">cett.</hi>
+                  </note>
 				pecuniae deberentur; quas cum peteret, non commisit ut sui procuratores quicquam
 				oneris absente se sustinerent; venire omnis suas possessiones et patrimonio se
 				ornatissimo spoliari maluit quam ullam moram cuiquam fieri creditorum suorum.
-					</p></div>
-			<div type="textpart" subtype="section" n="59"><p>A quo quidem genere, iudices, ego numquam
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="59">
+               <p>A quo quidem genere, iudices, ego numquam
 				timui, cum in illa rei publicae tempestate versarer. <reg>illud</reg> erat hominum
-					genus<note>hominum genus <hi rend="italic">T</hi>: genus hominum <hi
-						rend="italic">cett.</hi></note> horribile et pertimescendum qui tanto amore
+					genus<note>hominum genus <hi rend="italic">T</hi>: genus hominum <hi rend="italic">cett.</hi>
+                  </note> horribile et pertimescendum qui tanto amore
 				suas possessiones amplexi tenebant ut ab eis<note>iis <hi rend="italic">k</hi>: his
-						<hi rend="italic">cett.</hi></note> membra citius divelli<note>citius
-					divelli <hi rend="italic">T</hi>: divelli citius <hi rend="italic"
-					>cett.</hi></note> ac distrahi posse diceres. Sittius numquam sibi cognationem
+						<hi rend="italic">cett.</hi>
+                  </note> membra citius divelli<note>citius
+					divelli <hi rend="italic">T</hi>: divelli citius <hi rend="italic">cett.</hi>
+                  </note> ac distrahi posse diceres. Sittius numquam sibi cognationem
 				cum praediis esse existimavit suis. <reg>itaque</reg> se non modo ex suspicione
 				tanti sceleris verum etiam ex omni hominum sermone non armis, sed patrimonio suo
-				vindicavit. </p></div><milestone n="21" unit="chapter"/>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="60"><p>
-			<reg>iam</reg> vero quod obiecit<note>obiecit <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign>a</hi>: obicit (subicit <hi rend="italic"
-							>b1<foreign xml:lang="grc">s</foreign></hi>) <hi rend="italic"
-						>cett.</hi></note> Pompeianos esse a Sulla impulsos ut ad istam
-				coniurationem atque<note>atque (ac <hi rend="italic">k</hi>) <hi rend="italic"
-							>T<foreign xml:lang="grc">p</foreign>ak</hi>: et <hi rend="italic"
-						>cett.</hi></note> ad hoc nefarium facinus accederent, id cuius modi sit
+				vindicavit. </p>
+            </div>
+            <milestone n="21" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="60">
+               <p>
+                  <reg>iam</reg> vero quod obiecit<note>obiecit <hi rend="italic">T<foreign xml:lang="grc">π</foreign>a</hi>: obicit (subicit <hi rend="italic">b1<foreign xml:lang="grc">ς</foreign>
+                     </hi>) <hi rend="italic">cett.</hi>
+                  </note> Pompeianos esse a Sulla impulsos ut ad istam
+				coniurationem atque<note>atque (ac <hi rend="italic">k</hi>) <hi rend="italic">T<foreign xml:lang="grc">π</foreign>ak</hi>: et <hi rend="italic">cett.</hi>
+                  </note> ad hoc nefarium facinus accederent, id cuius modi sit
 				intellegere non possum. <reg>an</reg> tibi Pompeiani coniurasse videntur?
-					<reg>quis</reg> hoc dixit umquam<note>dixit umquam <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign></hi>: umquam dixit <hi rend="italic"
-						>cett.</hi></note>, aut quae fuit istius rei vel minima suspicio?
-					'Diiunxit<note>diiunxit <hi rend="italic">T</hi>: disiunxit <hi rend="italic"
-						>cett.</hi></note>,' inquit, 'eos a colonis ut hoc discidio ac dissensione
-				facta oppidum in sua potestate posset per<note>per <hi rend="italic">T</hi>: et <hi
-						rend="italic">cett.</hi></note> Pompeianos habere.' <reg>primum</reg> omnis
+					<reg>quis</reg> hoc dixit umquam<note>dixit umquam <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: umquam dixit <hi rend="italic">cett.</hi>
+                  </note>, aut quae fuit istius rei vel minima suspicio?
+					'Diiunxit<note>diiunxit <hi rend="italic">T</hi>: disiunxit <hi rend="italic">cett.</hi>
+                  </note>,' inquit, 'eos a colonis ut hoc discidio ac dissensione
+				facta oppidum in sua potestate posset per<note>per <hi rend="italic">T</hi>: et <hi rend="italic">cett.</hi>
+                  </note> Pompeianos habere.' <reg>primum</reg> omnis
 				Pompeianorum colonorumque dissensio delata ad patronos est, cum iam inveterasset ac
 				multos annos esset agitata<note>agitata <hi rend="italic">T</hi>: excogitata
-					(exagit. <foreign xml:lang="grc">p</foreign>) <hi rend="italic"
-					>cett.</hi></note>; deinde ita a patronis res cognita est ut nulla in re a
+					(exagit. <foreign xml:lang="grc">π</foreign>) <hi rend="italic">cett.</hi>
+                  </note>; deinde ita a patronis res cognita est ut nulla in re a
 				ceterorum sententiis Sulla dissenserit; postremo coloni ipsi sic intellegunt, non
-				Pompeianos a Sulla magis quam sese esse defensos. </p></div>
-			<div type="textpart" subtype="section" n="61"><p>
-				<reg>atque</reg> hoc, iudices, ex hac frequentia colonorum, honestissimorum
+				Pompeianos a Sulla magis quam sese esse defensos. </p>
+            </div>
+            <div type="textpart" subtype="section" n="61">
+               <p>
+                  <reg>atque</reg> hoc, iudices, ex hac frequentia colonorum, honestissimorum
 				hominum, intellegere potestis, qui adsunt, laborant, hunc patronum, defensorem,
-				custodem illius coloniae si in omni fortuna atque<note><app><lem>atque</lem></app> atque in
-						<hi rend="italic">b<foreign xml:lang="grc">xs</foreign></hi></note> omni
-				honore incolumem habere non potuerunt, in hoc tamen casu in quo<note>in quo <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign></hi>: quo (<hi
-						rend="italic">om. a</hi>) <hi rend="italic">cett.</hi></note> adflictus
-				iacet per vos iuvari<note>iuvari <hi rend="italic">T</hi>: tutari <hi
-						rend="italic">cett.</hi></note> conservarique cupiunt. <reg>adsunt</reg>
-				pari studio Pompeiani, qui ab istis<note>istis <hi rend="italic">Halm</hi>: his <hi
-						rend="italic">T</hi>: illis <hi rend="italic">cett.</hi></note> etiam in
+				custodem illius coloniae si in omni fortuna atque<note>
+                     <app>
+                        <lem>atque</lem>
+                     </app> atque in
+						<hi rend="italic">b<foreign xml:lang="grc">χς</foreign>
+                     </hi>
+                  </note> omni
+				honore incolumem habere non potuerunt, in hoc tamen casu in quo<note>in quo <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: quo (<hi rend="italic">om. a</hi>) <hi rend="italic">cett.</hi>
+                  </note> adflictus
+				iacet per vos iuvari<note>iuvari <hi rend="italic">T</hi>: tutari <hi rend="italic">cett.</hi>
+                  </note> conservarique cupiunt. <reg>adsunt</reg>
+				pari studio Pompeiani, qui ab istis<note>istis <hi rend="italic">Halm</hi>: his <hi rend="italic">T</hi>: illis <hi rend="italic">cett.</hi>
+                  </note> etiam in
 				crimen vocantur; qui ita de ambulatione ac de<note>ac de <hi rend="italic">T</hi>:
-					et de <hi rend="italic">cett.</hi></note> suffragiis suis cum colonis
-				dissenserunt ut idem de communi salute sentirent. </p></div>
-			<div type="textpart" subtype="section" n="62"><p>
-				<reg>ac</reg> ne haec quidem P. Sullae mihi videtur silentio praetereunda esse
+					et de <hi rend="italic">cett.</hi>
+                  </note> suffragiis suis cum colonis
+				dissenserunt ut idem de communi salute sentirent. </p>
+            </div>
+            <div type="textpart" subtype="section" n="62">
+               <p>
+                  <reg>ac</reg> ne haec quidem P. Sullae mihi videtur silentio praetereunda esse
 				virtus, quod, cum ab hoc illa colonia deducta sit, et cum commoda colonorum a
-				fortunis Pompeianorum rei publicae<note><app><lem>rei p.</lem></app> populi R. <hi
-						rend="italic">Angelius</hi></note> fortuna diiunxerit<note>diiunxerit (dis-
-						<hi rend="italic">E</hi>) <hi rend="italic">TE</hi>: diviserit <hi
-						rend="italic">cett.</hi></note>, ita carus utrisque est<note>est <hi
-						rend="italic">om. Tc1</hi></note> atque iucundus ut non alteros demovisse
-				sed utrosque constituisse videatur. <milestone unit="para"/><milestone n="22" unit="chapter"/>
-			<reg>at</reg> enim et gladiatores et omnis ista vis rogationis Caeciliae causa
-				comparabatur. <reg>atque</reg> hoc<note><app><lem>hoc</lem></app> hoc in <foreign
-						xml:lang="grc">p</foreign></note> loco in L. Caecilium,
-					pudentissimum<note>pudent. <hi rend="italic">Ta</hi>: prudent. <hi
-						rend="italic">cett.</hi></note> atque ornatissimum virum, vehementer
+				fortunis Pompeianorum rei publicae<note>
+                     <app>
+                        <lem>rei p.</lem>
+                     </app> populi R. <hi rend="italic">Angelius</hi>
+                  </note> fortuna diiunxerit<note>diiunxerit (dis-
+						<hi rend="italic">E</hi>) <hi rend="italic">TE</hi>: diviserit <hi rend="italic">cett.</hi>
+                  </note>, ita carus utrisque est<note>est <hi rend="italic">om. Tc1</hi>
+                  </note> atque iucundus ut non alteros demovisse
+				sed utrosque constituisse videatur. <milestone unit="para"/>
+                  <milestone n="22" unit="chapter"/>
+                  <reg>at</reg> enim et gladiatores et omnis ista vis rogationis Caeciliae causa
+				comparabatur. <reg>atque</reg> hoc<note>
+                     <app>
+                        <lem>hoc</lem>
+                     </app> hoc in <foreign xml:lang="grc">π</foreign>
+                  </note> loco in L. Caecilium,
+					pudentissimum<note>pudent. <hi rend="italic">Ta</hi>: prudent. <hi rend="italic">cett.</hi>
+                  </note> atque ornatissimum virum, vehementer
 				invectus est. <reg>cuius</reg> ego de virtute et constantia, iudices, tantum dico,
 				talem hunc in ista rogatione quam promulgarat non de tollenda, sed de levanda
-				calamitate fratris sui fuisse ut consulere<note>consulere <hi rend="italic"
-							>T<foreign xml:lang="grc">p</foreign>k;</hi> consulem <hi rend="italic"
-						>a</hi>: consul esse <hi rend="italic">cett.</hi></note> voluerit fratri,
+				calamitate fratris sui fuisse ut consulere<note>consulere <hi rend="italic">T<foreign xml:lang="grc">π</foreign>k;</hi> consulem <hi rend="italic">a</hi>: consul esse <hi rend="italic">cett.</hi>
+                  </note> voluerit fratri,
 				cum re publica pugnare noluerit; promulgarit impulsus amore fraterno, destiterit
-				fratris auctoritate deductus. </p></div>
-			<div type="textpart" subtype="section" n="63"><p><reg>atque</reg> in
+				fratris auctoritate deductus. </p>
+            </div>
+            <div type="textpart" subtype="section" n="63">
+               <p>
+                  <reg>atque</reg> in
 				ea re per L. Caecilium Sulla accusatur in qua re est uterque laudandus.
 					<reg>primum</reg> Caecilius—quid<note>quid <hi rend="italic">scripsi</hi>: qui
-						<hi rend="italic">codd.</hi>: qui si <hi rend="italic">Halm</hi></note>?
-				'id promulgavit<note>promulgavit <hi rend="italic">T</hi>: promulgarit (-re <hi
-						rend="italic">a,</hi> -ret <foreign xml:lang="grc">s</foreign>) <hi
-						rend="italic">cett.</hi></note> in quo res iudicatas
-					videbatur<note>videatur <hi rend="italic">Garatoni</hi></note> voluisse
+						<hi rend="italic">codd.</hi>: qui si <hi rend="italic">Halm</hi>
+                  </note>?
+				'id promulgavit<note>promulgavit <hi rend="italic">T</hi>: promulgarit (-re <hi rend="italic">a,</hi> -ret <foreign xml:lang="grc">ς</foreign>) <hi rend="italic">cett.</hi>
+                  </note> in quo res iudicatas
+					videbatur<note>videatur <hi rend="italic">Garatoni</hi>
+                  </note> voluisse
 				rescindere, ut restitueretur<note>stitueretur <hi rend="italic">T</hi>: statueretur
 						<hi rend="italic">cett.</hi>: <hi rend="italic">corr.
-					Pantagathus</hi></note> Sulla.' <reg>recte</reg><note>Sulla. Recte <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign></hi>: Sulla recte <hi
-						rend="italic">cett.</hi></note> reprehendis<note>reprehendis <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign>a2</hi>: reprehendendus
-						<hi rend="italic">a1</hi>: reprehendit <hi rend="italic"
-				>cett.</hi></note>; status enim rei publicae maxime iudicatis rebus continetur;
-				neque ego tantum fraterno amori dandum<note>neque dandum <hi rend="italic"
-					>T</hi></note> arbitror ut quisquam<note>quisquam <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign></hi>: quicquam <hi rend="italic">b1</hi>:
-					quisque <hi rend="italic">cett.</hi></note>, dum saluti<note>dum saluti <hi
-						rend="italic">T, Beck</hi>: de salute <hi rend="italic">cett.</hi></note>
-				suorum consulat, communem relinquat. <add><reg>at</reg></add><note>at <hi
-						rend="italic">suppl. Orelli</hi> de <hi rend="italic">Tc2</hi>: <hi
-						rend="italic">om. cett.</hi></note> nihil de iudicio ferebat, sed poenam
-				ambitus eam referebat<note>referebat <hi rend="italic">T</hi>: ferebat <hi
-						rend="italic">cett.</hi></note> quae fuerat nuper superioribus legibus
-				constituta. <reg>itaque</reg> hac rogatione non iudicum sententia<note>sententia <hi
-						rend="italic">Ta</hi>: sententiam <hi rend="italic">cett.</hi></note>, sed
+					Pantagathus</hi>
+                  </note> Sulla.' <reg>recte</reg>
+                  <note>Sulla. Recte <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: Sulla recte <hi rend="italic">cett.</hi>
+                  </note> reprehendis<note>reprehendis <hi rend="italic">T<foreign xml:lang="grc">π</foreign>a2</hi>: reprehendendus
+						<hi rend="italic">a1</hi>: reprehendit <hi rend="italic">cett.</hi>
+                  </note>; status enim rei publicae maxime iudicatis rebus continetur;
+				neque ego tantum fraterno amori dandum<note>neque dandum <hi rend="italic">T</hi>
+                  </note> arbitror ut quisquam<note>quisquam <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: quicquam <hi rend="italic">b1</hi>:
+					quisque <hi rend="italic">cett.</hi>
+                  </note>, dum saluti<note>dum saluti <hi rend="italic">T, Beck</hi>: de salute <hi rend="italic">cett.</hi>
+                  </note>
+				suorum consulat, communem relinquat. <add>
+                     <reg>at</reg>
+                  </add>
+                  <note>at <hi rend="italic">suppl. Orelli</hi> de <hi rend="italic">Tc2</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> nihil de iudicio ferebat, sed poenam
+				ambitus eam referebat<note>referebat <hi rend="italic">T</hi>: ferebat <hi rend="italic">cett.</hi>
+                  </note> quae fuerat nuper superioribus legibus
+				constituta. <reg>itaque</reg> hac rogatione non iudicum sententia<note>sententia <hi rend="italic">Ta</hi>: sententiam <hi rend="italic">cett.</hi>
+                  </note>, sed
 				legis vitium corrigebatur<note>corrigebatur <hi rend="italic">T</hi>: corrigebat
-						<hi rend="italic">cett.</hi></note>. <reg>nemo</reg> iudicium reprehendit,
-				cum de poena queritur, sed legem. <reg>damnatio</reg> est enim<note>est enim <hi
-						rend="italic">T</hi>: enim est <hi rend="italic">cett.</hi></note>
-				iudicum, quae manebat, poena legis, quae levabatur. </p></div>
-			<div type="textpart" subtype="section" n="64"><p>
-				<reg>noli</reg> igitur animos eorum ordinum qui praesunt iudiciis summa cum
+						<hi rend="italic">cett.</hi>
+                  </note>. <reg>nemo</reg> iudicium reprehendit,
+				cum de poena queritur, sed legem. <reg>damnatio</reg> est enim<note>est enim <hi rend="italic">T</hi>: enim est <hi rend="italic">cett.</hi>
+                  </note>
+				iudicum, quae manebat, poena legis, quae levabatur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="64">
+               <p>
+                  <reg>noli</reg> igitur animos eorum ordinum qui praesunt iudiciis summa cum
 				gravitate et dignitate alienare a causa. <reg>nemo</reg> labefactare iudicium est
 				conatus, nihil est eius modi promulgatum, semper Caecilius in calamitate fratris sui
-				iudicum potestatem perpetuandam<note>perpetiundam <hi rend="italic">T</hi></note>,
+				iudicum potestatem perpetuandam<note>perpetiundam <hi rend="italic">T</hi>
+                  </note>,
 				legis acerbitatem mitigandam putavit. <reg>sed</reg> quid ego de hoc plura disputem?
-					<milestone n="23" unit="chapter"/><reg>dicerem</reg> fortasse, et facile et
+					<milestone n="23" unit="chapter"/>
+                  <reg>dicerem</reg> fortasse, et facile et
 				libenter dicerem, si paulo etiam longius quam finis cotidiani offici postulat L.
 					Caecilium<note>L. Caecilium <hi rend="italic">hoc loco hab. T, post</hi> amor
-						<hi rend="italic">cett.</hi></note> pietas et fraternus amor
-					propulisset<note>propulisset <hi rend="italic">TE<foreign xml:lang="grc"
-							>p</foreign></hi>: protulisset <hi rend="italic">cett.</hi></note>,
+						<hi rend="italic">cett.</hi>
+                  </note> pietas et fraternus amor
+					propulisset<note>propulisset <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: protulisset <hi rend="italic">cett.</hi>
+                  </note>,
 				implorarem sensus vestros, unius cuiusque indulgentiam in suos testarer, peterem
-				veniam errato<note>veniam err. <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign></hi>: err. veniam <hi rend="italic">cett.</hi></note> L.
-				Caecili ex intimis vestris cogitationibus atque ex humanitate communi. </p></div>
-			<div type="textpart" subtype="section" n="65"><p>
-				<reg>lex</reg> dies fuit proposita paucos, ferri coepta
-				numquam, deposita<note>deposita <hi rend="italic">E</hi>: posita <hi rend="italic"
-						>cett.</hi> Kal. Ian. <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign></hi>: r. lateri (r. p. latuit <foreign xml:lang="grc"
-						>s</foreign>) <hi rend="italic">cett.</hi></note> est in senatu. Kalendis
+				veniam errato<note>veniam err. <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: err. veniam <hi rend="italic">cett.</hi>
+                  </note> L.
+				Caecili ex intimis vestris cogitationibus atque ex humanitate communi. </p>
+            </div>
+            <div type="textpart" subtype="section" n="65">
+               <p>
+                  <reg>lex</reg> dies fuit proposita paucos, ferri coepta
+				numquam, deposita<note>deposita <hi rend="italic">E</hi>: posita <hi rend="italic">cett.</hi> Kal. Ian. <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: r. lateri (r. p. latuit <foreign xml:lang="grc">ς</foreign>) <hi rend="italic">cett.</hi>
+                  </note> est in senatu. Kalendis
 				Ianuariis cum in Capitolium nos senatum convocassemus, nihil est actum prius, et id
-					mandatu<note>mandatu <hi rend="italic">T</hi>: mandato <hi rend="italic"
-						>cett.</hi></note> Sullae Q. Metellus praetor se loqui dixit Sullam illam
+					mandatu<note>mandatu <hi rend="italic">T</hi>: mandato <hi rend="italic">cett.</hi>
+                  </note> Sullae Q. Metellus praetor se loqui dixit Sullam illam
 				rogationem de se nolle ferri. <reg>ex</reg> illo tempore L. Caecilius egit de re
-					publica<note>egit de re p. <hi rend="italic">T</hi>: de re p. egit <hi
-						rend="italic">cett.</hi> (e re p. egit <hi rend="italic"
-					>Sylvius</hi>)</note> multa; agrariae legi, quae tota a me reprehensa et abiecta
-				est, se<note>se <hi rend="italic">T<foreign xml:lang="grc">p</foreign></hi>: <hi
-						rend="italic">om. cett.</hi></note> intercessorem fore
-					professus<note>professus <hi rend="italic">T<foreign xml:lang="grc"
-						>p</foreign></hi>: perpessus <hi rend="italic">cett.</hi></note> est,
+					publica<note>egit de re p. <hi rend="italic">T</hi>: de re p. egit <hi rend="italic">cett.</hi> (e re p. egit <hi rend="italic">Sylvius</hi>)</note> multa; agrariae legi, quae tota a me reprehensa et abiecta
+				est, se<note>se <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: <hi rend="italic">om. cett.</hi>
+                  </note> intercessorem fore
+					professus<note>professus <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: perpessus <hi rend="italic">cett.</hi>
+                  </note> est,
 				improbis largitionibus restitit, senatus auctoritatem numquam impedivit, ita se
 				gessit in tribunatu ut onere deposito domestici offici nihil postea nisi de rei
-				publicae commodis cogitarit. </p></div>
-			<div type="textpart" subtype="section" n="66"><p><reg>atque</reg> in
-				ipsa rogatione ne per vim quid ageretur, quis tum<note>tum <hi rend="italic"
-							>T<foreign xml:lang="grc">p</foreign>k</hi>: tamen <hi rend="italic"
-						>cett.</hi></note> nostrum Sullam aut Caecilium verebatur? nonne omnis ille
+				publicae commodis cogitarit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="66">
+               <p>
+                  <reg>atque</reg> in
+				ipsa rogatione ne per vim quid ageretur, quis tum<note>tum <hi rend="italic">T<foreign xml:lang="grc">π</foreign>k</hi>: tamen <hi rend="italic">cett.</hi>
+                  </note> nostrum Sullam aut Caecilium verebatur? nonne omnis ille
 				terror, omnis seditionis timor atque opinio ex Autroni improbitate pendebat?
 					<reg>eius</reg> voces, eius minae ferebantur, eius aspectus, concursatio,
 				stipatio, greges hominum perditorum metum nobis seditionesque<note>nobis caedis
-					seditionisque <hi rend="italic">Madvig</hi></note> adferebant.
-					<reg>itaque</reg> P. Sulla hoc importunissimo cum<note><app><lem>cum</lem></app> tum
-						<hi rend="italic"><foreign xml:lang="grc">p</foreign>ab<foreign
-							xml:lang="grc">xs</foreign></hi></note> honoris tum etiam calamitatis
+					seditionisque <hi rend="italic">Madvig</hi>
+                  </note> adferebant.
+					<reg>itaque</reg> P. Sulla hoc importunissimo cum<note>
+                     <app>
+                        <lem>cum</lem>
+                     </app> tum
+						<hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>ab<foreign xml:lang="grc">χς</foreign>
+                     </hi>
+                  </note> honoris tum etiam calamitatis
 				socio atque comite et secundas fortunas amittere coactus est et in adversis sine
-				ullo remedio atque adlevamento permanere. <milestone n="24" unit="chapter"
-					/></p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="67"><p>
-			<reg>hic</reg> tu epistulam meam saepe recitas quam ego ad Cn. Pompeium de meis rebus
-				gestis et de summa re publica<note>re p. <hi rend="italic">T</hi>: r. p. <hi
-						rend="italic">a</hi>: rei p. <hi rend="italic">cett.</hi></note> misi, et
+				ullo remedio atque adlevamento permanere. <milestone n="24" unit="chapter"/>
+               </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="67">
+               <p>
+                  <reg>hic</reg> tu epistulam meam saepe recitas quam ego ad Cn. Pompeium de meis rebus
+				gestis et de summa re publica<note>re p. <hi rend="italic">T</hi>: r. p. <hi rend="italic">a</hi>: rei p. <hi rend="italic">cett.</hi>
+                  </note> misi, et
 				ex ea crimen aliquod in P. Sullam quaeris et, si furorem incredibilem biennio ante
 				conceptum erupisse in meo consulatu scripsi, me hoc demonstrasse dicis, Sullam in
-				illa fuisse superiore coniuratione. <reg>scilicet</reg> ego<note>ego <hi
-						rend="italic">T</hi>: <hi rend="italic">om. cett.</hi></note> is sum qui
+				illa fuisse superiore coniuratione. <reg>scilicet</reg> ego<note>ego <hi rend="italic">T</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> is sum qui
 				existimem Cn. Pisonem et Catilinam et Vargunteium et Autronium nihil scelerate,
 				nihil audacter ipsos per sese sine P. Sulla facere
-				potuisse.</p></div>
-			<div type="textpart" subtype="section" n="68"><p><reg>de</reg> quo etiam si quis dubitasset antea an<note>an <hi
-						rend="italic">E. Eberhard</hi>: num <hi rend="italic">codd.</hi></note> id
-				quod tu arguis cogitasset, ut<note>ut <foreign xml:lang="grc">p</foreign>: <hi
-						rend="italic">om. cett.</hi></note> interfecto patre tuo consul<note>consul
-						<hi rend="italic">ed. R., O. Müller</hi>: consule <hi rend="italic"
-						>codd.</hi> descenderet <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign>a</hi>: descendere <hi rend="italic">cett.</hi></note>
-				descenderet Kalendis Ianuariis cum lictoribus, sustulisti<note>sustuli <hi
-						rend="italic">T</hi></note> hanc suspicionem, cum dixisti<note>dixi <hi
-						rend="italic">Ta</hi></note> hunc, ut Catilinam consulem efficeret, contra
+				potuisse.</p>
+            </div>
+            <div type="textpart" subtype="section" n="68">
+               <p>
+                  <reg>de</reg> quo etiam si quis dubitasset antea an<note>an <hi rend="italic">E. Eberhard</hi>: num <hi rend="italic">codd.</hi>
+                  </note> id
+				quod tu arguis cogitasset, ut<note>ut <foreign xml:lang="grc">π</foreign>: <hi rend="italic">om. cett.</hi>
+                  </note> interfecto patre tuo consul<note>consul
+						<hi rend="italic">ed. R., O. Müller</hi>: consule <hi rend="italic">codd.</hi> descenderet <hi rend="italic">T<foreign xml:lang="grc">π</foreign>a</hi>: descendere <hi rend="italic">cett.</hi>
+                  </note>
+				descenderet Kalendis Ianuariis cum lictoribus, sustulisti<note>sustuli <hi rend="italic">T</hi>
+                  </note> hanc suspicionem, cum dixisti<note>dixi <hi rend="italic">Ta</hi>
+                  </note> hunc, ut Catilinam consulem efficeret, contra
 				patrem tuum operas et manum comparasse. <reg>quod</reg> si tibi ego<note>tibi ego
-						<hi rend="italic">T<foreign xml:lang="grc">p</foreign>a<foreign
-							xml:lang="grc">x</foreign></hi>: ego tibi <hi rend="italic"
-					>cett.</hi></note> confitear<note>confitear <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign></hi>: confiteor <hi rend="italic"
-					>cett.</hi></note>, tu mihi concedas necesse est hunc, cum Catilinae
-				suffragaretur, nihil de suo<note><app><lem>suo</lem></app> meo <hi rend="italic"
-					>T</hi></note> consulatu, quem iudicio amiserat, per vim recuperando
+						<hi rend="italic">T<foreign xml:lang="grc">π</foreign>a<foreign xml:lang="grc">χ</foreign>
+                     </hi>: ego tibi <hi rend="italic">cett.</hi>
+                  </note> confitear<note>confitear <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: confiteor <hi rend="italic">cett.</hi>
+                  </note>, tu mihi concedas necesse est hunc, cum Catilinae
+				suffragaretur, nihil de suo<note>
+                     <app>
+                        <lem>suo</lem>
+                     </app> meo <hi rend="italic">T</hi>
+                  </note> consulatu, quem iudicio amiserat, per vim recuperando
 				cogitavisse. <reg>neque</reg> enim istorum facinorum tantorum, tam atrocium crimen,
-				iudices, P. Sullae persona suscipit. </p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="69"><p>
-			<reg>iam</reg> enim faciam criminibus omnibus fere dissolutis, contra atque in
+				iudices, P. Sullae persona suscipit. </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="69">
+               <p>
+                  <reg>iam</reg> enim faciam criminibus omnibus fere dissolutis, contra atque in
 				ceteris causis fieri solet, ut nunc denique de vita hominis ac de moribus dicam.
 					<reg>etenim</reg> de principio studuit animus occurrere magnitudini criminis,
-				satis facere exspectationi hominum, de me aliquid ipso<note>ipso <hi rend="italic"
-						>TE</hi>: de ipso <hi rend="italic">cett.</hi></note> qui accusatus
-					eram<note>eram <hi rend="italic">TE<foreign xml:lang="grc">p</foreign>a</hi>:
-					erat <hi rend="italic">cett.</hi></note> dicere; nunc iam revocandi estis eo
-				quo vos ipsa causa etiam tacente me cogit animos<note>animos <hi rend="italic"
-						>E</hi>: animus (<hi rend="italic">om. <foreign xml:lang="grc"
-						>p</foreign></hi>) <hi rend="italic">cett.</hi></note> mentisque
-					convertere<note>mentesque convertere <hi rend="italic">E</hi>: <hi
-						rend="italic">om. cett.</hi></note>. <milestone n="25" unit="chapter"
-					/><reg>omnibus</reg> in rebus, iudices<note>iudices <hi rend="italic">om.
-						T</hi></note>, quae graviores maioresque sunt, quid quisque voluerit,
+				satis facere exspectationi hominum, de me aliquid ipso<note>ipso <hi rend="italic">TE</hi>: de ipso <hi rend="italic">cett.</hi>
+                  </note> qui accusatus
+					eram<note>eram <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>a</hi>:
+					erat <hi rend="italic">cett.</hi>
+                  </note> dicere; nunc iam revocandi estis eo
+				quo vos ipsa causa etiam tacente me cogit animos<note>animos <hi rend="italic">E</hi>: animus (<hi rend="italic">om. <foreign xml:lang="grc">π</foreign>
+                     </hi>) <hi rend="italic">cett.</hi>
+                  </note> mentisque
+					convertere<note>mentesque convertere <hi rend="italic">E</hi>: <hi rend="italic">om. cett.</hi>
+                  </note>. <milestone n="25" unit="chapter"/>
+                  <reg>omnibus</reg> in rebus, iudices<note>iudices <hi rend="italic">om.
+						T</hi>
+                  </note>, quae graviores maioresque sunt, quid quisque voluerit,
 				cogitarit, admiserit, non ex crimine, sed ex moribus eius qui arguitur est
 				ponderandum. <reg>neque</reg> enim potest quisquam nostrum subito fingi neque
-				cuiusquam repente vita mutari aut natura converti. </p></div>
-			<div type="textpart" subtype="section" n="70"><p>
-				<reg>circumspicite</reg> paulisper mentibus vestris, ut alia
-					mittamus<note>mittamus <hi rend="italic">T</hi>: omittamus <hi rend="italic"
-						>cett.</hi></note>, hosce ipsos homines qui huic adfines sceleri fuerunt.
+				cuiusquam repente vita mutari aut natura converti. </p>
+            </div>
+            <div type="textpart" subtype="section" n="70">
+               <p>
+                  <reg>circumspicite</reg> paulisper mentibus vestris, ut alia
+					mittamus<note>mittamus <hi rend="italic">T</hi>: omittamus <hi rend="italic">cett.</hi>
+                  </note>, hosce ipsos homines qui huic adfines sceleri fuerunt.
 				Catilina contra rem publicam coniuravit. <reg>cuius</reg> aures umquam
-					haec<note>haec <hi rend="italic">V</hi>: hoc <hi rend="italic"
-					>cett.</hi></note> respuerunt? conatum esse audacter<note>audacter <hi
-						rend="italic">T</hi>: <hi rend="italic">om. cett.</hi></note> hominem a
+					haec<note>haec <hi rend="italic">V</hi>: hoc <hi rend="italic">cett.</hi>
+                  </note> respuerunt? conatum esse audacter<note>audacter <hi rend="italic">T</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> hominem a
 				pueritia non solum intemperantia et scelere sed etiam consuetudine et studio in omni
-				flagitio, stupro, caede versatum<note><app><lem>versatum</lem></app> grassatum <hi
-						rend="italic">E</hi></note>? <reg>quis</reg> eum contra patriam pugnantem
+				flagitio, stupro, caede versatum<note>
+                     <app>
+                        <lem>versatum</lem>
+                     </app> grassatum <hi rend="italic">E</hi>
+                  </note>? <reg>quis</reg> eum contra patriam pugnantem
 				perisse miratur quem semper omnes ad civile latrocinium natum putaverunt?
 					<reg>quis</reg> Lentuli societates cum indicibus, quis insaniam libidinum, quis
 				perversam atque impiam religionem recordatur qui illum aut nefarie
 					cogitasse<note>cogitasse <hi rend="italic">TE</hi>: <hi rend="italic">om.
-						cett.</hi></note> aut stulte sperasse<note>sperasse <hi rend="italic"
-						>E</hi>: cogitasse <hi rend="italic">cett.</hi></note> miretur?
+						cett.</hi>
+                  </note> aut stulte sperasse<note>sperasse <hi rend="italic">E</hi>: cogitasse <hi rend="italic">cett.</hi>
+                  </note> miretur?
 					<reg>quis</reg> de C. Cethego atque eius in Hispaniam profectione ac de volnere
 				Q. Metelli Pii cogitat cui non ad illius poenam carcer aedificatus esse videatur?
-					</p></div>
-			<div type="textpart" subtype="section" n="71"><p><reg>omitto</reg> ceteros, ne sit infinitum;
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="71">
+               <p>
+                  <reg>omitto</reg> ceteros, ne sit infinitum;
 				tantum a vobis peto ut taciti de omnibus quos coniurasse cognitum est cogitetis;
-					intellegetis<note>intelligitis <hi rend="italic">Tab2<foreign xml:lang="grc"
-							>x</foreign></hi></note> unum quemque eorum<note><app><lem>eorum</lem></app>
-					illorum <hi rend="italic">bk, ed. V</hi></note> prius ab<note>ab <hi
-						rend="italic">Tb2</hi>: a <hi rend="italic">cett.</hi>: <hi rend="italic"
-						>del. Madvig</hi></note> sua vita quam<note>quam a <hi rend="italic"
-							><foreign xml:lang="grc">p</foreign>c2</hi></note> vestra<note>vestra
-						<hi rend="italic">T<foreign xml:lang="grc">p</foreign>c</hi>: nostra <hi
-						rend="italic">cett.</hi></note> suspicione esse damnatum. <reg>ipsum</reg>
+					intellegetis<note>intelligitis <hi rend="italic">Tab2<foreign xml:lang="grc">χ</foreign>
+                     </hi>
+                  </note> unum quemque eorum<note>
+                     <app>
+                        <lem>eorum</lem>
+                     </app>
+					illorum <hi rend="italic">bk, ed. V</hi>
+                  </note> prius ab<note>ab <hi rend="italic">Tb2</hi>: a <hi rend="italic">cett.</hi>: <hi rend="italic">del. Madvig</hi>
+                  </note> sua vita quam<note>quam a <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>c2</hi>
+                  </note> vestra<note>vestra
+						<hi rend="italic">T<foreign xml:lang="grc">π</foreign>c</hi>: nostra <hi rend="italic">cett.</hi>
+                  </note> suspicione esse damnatum. <reg>ipsum</reg>
 				illum Autronium, quoniam eius nomen finitimum maxime est
-						huius<note><app><lem>huius</lem></app> huic <hi rend="italic"><foreign
-							xml:lang="grc">p</foreign></hi></note> periculo et crimini, non sua vita
-				ac natura<note>vita ac natura <hi rend="italic">T</hi>: ante acta vita <hi
-						rend="italic"><foreign xml:lang="grc">S</foreign>g</hi>: consuetudine ac
-					vita <hi rend="italic">c</hi>: ac (hac <foreign xml:lang="grc">x</foreign>:
-					haec <hi rend="italic">k</hi>) vita <hi rend="italic">ap<foreign
-							xml:lang="grc">x</foreign>k</hi></note> convicit<note>convicit <hi
-						rend="italic">T</hi>: convincit <hi rend="italic">cett.</hi></note>?
+						huius<note>
+                     <app>
+                        <lem>huius</lem>
+                     </app> huic <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note> periculo et crimini, non sua vita
+				ac natura<note>vita ac natura <hi rend="italic">T</hi>: ante acta vita <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>g</hi>: consuetudine ac
+					vita <hi rend="italic">c</hi>: ac (hac <foreign xml:lang="grc">χ</foreign>:
+					haec <hi rend="italic">k</hi>) vita <hi rend="italic">ap<foreign xml:lang="grc">χ</foreign>k</hi>
+                  </note> convicit<note>convicit <hi rend="italic">T</hi>: convincit <hi rend="italic">cett.</hi>
+                  </note>?
 					<reg>semper</reg> audax, petulans, libidinosus; quem in stuprorum defensionibus
 				non solum verbis uti improbissimis solitum esse scimus verum etiam pugnis et
-				calcibus, quem exturbare homines ex<note>ex (et <hi rend="italic">a</hi>) <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign>ac</hi>: e <hi
-						rend="italic">cett.</hi></note> possessionibus, caedem facere vicinorum,
+				calcibus, quem exturbare homines ex<note>ex (et <hi rend="italic">a</hi>) <hi rend="italic">T<foreign xml:lang="grc">π</foreign>ac</hi>: e <hi rend="italic">cett.</hi>
+                  </note> possessionibus, caedem facere vicinorum,
 				spoliare fana sociorum, comitatu<note>comitatu <hi rend="italic">scripsi</hi>: vi
-					(vi. <hi rend="italic">a</hi>) conatum (-u <hi rend="italic"><foreign
-							xml:lang="grc">S</foreign>b<foreign xml:lang="grc">y</foreign>k</hi>)
-						<hi rend="italic">codd.</hi> (<hi rend="italic">cf.</hi> § 51): vi <hi
-						rend="italic">Lambinus</hi></note> et armis disturbare iudicia, in bonis
+					(vi. <hi rend="italic">a</hi>) conatum (-u <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>b<foreign xml:lang="grc">ψ</foreign>k</hi>)
+						<hi rend="italic">codd.</hi> (<hi rend="italic">cf.</hi> § 51): vi <hi rend="italic">Lambinus</hi>
+                  </note> et armis disturbare iudicia, in bonis
 				rebus omnis contemnere, in malis pugnare contra bonos, non rei publicae cedere, non
 				fortunae ipsi succumbere. <reg>huius</reg> si causa non manifestissimis rebus
-				teneretur, tamen eum mores ipsius ac vita convinceret. <milestone n="26"
-					unit="chapter"/></p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="72"><p>
-			<reg>agedum</reg>, conferte nunc cum illius<note>illis <foreign xml:lang="grc"
-						>s</foreign></note> vita <add>vitam</add><note>vita vitam <hi rend="italic"
-						>Angelius</hi> (<hi rend="italic">cf.</hi> § 74): vita <hi rend="italic"
-						>T</hi>: vitam <hi rend="italic">cett.</hi></note> P. Sullae vobis
+				teneretur, tamen eum mores ipsius ac vita convinceret. <milestone n="26" unit="chapter"/>
+               </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="72">
+               <p>
+                  <reg>agedum</reg>, conferte nunc cum illius<note>illis <foreign xml:lang="grc">ς</foreign>
+                  </note> vita <add>vitam</add>
+                  <note>vita vitam <hi rend="italic">Angelius</hi> (<hi rend="italic">cf.</hi> § 74): vita <hi rend="italic">T</hi>: vitam <hi rend="italic">cett.</hi>
+                  </note> P. Sullae vobis
 				populoque Romano notissimam, iudices, et eam ante oculos vestros proponite.
-					<reg>ecquod</reg><note>et quod <hi rend="italic">codd.</hi>: <hi rend="italic"
-						>corr. ed. Med.</hi></note> est<note>est <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign>a</hi>: <hi rend="italic">om.
-					cett.</hi></note> huius factum aut commissum non dicam audacius, sed quod
+					<reg>ecquod</reg>
+                  <note>et quod <hi rend="italic">codd.</hi>: <hi rend="italic">corr. ed. Med.</hi>
+                  </note> est<note>est <hi rend="italic">T<foreign xml:lang="grc">π</foreign>a</hi>: <hi rend="italic">om.
+					cett.</hi>
+                  </note> huius factum aut commissum non dicam audacius, sed quod
 				cuiquam paulo minus consideratum videretur? <reg>factum</reg> quaero; verbum ecquod
-				umquam ex ore huius excidit in quo<note>in quo <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign>a</hi>: in <hi rend="italic">g</hi>: ut
-						<foreign xml:lang="grc">S</foreign>: unde <hi rend="italic">b<foreign
-							xml:lang="grc">s</foreign></hi></note> quisquam posset offendi?
+				umquam ex ore huius excidit in quo<note>in quo <hi rend="italic">T<foreign xml:lang="grc">π</foreign>a</hi>: in <hi rend="italic">g</hi>: ut
+						<foreign xml:lang="grc">ς</foreign>: unde <hi rend="italic">b<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> quisquam posset offendi?
 					<reg>at</reg> vero in illa gravi L. Sullae turbulentaque
 					victoria<note>turbulentaque vict. <hi rend="italic">T</hi>: vict. turbulentaque
-						<hi rend="italic">cett.</hi></note> quis P. Sulla mitior, quis
-				misericordior inventus est? <add><reg>quam</reg></add><note>quam <hi rend="italic"
-						>Gellius</hi> vii. 6. 16: <hi rend="italic">om. codd.</hi></note> multorum
+						<hi rend="italic">cett.</hi>
+                  </note> quis P. Sulla mitior, quis
+				misericordior inventus est? <add>
+                     <reg>quam</reg>
+                  </add>
+                  <note>quam <hi rend="italic">Gellius</hi> vii. 6. 16: <hi rend="italic">om. codd.</hi>
+                  </note> multorum
 				hic vitam est<note>quis ... est <hi rend="italic">E</hi>: <hi rend="italic">om.
-						cett.</hi></note> a L. Sulla deprecatus! quam multi sunt summi homines et
+						cett.</hi>
+                  </note> a L. Sulla deprecatus! quam multi sunt summi homines et
 				ornatissimi et nostri et equestris ordinis quorum pro salute se hic Sullae
 				obligavit! <reg>quos</reg> ego nominarem—neque enim ipsi nolunt et huic animo
 				gratissimo adsunt—sed, quia maius est beneficium quam posse debet civis civi dare,
-				ideo a vobis peto ut quod potuit, tempori tribuatis, quod fecit, ipsi.</p></div>
-			<div type="textpart" subtype="section" n="73"><p>
-<reg>quid</reg> reliquae<note>reliquae <hi rend="italic">Richter</hi> (<hi
-						rend="italic">cf.</hi> § 88): reliquam <hi rend="italic">codd.</hi></note>
+				ideo a vobis peto ut quod potuit, tempori tribuatis, quod fecit, ipsi.</p>
+            </div>
+            <div type="textpart" subtype="section" n="73">
+               <p>
+                  <reg>quid</reg> reliquae<note>reliquae <hi rend="italic">Richter</hi> (<hi rend="italic">cf.</hi> § 88): reliquam <hi rend="italic">codd.</hi>
+                  </note>
 				constantiam vitae commemorem,dignitatem,
-					liberalitatem<note>libertatem <hi rend="italic">T</hi></note>, moderationem in
+					liberalitatem<note>libertatem <hi rend="italic">T</hi>
+                  </note>, moderationem in
 				privatis rebus, splendorem in publicis? quae ita deformata sunt a
 					fortuna<note>deform. sunt a fortuna <hi rend="italic">T</hi>: a fortuna deform.
-					sunt <hi rend="italic">cett.</hi></note> ut tamen a natura inchoata compareant.
-					<reg>quae</reg> domus, quae<note><app><lem>domus, quae</lem></app> domus <hi
-						rend="italic">Jordan</hi></note> celebratio cotidiana, quae
-					familiarium<note>familiarium <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign></hi>: familiaris <hi rend="italic">cett.</hi></note>
+					sunt <hi rend="italic">cett.</hi>
+                  </note> ut tamen a natura inchoata compareant.
+					<reg>quae</reg> domus, quae<note>
+                     <app>
+                        <lem>domus, quae</lem>
+                     </app> domus <hi rend="italic">Jordan</hi>
+                  </note> celebratio cotidiana, quae
+					familiarium<note>familiarium <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: familiaris <hi rend="italic">cett.</hi>
+                  </note>
 				dignitas, quae studia amicorum, quae ex quoque ordine multitudo! <reg>haec</reg> diu
-					multumque<note>multumque <hi rend="italic">TE<foreign xml:lang="grc"
-							>p</foreign></hi>: multum <hi rend="italic">cett.</hi></note> et multo
+					multumque<note>multumque <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: multum <hi rend="italic">cett.</hi>
+                  </note> et multo
 				labore quaesita una eripuit hora. <reg>accepit</reg> P. Sulla, iudices, volnus
-				vehemens et mortiferum, verum tamen eius modi quod videretur huius<note>huius <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign>ag</hi>: eius <hi
-						rend="italic">cett.</hi></note> vita et natura accipere potuisse.
-					<reg>honestatis</reg> enim<note>enim <hi rend="italic">T</hi>: <hi
-						rend="italic">om. cett.</hi></note> et dignitatis habuisse nimis magnam
+				vehemens et mortiferum, verum tamen eius modi quod videretur huius<note>huius <hi rend="italic">T<foreign xml:lang="grc">π</foreign>ag</hi>: eius <hi rend="italic">cett.</hi>
+                  </note> vita et natura accipere potuisse.
+					<reg>honestatis</reg> enim<note>enim <hi rend="italic">T</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> et dignitatis habuisse nimis magnam
 				iudicatus est cupiditatem; quam si nemo alius habuit in consulatu petendo, cupidior
 				iudicatus est hic fuisse quam ceteri; sin etiam in aliis non nullis fuit iste
-				consulatus amor, fortuna in hoc fuit fortasse gravior quam in ceteris.</p></div>
-			<div type="textpart" subtype="section" n="74"><p><reg>postea</reg> vero quis P.Sullam nisi
+				consulatus amor, fortuna in hoc fuit fortasse gravior quam in ceteris.</p>
+            </div>
+            <div type="textpart" subtype="section" n="74">
+               <p>
+                  <reg>postea</reg> vero quis P.Sullam nisi
 				maerentem, demissum adflictumque vidit, quis umquam est suspicatus hunc magis odio
 				quam pudore hominum aspectum lucemque vitare? <reg>qui</reg> cum multa haberet
 				invitamenta urbis et fori propter summa studia amicorum, quae
-						tamen<note><app><lem>tamen</lem></app> tantum <foreign xml:lang="grc">p</foreign>:
-					tum <foreign xml:lang="grc">S</foreign>: <hi rend="italic">post</hi> afuit <hi
-						rend="italic">transp. Fleckeisen</hi></note> ei sola in malis restiterunt,
-					afuit<note>affuit <hi rend="italic">Ta</hi>: abfuit <hi rend="italic"
-						>cett.</hi>: <hi rend="italic">corr. Lambinus</hi></note> ab oculis
-					vestris<note>nostris <hi rend="italic"><foreign xml:lang="grc"
-						>S</foreign>b1gc</hi></note> et, cum lege retineretur, ipse se exsilio paene
-				multavit. <milestone n="27" unit="chapter"/><reg>in</reg> hoc vos pudore,
+						tamen<note>
+                     <app>
+                        <lem>tamen</lem>
+                     </app> tantum <foreign xml:lang="grc">π</foreign>:
+					tum <foreign xml:lang="grc">ς</foreign>: <hi rend="italic">post</hi> afuit <hi rend="italic">transp. Fleckeisen</hi>
+                  </note> ei sola in malis restiterunt,
+					afuit<note>affuit <hi rend="italic">Ta</hi>: abfuit <hi rend="italic">cett.</hi>: <hi rend="italic">corr. Lambinus</hi>
+                  </note> ab oculis
+					vestris<note>nostris <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>b1gc</hi>
+                  </note> et, cum lege retineretur, ipse se exsilio paene
+				multavit. <milestone n="27" unit="chapter"/>
+                  <reg>in</reg> hoc vos pudore,
 					iudices<note>iudicii <hi rend="italic">codd.</hi>: <hi rend="italic">corr.
-						Angelius</hi></note>, et in hac vita tanto sceleri locum fuisse
-					credatis<note>credatis <hi rend="italic">Zielinski</hi> (<hi rend="italic"
-						>p.</hi> 204): creditis <hi rend="italic">codd.</hi></note>?
+						Angelius</hi>
+                  </note>, et in hac vita tanto sceleri locum fuisse
+					credatis<note>credatis <hi rend="italic">Zielinski</hi> (<hi rend="italic">p.</hi> 204): creditis <hi rend="italic">codd.</hi>
+                  </note>?
 					<reg>aspicite</reg> ipsum, contuemini os, conferte crimen cum vita,
 					vitam<note>vitam <hi rend="italic">TE</hi>: <hi rend="italic">om.
-					cett.</hi></note> ab initio usque<note>ab initio usque <hi rend="italic"
-							>T<foreign xml:lang="grc">p</foreign>a</hi>: ab initio <hi
-						rend="italic">E</hi>: usque <hi rend="italic">cett.</hi></note> ad hoc
-				tempus explicatam<note>explicatam <hi rend="italic">TE</hi>: explicata <hi
-						rend="italic">cett.</hi></note> cum crimine recognoscite. </p></div>
-			<div type="textpart" subtype="section" n="75"><p>
+					cett.</hi>
+                  </note> ab initio usque<note>ab initio usque <hi rend="italic">T<foreign xml:lang="grc">π</foreign>a</hi>: ab initio <hi rend="italic">E</hi>: usque <hi rend="italic">cett.</hi>
+                  </note> ad hoc
+				tempus explicatam<note>explicatam <hi rend="italic">TE</hi>: explicata <hi rend="italic">cett.</hi>
+                  </note> cum crimine recognoscite. </p>
+            </div>
+            <div type="textpart" subtype="section" n="75">
+               <p>
 				Mitto rem publicam, quae fuit semper Sullae carissima; hosne
 				amicos, talis viros, tam cupidos sui, per quos res eius secundae quondam erant
-					ornatae<note>ornatae <hi rend="italic">b2<foreign xml:lang="grc"
-						>s</foreign></hi>: ordinatae <hi rend="italic">cett.</hi></note>, nunc
+					ornatae<note>ornatae <hi rend="italic">b2<foreign xml:lang="grc">ς</foreign>
+                     </hi>: ordinatae <hi rend="italic">cett.</hi>
+                  </note>, nunc
 				sublevantur adversae, crudelissime perire voluit, ut cum Lentulo et Catilina et
 				Cethego foedissimam vitam ac miserrimam turpissima morte proposita degeret?
-					<reg>non</reg>, inquam, cadit<note>non cadit non inquam cadit <hi rend="italic"
-						>cod. H. Stephani</hi></note> in hos mores, non in hunc pudorem, non in hanc
+					<reg>non</reg>, inquam, cadit<note>non cadit non inquam cadit <hi rend="italic">cod. H. Stephani</hi>
+                  </note> in hos mores, non in hunc pudorem, non in hanc
 				vitam, non in hunc hominem ista suspicio. <reg>nova</reg> quaedam illa immanitas
 				exorta est, incredibilis fuit ac singularis furor, ex multis ab adulescentia
 				conlectis perditorum hominum vitiis repente ista tanta importunitas inauditi
-				sceleris exarsit.</p></div>
-			<div type="textpart" subtype="section" n="76"><p><reg>nolite</reg>, iudices,
+				sceleris exarsit.</p>
+            </div>
+            <div type="textpart" subtype="section" n="76">
+               <p>
+                  <reg>nolite</reg>, iudices,
 				arbitrari hominum illum impetum et conatum fuisse—neque enim ulla gens tam barbara
 				aut tam immanis umquam fuit in qua non modo tot, sed unus tam crudelis hostis
 				patriae sit inventus—, beluae quaedam illae ex portentis immanes ac ferae
-					forma<note>formas <foreign xml:lang="grc">p</foreign></note> hominum indutae
+					forma<note>formas <foreign xml:lang="grc">π</foreign>
+                  </note> hominum indutae
 				exstiterunt. <reg>perspicite</reg> etiam atque etiam, iudices,—nihil enim est quod
-				in hac causa dici possit<note>possit <hi rend="italic"><foreign xml:lang="grc"
-							>p</foreign>b<foreign xml:lang="grc">xs</foreign></hi>: posset <hi
-						rend="italic">cett.</hi></note> vehementius— penitus introspicite
+				in hac causa dici possit<note>possit <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>b<foreign xml:lang="grc">χς</foreign>
+                     </hi>: posset <hi rend="italic">cett.</hi>
+                  </note> vehementius— penitus introspicite
 				Catilinae, Autroni, Cethegi, Lentuli ceterorumque mentis; quas vos in his libidines,
 				quae flagitia, quas turpitudines, quantas audacias, quam incredibilis furores, quas
 				notas facinorum, quae indicia parricidiorum, quantos acervos scelerum<note>facinorum
-					... scelerum <hi rend="italic">T</hi>: scelerum ... facinorum <hi
-						rend="italic">cett.</hi></note> reperietis! <reg>ex</reg> magnis et
+					... scelerum <hi rend="italic">T</hi>: scelerum ... facinorum <hi rend="italic">cett.</hi>
+                  </note> reperietis! <reg>ex</reg> magnis et
 				diuturnis et iam desperatis rei publicae morbis ista repente vis erupit, ut ea
-				confecta et eiecta convalescere aliquando et sanari civitas posset<note>posset <hi
-						rend="italic">k, Ernesti</hi>: possit <hi rend="italic">cett.</hi></note>;
+				confecta et eiecta convalescere aliquando et sanari civitas posset<note>posset <hi rend="italic">k, Ernesti</hi>: possit <hi rend="italic">cett.</hi>
+                  </note>;
 				neque enim est quisquam qui arbitretur illis inclusis in re publica pestibus diutius
-						haec<note><app><lem>haec</lem></app> hoc imperium <hi rend="italic">c2</hi></note>
+						haec<note>
+                     <app>
+                        <lem>haec</lem>
+                     </app> hoc imperium <hi rend="italic">c2</hi>
+                  </note>
 				stare potuisse. <reg>itaque</reg> eos non ad perficiendum scelus, sed ad luendas rei
-				publicae poenas Furiae quaedam incitaverunt. </p></div><milestone n="28" unit="chapter"/>
-			<div type="textpart" subtype="section" n="77"><p><reg>in</reg> hunc igitur gregem vos
+				publicae poenas Furiae quaedam incitaverunt. </p>
+            </div>
+            <milestone n="28" unit="chapter"/>
+            <div type="textpart" subtype="section" n="77">
+               <p>
+                  <reg>in</reg> hunc igitur gregem vos
 				nunc P. Sullam,
-				iudices, ex his<note>iis <foreign xml:lang="grc">s</foreign>, <hi rend="italic">ed.
-						V</hi></note> qui cum hoc vivunt atque<note><app><lem>atque</lem></app> aut <hi
-						rend="italic">T</hi>: at <foreign xml:lang="grc">p</foreign></note>
-				vixerunt honestissimorum hominum<note><app><lem>hominum</lem></app> amicorum <hi
-						rend="italic">T</hi></note> gregibus reicietis, ex hoc
-					amicorum<note>amicorum <hi rend="italic">Klotz</hi>: hominum <hi rend="italic"
-						>codd.</hi></note> numero, ex hac familiarium<note>familiarium <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign>b2<foreign xml:lang="grc"
-							>x</foreign></hi>: familiari <hi rend="italic">cett.</hi></note>
-				dignitate in impiorum partem atque in parricidarum sedem<note>sedem <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign></hi>: cedem <hi
-						rend="italic">cett.</hi></note> et<note><app><lem>et</lem></app> atque <hi
-						rend="italic">T</hi>: ac <hi rend="italic">ab</hi></note> numerum
-				transferetis? Vbi erit igitur illud firmissimum<note>firmissimum <hi rend="italic"
-						>T</hi>: fortissimum <hi rend="italic">cett.</hi></note> praesidium
+				iudices, ex his<note>iis <foreign xml:lang="grc">ς</foreign>, <hi rend="italic">ed.
+						V</hi>
+                  </note> qui cum hoc vivunt atque<note>
+                     <app>
+                        <lem>atque</lem>
+                     </app> aut <hi rend="italic">T</hi>: at <foreign xml:lang="grc">π</foreign>
+                  </note>
+				vixerunt honestissimorum hominum<note>
+                     <app>
+                        <lem>hominum</lem>
+                     </app> amicorum <hi rend="italic">T</hi>
+                  </note> gregibus reicietis, ex hoc
+					amicorum<note>amicorum <hi rend="italic">Klotz</hi>: hominum <hi rend="italic">codd.</hi>
+                  </note> numero, ex hac familiarium<note>familiarium <hi rend="italic">T<foreign xml:lang="grc">π</foreign>b2<foreign xml:lang="grc">χ</foreign>
+                     </hi>: familiari <hi rend="italic">cett.</hi>
+                  </note>
+				dignitate in impiorum partem atque in parricidarum sedem<note>sedem <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: cedem <hi rend="italic">cett.</hi>
+                  </note> et<note>
+                     <app>
+                        <lem>et</lem>
+                     </app> atque <hi rend="italic">T</hi>: ac <hi rend="italic">ab</hi>
+                  </note> numerum
+				transferetis? Vbi erit igitur illud firmissimum<note>firmissimum <hi rend="italic">T</hi>: fortissimum <hi rend="italic">cett.</hi>
+                  </note> praesidium
 				pudoris, quo in loco nobis vita ante acta proderit, quod ad tempus existimationis
-				partae fructus reservabitur, si in<note><app><lem>in</lem></app> non <hi rend="italic"
-						>T</hi>: nos in <hi rend="italic">Richter</hi></note> extremo discrimine ac
+				partae fructus reservabitur, si in<note>
+                     <app>
+                        <lem>in</lem>
+                     </app> non <hi rend="italic">T</hi>: nos in <hi rend="italic">Richter</hi>
+                  </note> extremo discrimine ac
 				dimicatione fortunae deseret<note>deseret <hi rend="italic">k</hi>: deserit (-uit
-						<hi rend="italic">b1c2</hi>) <hi rend="italic">cett.</hi></note>, si non
-				aderit, si nihil adiuvabit? </p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="78"><p>
-			<reg>quaestiones</reg> nobis servorum accusator et tormenta<note>accus. et tormenta
-						<hi rend="italic">T</hi>: ac tormenta accus. <hi rend="italic"
-					>cett.</hi></note> minitatur. <reg>in</reg> quibus quamquam nihil periculi
+						<hi rend="italic">b1c2</hi>) <hi rend="italic">cett.</hi>
+                  </note>, si non
+				aderit, si nihil adiuvabit? </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="78">
+               <p>
+                  <reg>quaestiones</reg> nobis servorum accusator et tormenta<note>accus. et tormenta
+						<hi rend="italic">T</hi>: ac tormenta accus. <hi rend="italic">cett.</hi>
+                  </note> minitatur. <reg>in</reg> quibus quamquam nihil periculi
 				suspicamur, tamen illa tormenta gubernat dolor, moderatur natura cuiusque cum animi
-				tum corporis, regit quaesitor<note>quaesitor <hi rend="italic">T</hi>: quaestor <hi
-						rend="italic">cett.</hi></note>, flectit libido, corrumpit spes, infirmat
+				tum corporis, regit quaesitor<note>quaesitor <hi rend="italic">T</hi>: quaestor <hi rend="italic">cett.</hi>
+                  </note>, flectit libido, corrumpit spes, infirmat
 				metus, ut in tot rerum angustiis nihil veritati loci relinquatur. <reg>vita</reg> P.
-				Sullae torqueatur<note>torqueatur <hi rend="italic">T<foreign xml:lang="grc"
-							>p</foreign></hi>: Torquate <hi rend="italic">cett.</hi></note>, ex ea
+				Sullae torqueatur<note>torqueatur <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: Torquate <hi rend="italic">cett.</hi>
+                  </note>, ex ea
 				quaeratur num quae occultetur libido, num quod lateat facinus, num quae crudelitas,
 				num quae audacia. <reg>nihil</reg> erroris erit in causa nec obscuritatis, iudices,
 				si a vobis vitae perpetuae vox, ea quae verissima et gravissima<note>verissima et
-					gravissima <hi rend="italic">T</hi>: gravissima et verissima <hi rend="italic"
-							><foreign xml:lang="grc">p</foreign>a</hi>: gravissima <hi
-						rend="italic">cett.</hi></note> debet esse, audietur. </p></div>
-			<div type="textpart" subtype="section" n="79"><p>
-				<reg>nullum</reg> in hac causa testem timemus, nihil quemquam
+					gravissima <hi rend="italic">T</hi>: gravissima et verissima <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>a</hi>: gravissima <hi rend="italic">cett.</hi>
+                  </note> debet esse, audietur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="79">
+               <p>
+                  <reg>nullum</reg> in hac causa testem timemus, nihil quemquam
 				scire, nihil vidisse, nihil audisse arbitramur. <reg>sed</reg> tamen, si nihil vos
 				P. Sullae fortuna movet, iudices, vestra moveat. <reg>vestra</reg> enim, qui cum
 				summa elegantia atque integritate vixistis, hoc maxime interest, non ex libidine aut
 				simultate aut levitate testium causas honestorum hominum ponderari, sed in magnis
-					disquisitionibus<note>disceptationibus <hi rend="italic">Madvig</hi></note>
+					disquisitionibus<note>disceptationibus <hi rend="italic">Madvig</hi>
+                  </note>
 				repentinisque periculis vitam unius cuiusque esse testem. <reg>quam</reg> vos,
 				iudices, nolite armis suis spoliatam atque nudatam obicere invidiae, dedere
 				suspicioni; munite communem arcem bonorum, obstruite perfugia improborum; valeat ad
-				poenam et ad salutem vita<note>vita <foreign xml:lang="grc">p</foreign>: <hi
-						rend="italic">om. cett.</hi></note> plurimum, quam solam videtis per
+				poenam et ad salutem vita<note>vita <foreign xml:lang="grc">π</foreign>: <hi rend="italic">om. cett.</hi>
+                  </note> plurimum, quam solam videtis per
 					se<note>per se <hi rend="italic">Mommsen</hi>: ipse <hi rend="italic">T</hi>:
 					ipsam <hi rend="italic">cett.</hi> ex sua <hi rend="italic">T</hi>: ex vi sua
-					(ex nat. sua et in <foreign xml:lang="grc">p</foreign>) <hi rend="italic"
-						>cett., cf.</hi> § 71, <hi rend="italic">Caec.</hi> 88. 104 natura <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign></hi>: naturaque <hi
-						rend="italic">cett.</hi></note> ex sua natura facillime perspici, subito
-				flecti fingique non posse. </p></div><milestone n="29" unit="chapter"/>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="80"><p>
-			<reg>quid</reg> vero? haec auctoritas—saepe<note>saepe <hi rend="italic"
-						>Spengel</hi>: semper <hi rend="italic">codd.</hi></note> enim est de ea
-				dicendum, quamquam a me timide modiceque<note>modiceque <hi rend="italic">T<foreign
-							xml:lang="grc">p</foreign>k</hi>: et modice <hi rend="italic">b</hi>:
-					modice <hi rend="italic">cett.</hi></note> dicetur—quid? inquam<note>inquam <hi
-						rend="italic">om. bc1</hi></note>, haec auctoritas nostra, qui a ceteris
+					(ex nat. sua et in <foreign xml:lang="grc">π</foreign>) <hi rend="italic">cett., cf.</hi> § 71, <hi rend="italic">Caec.</hi> 88. 104 natura <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: naturaque <hi rend="italic">cett.</hi>
+                  </note> ex sua natura facillime perspici, subito
+				flecti fingique non posse. </p>
+            </div>
+            <milestone n="29" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="80">
+               <p>
+                  <reg>quid</reg> vero? haec auctoritas—saepe<note>saepe <hi rend="italic">Spengel</hi>: semper <hi rend="italic">codd.</hi>
+                  </note> enim est de ea
+				dicendum, quamquam a me timide modiceque<note>modiceque <hi rend="italic">T<foreign xml:lang="grc">π</foreign>k</hi>: et modice <hi rend="italic">b</hi>:
+					modice <hi rend="italic">cett.</hi>
+                  </note> dicetur—quid? inquam<note>inquam <hi rend="italic">om. bc1</hi>
+                  </note>, haec auctoritas nostra, qui a ceteris
 				coniurationis causis abstinuimus, P. Sullam defendimus, nihil hunc tandem iuvabit?
-					<reg>grave</reg> est hoc dictu<note>grave est hoc dictum (<hi rend="italic"
-						>corr. Madvig</hi>) fortasse iudices <hi rend="italic">E</hi>: <hi
-						rend="italic">om. cett.</hi></note> fortasse, iudices, grave, si appetimus
+					<reg>grave</reg> est hoc dictu<note>grave est hoc dictum (<hi rend="italic">corr. Madvig</hi>) fortasse iudices <hi rend="italic">E</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> fortasse, iudices, grave, si appetimus
 				aliquid; si, cum ceteri de nobis silent, non etiam nosmet ipsi tacemus, grave; sed,
 				si laedimur, si accusamur, si in invidiam vocamur, profecto
-					conceditis<note>concedetis <foreign xml:lang="grc">s</foreign></note>, iudices,
-				ut nobis libertatem retinere liceat, si minus liceat dignitatem. </p></div>
-			<div type="textpart" subtype="section" n="81"><p>
-				<reg>accusati</reg> sunt uno nomine <add>omnes</add><note>omnes
+					conceditis<note>concedetis <foreign xml:lang="grc">ς</foreign>
+                  </note>, iudices,
+				ut nobis libertatem retinere liceat, si minus liceat dignitatem. </p>
+            </div>
+            <div type="textpart" subtype="section" n="81">
+               <p>
+                  <reg>accusati</reg> sunt uno nomine <add>omnes</add>
+                  <note>omnes
 						<hi rend="italic">supplevi</hi> (<hi rend="italic">hoc loco, ante</hi> uno
 						<hi rend="italic">Lambinus</hi>)</note> consulares, ut iam videatur honoris
 				amplissimi nomen plus invidiae quam dignitatis adferre. '<reg>adfuerunt</reg>,'
-				inquit, 'Catilinae illumque laudarunt.' <reg>nulla</reg> tum<note><app><lem>tum</lem></app>
-					tamen <hi rend="italic">abc</hi></note> patebat, nulla erat cognita coniuratio;
+				inquit, 'Catilinae illumque laudarunt.' <reg>nulla</reg> tum<note>
+                     <app>
+                        <lem>tum</lem>
+                     </app>
+					tamen <hi rend="italic">abc</hi>
+                  </note> patebat, nulla erat cognita coniuratio;
 				defendebant amicum, aderant supplici, vitae eius turpitudinem in summis eius
 				periculis non insequebantur. <reg>quin</reg> etiam parens tuus, Torquate, consul reo
-				de pecuniis repetundis<note><app><lem>repetundis</lem></app>
-					<hi rend="italic">hic incipit E</hi></note> Catilinae fuit advocatus, improbo
+				de pecuniis repetundis<note>
+                     <app>
+                        <lem>repetundis</lem>
+                     </app>
+                     <hi rend="italic">hic incipit E</hi>
+                  </note> Catilinae fuit advocatus, improbo
 				homini, at supplici, fortasse audaci, at aliquando amico. <reg>cui</reg> cum adfuit
-				post delatam ad eum primam illam coniurationem, indicavit<note>iudicavit <hi
-						rend="italic">T<foreign xml:lang="grc">S</foreign></hi></note> se audisse
+				post delatam ad eum primam illam coniurationem, indicavit<note>iudicavit <hi rend="italic">T<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> se audisse
 				aliquid, non credidisse. '<reg>at</reg> idem non adfuit alio in iudicio, cum
-				adessent ceteri.' <reg>si</reg><note>si <hi rend="italic"><foreign xml:lang="grc"
-							>S</foreign>bk</hi>: sed <hi rend="italic">cett.</hi></note> postea
-				cognorat ipse aliquid quod in consulatu ignorasset, ignoscendum est eis<note>iis <hi
-						rend="italic">edd. VR</hi>: his <hi rend="italic">codd.</hi></note> qui
-				postea nihil audierunt; sin illa res prima valuit, num<note>num <hi rend="italic"
-						>TE</hi>: non <hi rend="italic">cett.</hi></note> inveterata quam recens
-				debuit esse gravior? <reg>sed</reg> si tuus parens etiam in ipsa<note>ipsa <hi
-						rend="italic">TE</hi>: illa <hi rend="italic">cett.</hi></note> suspicione
+				adessent ceteri.' <reg>si</reg>
+                  <note>si <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>bk</hi>: sed <hi rend="italic">cett.</hi>
+                  </note> postea
+				cognorat ipse aliquid quod in consulatu ignorasset, ignoscendum est eis<note>iis <hi rend="italic">edd. VR</hi>: his <hi rend="italic">codd.</hi>
+                  </note> qui
+				postea nihil audierunt; sin illa res prima valuit, num<note>num <hi rend="italic">TE</hi>: non <hi rend="italic">cett.</hi>
+                  </note> inveterata quam recens
+				debuit esse gravior? <reg>sed</reg> si tuus parens etiam in ipsa<note>ipsa <hi rend="italic">TE</hi>: illa <hi rend="italic">cett.</hi>
+                  </note> suspicione
 				periculi sui tamen humanitate adductus advocationem hominis improbissimi sella
 				curuli atque ornamentis et suis et consulatus honestavit, quid est quam ob rem
-				consulares qui Catilinae adfuerunt reprendantur<note>reprehendantur <hi
-						rend="italic">codd.</hi></note>? </p></div>
-			<div type="textpart" subtype="section" n="82"><p>
-				'<reg>at</reg> idem eis<note>iis <hi rend="italic">edd. VR</hi>: is <hi
-						rend="italic">a<foreign xml:lang="grc">S</foreign>g</hi>: his <hi
-						rend="italic">cett.</hi></note> qui ante hunc causam de coniuratione
+				consulares qui Catilinae adfuerunt reprendantur<note>reprehendantur <hi rend="italic">codd.</hi>
+                  </note>? </p>
+            </div>
+            <div type="textpart" subtype="section" n="82">
+               <p>
+				'<reg>at</reg> idem eis<note>iis <hi rend="italic">edd. VR</hi>: is <hi rend="italic">a<foreign xml:lang="grc">ς</foreign>g</hi>: his <hi rend="italic">cett.</hi>
+                  </note> qui ante hunc causam de coniuratione
 				dixerunt non adfuerunt.' <reg>tanto</reg> scelere astrictis hominibus statuerunt
-				nihil a se adiumenti, nihil opis, nihil auxili ferri<note>ferre <hi rend="italic"
-						>TE</hi></note> oportere. <reg>atque</reg> ut de eorum constantia atque
+				nihil a se adiumenti, nihil opis, nihil auxili ferri<note>ferre <hi rend="italic">TE</hi>
+                  </note> oportere. <reg>atque</reg> ut de eorum constantia atque
 				animo in rem publicam dicam quorum tacita gravitas et fides de uno quoque loquitur
 				neque cuiusquam ornamenta orationis desiderat, potest quisquam dicere<note>dicere
-					quisquam <hi rend="italic">Ek</hi></note> umquam meliores, fortiores,
-				constantiores consularis fuisse quam his<note><app><lem>his</lem></app> iis <hi
-						rend="italic">ed. R</hi></note> temporibus et periculis quibus paene
+					quisquam <hi rend="italic">Ek</hi>
+                  </note> umquam meliores, fortiores,
+				constantiores consularis fuisse quam his<note>
+                     <app>
+                        <lem>his</lem>
+                     </app> iis <hi rend="italic">ed. R</hi>
+                  </note> temporibus et periculis quibus paene
 				oppressa est res publica? <reg>quis</reg> non de communi salute optime<note>optime
-						<hi rend="italic">Spengel</hi>: apertissime (aptissime <hi rend="italic"
-						>c1</hi>) <hi rend="italic">codd.</hi></note>, quis non fortissime, quis
+						<hi rend="italic">Spengel</hi>: apertissime (aptissime <hi rend="italic">c1</hi>) <hi rend="italic">codd.</hi>
+                  </note>, quis non fortissime, quis
 				non constantissime sensit? <reg>neque</reg> ego praecipue de consularibus
-					disputo<note>dico seu disputo <hi rend="italic">b2<foreign xml:lang="grc"
-							>xy</foreign>c</hi></note>; nam haec et hominum ornatissimorum, qui
+					disputo<note>dico seu disputo <hi rend="italic">b2<foreign xml:lang="grc">χψ</foreign>c</hi>
+                  </note>; nam haec et hominum ornatissimorum, qui
 				praetores fuerunt, et universi senatus communis est laus, ut constet post hominum
 				memoriam numquam in illo ordine plus virtutis, plus amoris in rem publicam, plus
 				gravitatis fuisse; sed quia sunt descripti consulares, de his tantum mihi dicendum
-				putavi quod satis esset ad testandam<note>ad testandam (-dum <hi rend="italic"
-						>T</hi>) <hi rend="italic">TE, Lambinus</hi>: attestantem (-tationem <hi
-						rend="italic">k</hi>) <hi rend="italic">cett.</hi></note> omnium
-					memoriam<note>omnium memoriam <hi rend="italic">TE</hi>: memoriam omnium <hi
-						rend="italic">cett.</hi></note>, neminem esse ex illo honoris gradu qui non
+				putavi quod satis esset ad testandam<note>ad testandam (-dum <hi rend="italic">T</hi>) <hi rend="italic">TE, Lambinus</hi>: attestantem (-tationem <hi rend="italic">k</hi>) <hi rend="italic">cett.</hi>
+                  </note> omnium
+					memoriam<note>omnium memoriam <hi rend="italic">TE</hi>: memoriam omnium <hi rend="italic">cett.</hi>
+                  </note>, neminem esse ex illo honoris gradu qui non
 				omni studio, virtute, auctoritate incubuerit ad rem publicam conservandam.
-					</p></div><milestone n="30" unit="chapter"/>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="83"><p>
-			<reg>sed</reg> quid ego?<note>quid ego? <hi rend="italic">a, Reid</hi>: quid? Ego
-						<hi rend="italic">cett.</hi></note> qui Catilinam non laudavi, qui reo
+					</p>
+            </div>
+            <milestone n="30" unit="chapter"/>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="83">
+               <p>
+                  <reg>sed</reg> quid ego?<note>quid ego? <hi rend="italic">a, Reid</hi>: quid? Ego
+						<hi rend="italic">cett.</hi>
+                  </note> qui Catilinam non laudavi, qui reo
 				Catilinae consul non adfui, qui testimonium de coniuratione dixi in alios, adeone
 				vobis alienus a sanitate, adeo oblitus constantiae meae, adeo immemor rerum a me
 				gestarum esse videor ut, cum consul bellum gesserim cum coniuratis, nunc eorum ducem
-				servare cupiam et animum<note>et animum <hi rend="italic">Sylvius</hi>: et (<hi
-						rend="italic">om.</hi>
-					<foreign xml:lang="grc">S1</foreign>) in animum <hi rend="italic"
-					>codd.</hi></note> inducam, cuius nuper ferrum rettuderim<note>rettud. <hi
-						rend="italic">Halm</hi>: retud. <hi rend="italic">codd.</hi></note>
+				servare cupiam et animum<note>et animum <hi rend="italic">Sylvius</hi>: et (<hi rend="italic">om.</hi>
+                     <foreign xml:lang="grc">ς1</foreign>) in animum <hi rend="italic">codd.</hi>
+                  </note> inducam, cuius nuper ferrum rettuderim<note>rettud. <hi rend="italic">Halm</hi>: retud. <hi rend="italic">codd.</hi>
+                  </note>
 				flammamque restinxerim, eiusdem nunc causam vitamque defendere? <reg>si</reg> me
 				dius fidius, iudices, non me ipsa res publica meis laboribus et periculis conservata
 				ad gravitatem animi et constantiam sua dignitate revocaret, tamen hoc natura est
 				insitum ut, quem timueris, quicum de vita fortunisque contenderis, cuius ex insidiis
 				evaseris, hunc semper oderis. <reg>sed</reg> cum agatur honos meus amplissimus,
-				gloria rerum gestarum singularis, cum, quotiens quisque<note>quisque <hi
-						rend="italic">T<foreign xml:lang="grc">pS1</foreign>b1</hi>: quisquam <hi
-						rend="italic">cett.</hi></note> est in<note>in <hi rend="italic">del.
-						Lambinus</hi></note> hoc scelere convictus, totiens renovetur memoria per me
+				gloria rerum gestarum singularis, cum, quotiens quisque<note>quisque <hi rend="italic">T<foreign xml:lang="grc">πς1</foreign>b1</hi>: quisquam <hi rend="italic">cett.</hi>
+                  </note> est in<note>in <hi rend="italic">del.
+						Lambinus</hi>
+                  </note> hoc scelere convictus, totiens renovetur memoria per me
 				inventae salutis, ego sim tam demens, ego committam ut ea quae pro salute omnium
 				gessi, casu magis et felicitate a me quam virtute et consilio gesta esse videantur?
-					</p></div>
-			<div type="textpart" subtype="section" n="84"><p>'<reg>quid</reg> ergo? hoc tibi sumis,' dicet
-				fortasse quispiam, 'ut, quia tu defendis<note>defendis <hi rend="italic">TE<foreign
-							xml:lang="grc">p</foreign>b2c</hi>: defenderis <hi rend="italic"
-						>cett.</hi></note>, innocens iudicetur?' <reg>ego</reg> vero, iudices, non
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="84">
+               <p>'<reg>quid</reg> ergo? hoc tibi sumis,' dicet
+				fortasse quispiam, 'ut, quia tu defendis<note>defendis <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>b2c</hi>: defenderis <hi rend="italic">cett.</hi>
+                  </note>, innocens iudicetur?' <reg>ego</reg> vero, iudices, non
 				modo mihi nihil adsumo in quo quispiam repugnet sed etiam, si quid ab omnibus
 				conceditur, id reddo ac remitto. <reg>non</reg> in ea re publica versor, non eis
-				temporibus caput meum<note>meum caput <hi rend="italic">E</hi></note> obtuli pro
+				temporibus caput meum<note>meum caput <hi rend="italic">E</hi>
+                  </note> obtuli pro
 					patria<note>patriae <hi rend="italic">codd.</hi>: <hi rend="italic">corr. ed.
-						Crat.</hi></note> periculis omnibus, non aut ita sunt exstincti quos vici
-				aut ita grati quos servavi, ut ego<note><app><lem>ego</lem></app> eo <hi rend="italic"
-							>Ta<foreign xml:lang="grc">S1</foreign>b<foreign xml:lang="grc"
-							>x</foreign></hi></note> mihi plus appetere coner quam
-						quantum<note><app><lem>quam quantum</lem></app> quamquam tum <hi rend="italic"
-						>TEa</hi></note> omnes inimici invidique patiantur. </p></div>
-			<div type="textpart" subtype="section" n="85"><p>
-				<reg>grave</reg> esse videtur eum<note>esse videtur eum <hi
-						rend="italic">TEk</hi>: esse eum (eum esse <hi rend="italic"><foreign
-							xml:lang="grc">p</foreign>g</hi>) videtur <hi rend="italic">cett.</hi>:
-						<hi rend="italic">fort.</hi> esse <hi rend="italic">delendum</hi></note>
+						Crat.</hi>
+                  </note> periculis omnibus, non aut ita sunt exstincti quos vici
+				aut ita grati quos servavi, ut ego<note>
+                     <app>
+                        <lem>ego</lem>
+                     </app> eo <hi rend="italic">Ta<foreign xml:lang="grc">ς1</foreign>b<foreign xml:lang="grc">χ</foreign>
+                     </hi>
+                  </note> mihi plus appetere coner quam
+						quantum<note>
+                     <app>
+                        <lem>quam quantum</lem>
+                     </app> quamquam tum <hi rend="italic">TEa</hi>
+                  </note> omnes inimici invidique patiantur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="85">
+               <p>
+                  <reg>grave</reg> esse videtur eum<note>esse videtur eum <hi rend="italic">TEk</hi>: esse eum (eum esse <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>g</hi>) videtur <hi rend="italic">cett.</hi>:
+						<hi rend="italic">fort.</hi> esse <hi rend="italic">delendum</hi>
+                  </note>
 				qui investigarit coniurationem, qui patefecerit, qui oppresserit, cui senatus
 				singularibus verbis gratias egerit, cui uni togato supplicationem decreverit, dicere
 				in iudicio: 'non defenderem, si coniurasset.' <reg>non</reg> dico id quod grave est,
 				dico illud quod in his causis coniurationis non auctoritati adsumam, sed pudori meo:
 				'ego ille coniurationis investigator atque ultor certe non defenderem Sullam, si
 				coniurasse arbitrarer.' <reg>ego</reg>, iudices, de tantis omnium periculis cum
-				quaererem omnia, multa audirem, crederem non omnia<note>crederem non omnia <hi
-						rend="italic">E</hi>: non crederem omnia <hi rend="italic"
-					>cett.</hi></note>, caverem omnia<note>multa ... caverem omnia <hi
-						rend="italic">om. T</hi></note>, dico hoc quod initio<note>in initio <hi
-						rend="italic">T</hi></note> dixi, nullius indicio<note>iudicio <hi
-						rend="italic">E</hi></note>, nullius nuntio<note>nullius nuntio <hi
-						rend="italic">E</hi>: <hi rend="italic">om. cett.</hi></note>, nullius
-				suspicione, nullius litteris<note>nullis litteris <hi rend="italic"><foreign
-							xml:lang="grc">S</foreign>bgp</hi></note> de P. Sulla<note><app><lem>de
-						P.</lem></app> de re p. <hi rend="italic">abgp<foreign xml:lang="grc"
-							>xs</foreign></hi>: de reatu P. <foreign xml:lang="grc">S</foreign>
-					<hi rend="italic">mg.</hi></note><note>Sulla <hi rend="italic">TE<foreign
-							xml:lang="grc">p</foreign></hi>: Sullae <hi rend="italic"
-					>cett.</hi></note> rem ullam ad me esse delatam. <milestone n="31"
-					unit="chapter"/></p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="86"><p>
-			<reg>quam</reg> ob rem vos, di patrii ac penates, qui huic urbi atque huic rei
-					publicae<note>rei p. <hi rend="italic">TE<foreign xml:lang="grc"
-						>p</foreign>a</hi>: imperio <hi rend="italic">cett.</hi></note>
+				quaererem omnia, multa audirem, crederem non omnia<note>crederem non omnia <hi rend="italic">E</hi>: non crederem omnia <hi rend="italic">cett.</hi>
+                  </note>, caverem omnia<note>multa ... caverem omnia <hi rend="italic">om. T</hi>
+                  </note>, dico hoc quod initio<note>in initio <hi rend="italic">T</hi>
+                  </note> dixi, nullius indicio<note>iudicio <hi rend="italic">E</hi>
+                  </note>, nullius nuntio<note>nullius nuntio <hi rend="italic">E</hi>: <hi rend="italic">om. cett.</hi>
+                  </note>, nullius
+				suspicione, nullius litteris<note>nullis litteris <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>bgp</hi>
+                  </note> de P. Sulla<note>
+                     <app>
+                        <lem>de
+						P.</lem>
+                     </app> de re p. <hi rend="italic">abgp<foreign xml:lang="grc">χς</foreign>
+                     </hi>: de reatu P. <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italic">mg.</hi>
+                  </note>
+                  <note>Sulla <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: Sullae <hi rend="italic">cett.</hi>
+                  </note> rem ullam ad me esse delatam. <milestone n="31" unit="chapter"/>
+               </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="86">
+               <p>
+                  <reg>quam</reg> ob rem vos, di patrii ac penates, qui huic urbi atque huic rei
+					publicae<note>rei p. <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>a</hi>: imperio <hi rend="italic">cett.</hi>
+                  </note>
 				praesidetis, qui hoc imperium, qui hanc libertatem, qui populum Romanum<note>qui
-					populum Rom. <hi rend="italic">TEa</hi>: populumque Rom. <hi rend="italic"
-						>cett.</hi></note>, qui haec tecta atque templa me consule vestro numine
+					populum Rom. <hi rend="italic">TEa</hi>: populumque Rom. <hi rend="italic">cett.</hi>
+                  </note>, qui haec tecta atque templa me consule vestro numine
 				auxilioque servastis, testor integro me animo ac libero P. Sullae causam defendere,
 				nullum a me sciente facinus occultari, nullum scelus susceptum contra salutem omnium
 				defendi ac tegi. <reg>nihil</reg> de hoc consul comperi, nihil suspicatus sum, nihil
-				audivi. </p></div>
-			<div type="textpart" subtype="section" n="87"><p><reg>itaque</reg> idem ego ille qui vehemens in alios<note>in alios <hi rend="italic">del. Madvig</hi></note>,qui inexorabilis in ceteros esse visus sum, persolvi patriae quod debui; reliqua
+				audivi. </p>
+            </div>
+            <div type="textpart" subtype="section" n="87">
+               <p>
+                  <reg>itaque</reg> idem ego ille qui vehemens in alios<note>in alios <hi rend="italic">del. Madvig</hi>
+                  </note>,qui inexorabilis in ceteros esse visus sum, persolvi patriae quod debui; reliqua
 				iam a me meae perpetuae consuetudini naturaeque debentur; tam sum misericors,
 				iudices, quam vos, tam mitis quam qui lenissimus; in quo vehemens fui vobiscum nihil
 				feci nisi coactus, rei publicae praecipitanti subveni, patriam demersam extuli;
-				misericordia civium adducti tum<note>tum <hi rend="italic">TE</hi>: tunc <hi
-						rend="italic">cett.</hi></note> fuimus tam vehementes quam necesse fuit.
-					<reg>salus</reg> esset amissa omnium<note>amissa omnium <hi rend="italic"
-						>TE</hi>: omnium amissa <hi rend="italic">cett.</hi></note> una nocte, nisi
+				misericordia civium adducti tum<note>tum <hi rend="italic">TE</hi>: tunc <hi rend="italic">cett.</hi>
+                  </note> fuimus tam vehementes quam necesse fuit.
+					<reg>salus</reg> esset amissa omnium<note>amissa omnium <hi rend="italic">TE</hi>: omnium amissa <hi rend="italic">cett.</hi>
+                  </note> una nocte, nisi
 				esset severitas illa suscepta. <reg>sed</reg> ut ad sceleratorum poenam amore rei
-				publicae sum adductus, sic ad salutem innocentium voluntate deducor<note>ducor <hi
-						rend="italic">T<foreign xml:lang="grc">p</foreign></hi>: adducor <hi
-						rend="italic">b2c</hi></note>. </p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="88"><p>
-			<reg>nihil</reg> video esse in hoc P. Sulla, iudices, odio dignum, misericordia digna
+				publicae sum adductus, sic ad salutem innocentium voluntate deducor<note>ducor <hi rend="italic">T<foreign xml:lang="grc">π</foreign>
+                     </hi>: adducor <hi rend="italic">b2c</hi>
+                  </note>. </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="88">
+               <p>
+                  <reg>nihil</reg> video esse in hoc P. Sulla, iudices, odio dignum, misericordia digna
 				multa. <reg>neque</reg> enim nunc propulsandae calamitatis suae causa supplex ad
 				vos, iudices, confugit, sed ne qua generi ac nomini suo nota nefariae turpitudinis
 				inuratur. <reg>nam</reg> ipse quidem, si erit vestro iudicio liberatus, quae habet
 				ornamenta, quae solacia reliquae vitae<note>reliqua vitae <hi rend="italic">E</hi>:
-					vitae reliqua <hi rend="italic">c</hi></note> quibus laetari ac<note>ac <hi
-						rend="italic">TE<foreign xml:lang="grc">p</foreign>k</hi>: et <hi
-						rend="italic">cett.</hi></note> perfrui possit? <reg>domus</reg> erit,
+					vitae reliqua <hi rend="italic">c</hi>
+                  </note> quibus laetari ac<note>ac <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>k</hi>: et <hi rend="italic">cett.</hi>
+                  </note> perfrui possit? <reg>domus</reg> erit,
 				credo, exornata, aperientur maiorum imagines, ipse ornatum ac vestitum
 					pristinum<note>pristinum <hi rend="italic">E</hi>: <hi rend="italic">om.
-						cett.</hi></note> recuperabit. <reg>omnia</reg>, iudices, haec amissa sunt,
+						cett.</hi>
+                  </note> recuperabit. <reg>omnia</reg>, iudices, haec amissa sunt,
 				omnia generis, nominis, honoris insignia atque ornamenta unius iudici calamitate
-					occiderunt<note>ceciderunt <hi rend="italic">bc1</hi></note>. <reg>sed</reg> ne
+					occiderunt<note>ceciderunt <hi rend="italic">bc1</hi>
+                  </note>. <reg>sed</reg> ne
 				exstinctor patriae, ne proditor, ne hostis appelletur, ne hanc labem tanti
-					sceleris<note>sceleris <hi rend="italic">TE</hi>: generis <hi rend="italic"
-						>cett.</hi></note> in familia relinquat, id laborat, id metuit, ne denique
+					sceleris<note>sceleris <hi rend="italic">TE</hi>: generis <hi rend="italic">cett.</hi>
+                  </note> in familia relinquat, id laborat, id metuit, ne denique
 				hic miser coniurati et conscelerati et proditoris filius nominetur; huic puero qui
-				est ei vita sua multo carior metuit<note>ne denique ... metuit <hi rend="italic"
-						>TE</hi>: <hi rend="italic">om. cett.</hi></note>, cui honoris integros
-				fructus non sit traditurus, ne aeternam memoriam dedecoris relinquat. </p></div>
-			<div type="textpart" subtype="section" n="89"><p>
-				<reg>hic</reg><note>hoc <hi rend="italic">T</hi> parvus
-						<hi rend="italic">TE<foreign xml:lang="grc">p</foreign>k</hi>: patruus <hi
-						rend="italic">cett.</hi></note> vos orat, iudices, parvus, ut se aliquando
-				si non integra fortuna, at ut<note>at ut <hi rend="italic">TE<foreign
-							xml:lang="grc">p</foreign></hi>: ut <hi rend="italic">apc</hi>: at (ac
-						<hi rend="italic">g</hi>) <hi rend="italic">cett.</hi></note> adflicta
+				est ei vita sua multo carior metuit<note>ne denique ... metuit <hi rend="italic">TE</hi>: <hi rend="italic">om. cett.</hi>
+                  </note>, cui honoris integros
+				fructus non sit traditurus, ne aeternam memoriam dedecoris relinquat. </p>
+            </div>
+            <div type="textpart" subtype="section" n="89">
+               <p>
+                  <reg>hic</reg>
+                  <note>hoc <hi rend="italic">T</hi> parvus
+						<hi rend="italic">TE<foreign xml:lang="grc">π</foreign>k</hi>: patruus <hi rend="italic">cett.</hi>
+                  </note> vos orat, iudices, parvus, ut se aliquando
+				si non integra fortuna, at ut<note>at ut <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: ut <hi rend="italic">apc</hi>: at (ac
+						<hi rend="italic">g</hi>) <hi rend="italic">cett.</hi>
+                  </note> adflicta
 				patri suo gratulari sinatis. <reg>huic</reg> misero notiora sunt itinera
-					iudiciorum<note>itinera iudic. <hi rend="italic">TE</hi>: iudic. itinera <hi
-						rend="italic">cett.</hi></note> et fori quam campi et<note>campi et <hi
-						rend="italic">E</hi>: et <hi rend="italic">T</hi>: <hi rend="italic">om.
-						cett.</hi></note> disciplinarum. <reg>non</reg> iam de vita P. Sullae,
+					iudiciorum<note>itinera iudic. <hi rend="italic">TE</hi>: iudic. itinera <hi rend="italic">cett.</hi>
+                  </note> et fori quam campi et<note>campi et <hi rend="italic">E</hi>: et <hi rend="italic">T</hi>: <hi rend="italic">om.
+						cett.</hi>
+                  </note> disciplinarum. <reg>non</reg> iam de vita P. Sullae,
 				iudices, sed de sepultura contenditur; vita erepta est superiore iudicio, nunc ne
 				corpus eiciatur laboramus. <reg>quid</reg> enim est huic reliqui quod eum in hac
-					vita<note>hac vita <hi rend="italic">TE<foreign xml:lang="grc"
-					>p</foreign></hi>: vita hac <hi rend="italic">cett.</hi></note> teneat, aut
-				quid est quam ob rem haec cuiquam vita videatur? <milestone n="32" unit="chapter"
-					/><reg>nuper</reg> is homo fuit in civitate P. Sulla ut nemo ei se neque honore
+					vita<note>hac vita <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: vita hac <hi rend="italic">cett.</hi>
+                  </note> teneat, aut
+				quid est quam ob rem haec cuiquam vita videatur? <milestone n="32" unit="chapter"/>
+                  <reg>nuper</reg> is homo fuit in civitate P. Sulla ut nemo ei se neque honore
 				neque gratia neque fortunis anteferret, nunc spoliatus omni dignitate quae erepta
 				sunt non repetit; quod fortuna in malis reliqui fecit, ut cum parente, cum liberis,
-				cum fratre, cum his necessariis lugere<note>lugere <hi rend="italic">TE<foreign
-							xml:lang="grc">p</foreign>ab1</hi>: iungere <hi rend="italic"
-						>cett.</hi></note> suam calamitatem liceat, id sibi ne eripiatis vos,
-				iudices, obtestatur. </p></div>
-			<div type="textpart" subtype="section" n="90"><p><reg>te</reg> ipsum iam,
-				Torquate, expletum huius<note><app><lem>huius</lem></app> his <foreign xml:lang="grc"
-						>S</foreign></note> miseriis esse<note>esse <hi rend="italic">TE<foreign
-							xml:lang="grc">p</foreign>a</hi>: <hi rend="italic">om.
-					cett.</hi></note> par erat<note>par erat <hi rend="italic">TE<foreign
-							xml:lang="grc">p</foreign></hi>: pateat <hi rend="italic"
-					>cett.</hi></note> et, si<note>et si <hi rend="italic"><foreign xml:lang="grc"
-							>p</foreign>a<foreign xml:lang="grc">Sy</foreign>, Müller</hi>: etsi <hi
-						rend="italic">cett.</hi></note> nihil aliud Sullae nisi consulatum
-				abstulissetis, tamen eo vos contentos<note>contentos vos <hi rend="italic"
-							>E<foreign xml:lang="grc">p</foreign></hi></note> esse oportebat;
+				cum fratre, cum his necessariis lugere<note>lugere <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>ab1</hi>: iungere <hi rend="italic">cett.</hi>
+                  </note> suam calamitatem liceat, id sibi ne eripiatis vos,
+				iudices, obtestatur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="90">
+               <p>
+                  <reg>te</reg> ipsum iam,
+				Torquate, expletum huius<note>
+                     <app>
+                        <lem>huius</lem>
+                     </app> his <foreign xml:lang="grc">ς</foreign>
+                  </note> miseriis esse<note>esse <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>a</hi>: <hi rend="italic">om.
+					cett.</hi>
+                  </note> par erat<note>par erat <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: pateat <hi rend="italic">cett.</hi>
+                  </note> et, si<note>et si <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>a<foreign xml:lang="grc">σψ</foreign>, Müller</hi>: etsi <hi rend="italic">cett.</hi>
+                  </note> nihil aliud Sullae nisi consulatum
+				abstulissetis, tamen eo vos contentos<note>contentos vos <hi rend="italic">E<foreign xml:lang="grc">π</foreign>
+                     </hi>
+                  </note> esse oportebat;
 				honoris enim contentio vos ad causam, non inimicitiae deduxerunt. <reg>sed</reg> cum
-				huic omnia cum honore detracta sint, cum in hac fortuna miserrima<note>miserrima <hi
-						rend="italic">TE</hi>: misera <hi rend="italic">cett.</hi></note> ac
-				luctuosissima destitutus sit<note><app><lem>sit</lem></app> est <hi rend="italic"
-					>E</hi></note>, quid est quod expetas<note>expetas <hi rend="italic">E</hi>:
-					expectas (-es <hi rend="italic"><foreign xml:lang="grc">p</foreign>c</hi>) <hi
-						rend="italic">cett.</hi></note> amplius? Lucisne hanc usuram eripere
-						vis<note><app><lem>vis</lem></app> eius <foreign xml:lang="grc">p</foreign>: <hi
-						rend="italic">fort.</hi> ei vis</note> plenam lacrimarum atque maeroris, in
-				qua cum maximo cruciatu ac<note>ac <hi rend="italic">TEb</hi>: atque <hi
-						rend="italic">cett.</hi></note> dolore retinetur? <reg>libenter</reg>
+				huic omnia cum honore detracta sint, cum in hac fortuna miserrima<note>miserrima <hi rend="italic">TE</hi>: misera <hi rend="italic">cett.</hi>
+                  </note> ac
+				luctuosissima destitutus sit<note>
+                     <app>
+                        <lem>sit</lem>
+                     </app> est <hi rend="italic">E</hi>
+                  </note>, quid est quod expetas<note>expetas <hi rend="italic">E</hi>:
+					expectas (-es <hi rend="italic">
+                        <foreign xml:lang="grc">π</foreign>c</hi>) <hi rend="italic">cett.</hi>
+                  </note> amplius? Lucisne hanc usuram eripere
+						vis<note>
+                     <app>
+                        <lem>vis</lem>
+                     </app> eius <foreign xml:lang="grc">π</foreign>: <hi rend="italic">fort.</hi> ei vis</note> plenam lacrimarum atque maeroris, in
+				qua cum maximo cruciatu ac<note>ac <hi rend="italic">TEb</hi>: atque <hi rend="italic">cett.</hi>
+                  </note> dolore retinetur? <reg>libenter</reg>
 				reddiderit adempta ignominia foedissimi criminis. <reg>an</reg> vero inimicum ut
 				expellas? cuius ex miseriis, si esses crudelissimus, videndo fructum caperes
-					maiorem<note>maiorem caperes <hi rend="italic">E</hi></note> quam audiendo.
-					</p></div>
-			<div type="textpart" subtype="section" n="91"><p>O miserum et infelicem illum diem quo consul
+					maiorem<note>maiorem caperes <hi rend="italic">E</hi>
+                  </note> quam audiendo.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="91">
+               <p>O miserum et infelicem illum diem quo consul
 				omnibus centuriis P. Sulla renuntiatus est, o falsam spem, o volucrem fortunam, o
 				caecam cupiditatem, o praeposteram gratulationem! <reg>quam</reg> cito illa omnia ex
-				laetitia et voluptate ad luctum et lacrimas recciderunt<note>recc. <hi
-						rend="italic">Zielinski</hi>: rec. <hi rend="italic">codd.</hi></note>,
+				laetitia et voluptate ad luctum et lacrimas recciderunt<note>recc. <hi rend="italic">Zielinski</hi>: rec. <hi rend="italic">codd.</hi>
+                  </note>,
 				ut, qui paulo ante consul designatus fuisset, repente nullum vestigium
 					retineret<note>retineret <hi rend="italic">hoc loco hab. TE, post</hi> fuisset
-						(<hi rend="italic">om.</hi> repente <hi rend="italic">a</hi>) <hi
-						rend="italic">cett.</hi></note> pristinae dignitatis! <reg>quid</reg> enim
-				erat mali quod huic spoliato fama, honore<note>fama honore <hi rend="italic"
-							>TE<foreign xml:lang="grc">p</foreign></hi>: honore fama <hi
-						rend="italic">cett.</hi></note>, fortunis deesse videretur? aut cui novae
-				calamitati locus ullus relictus<note><app><lem>relictus</lem></app> esset (est <hi
-						rend="italic">b1</hi>: esse <hi rend="italic">cod. H. Stephani</hi>) <hi
-						rend="italic">add. codd.</hi>: <hi rend="italic">ego delevi</hi></note>?
+						(<hi rend="italic">om.</hi> repente <hi rend="italic">a</hi>) <hi rend="italic">cett.</hi>
+                  </note> pristinae dignitatis! <reg>quid</reg> enim
+				erat mali quod huic spoliato fama, honore<note>fama honore <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: honore fama <hi rend="italic">cett.</hi>
+                  </note>, fortunis deesse videretur? aut cui novae
+				calamitati locus ullus relictus<note>
+                     <app>
+                        <lem>relictus</lem>
+                     </app> esset (est <hi rend="italic">b1</hi>: esse <hi rend="italic">cod. H. Stephani</hi>) <hi rend="italic">add. codd.</hi>: <hi rend="italic">ego delevi</hi>
+                  </note>?
 				Vrget eadem fortuna quae coepit, repperit novum maerorem, non patitur hominem
-				calamitosum uno malo<note>malo <hi rend="italic">TE</hi>: modo <hi rend="italic"
-						>cett.</hi></note> adflictum uno in luctu perire. <milestone n="33"
-					unit="chapter"/></p></div>
-				<milestone unit="para"/><div type="textpart" subtype="section" n="92"><p>
-			<reg>sed</reg> iam impedior egomet, iudices, dolore animi ne de huius miseria plura
-				dicam. <reg>vestrae</reg> sunt iam<note>sunt iam <hi rend="italic">TE<foreign
-							xml:lang="grc">p</foreign></hi>: iam sunt <hi rend="italic"
-					>cett.</hi></note> partes, iudices, in vestra mansuetudine atque humanitate
-				causam totam repono. <reg>vos</reg><note>vos <hi rend="italic">Schol.</hi>: vos ex
-						<hi rend="italic">TE</hi>: vos et (etiam <hi rend="italic">k</hi>) <hi
-						rend="italic">cett.</hi></note> reiectione interposita nihil suspicantibus
+				calamitosum uno malo<note>malo <hi rend="italic">TE</hi>: modo <hi rend="italic">cett.</hi>
+                  </note> adflictum uno in luctu perire. <milestone n="33" unit="chapter"/>
+               </p>
+            </div>
+            <milestone unit="para"/>
+            <div type="textpart" subtype="section" n="92">
+               <p>
+                  <reg>sed</reg> iam impedior egomet, iudices, dolore animi ne de huius miseria plura
+				dicam. <reg>vestrae</reg> sunt iam<note>sunt iam <hi rend="italic">TE<foreign xml:lang="grc">π</foreign>
+                     </hi>: iam sunt <hi rend="italic">cett.</hi>
+                  </note> partes, iudices, in vestra mansuetudine atque humanitate
+				causam totam repono. <reg>vos</reg>
+                  <note>vos <hi rend="italic">Schol.</hi>: vos ex
+						<hi rend="italic">TE</hi>: vos et (etiam <hi rend="italic">k</hi>) <hi rend="italic">cett.</hi>
+                  </note> reiectione interposita nihil suspicantibus
 				nobis repentini in nos iudices consedistis, ab accusatoribus delecti ad spem
 				acerbitatis, a fortuna nobis ad praesidium innocentiae constituti. Vt ego quid de me
 				populus Romanus existimaret, quia severus in improbos fueram, laboravi et, quae
 				prima innocentis mihi defensio est oblata, suscepi, sic vos severitatem iudiciorum
-				quae per hos mensis in homines audacissimos facta sunt<note>sunt <hi rend="italic"
-						>TE, Lambinus</hi>: est <hi rend="italic">cett.</hi></note> lenitate ac
-				misericordia mitigate.</p></div>
-			<div type="textpart" subtype="section" n="93"><p>
-				<reg>hoc</reg> cum a vobis impetrare<note>a vobis impetrare
-						<hi rend="italic">TE</hi>: impetrare a vobis <hi rend="italic"
-					>cett.</hi></note> causa ipsa<note>causa ipsa <hi rend="italic">TE</hi>: ipsa
-					causa <hi rend="italic">cett.</hi></note> debet, tum est vestri animi atque virtutis declarare non esse eos vos
+				quae per hos mensis in homines audacissimos facta sunt<note>sunt <hi rend="italic">TE, Lambinus</hi>: est <hi rend="italic">cett.</hi>
+                  </note> lenitate ac
+				misericordia mitigate.</p>
+            </div>
+            <div type="textpart" subtype="section" n="93">
+               <p>
+                  <reg>hoc</reg> cum a vobis impetrare<note>a vobis impetrare
+						<hi rend="italic">TE</hi>: impetrare a vobis <hi rend="italic">cett.</hi>
+                  </note> causa ipsa<note>causa ipsa <hi rend="italic">TE</hi>: ipsa
+					causa <hi rend="italic">cett.</hi>
+                  </note> debet, tum est vestri animi atque virtutis declarare non esse eos vos
 				ad quos potissimum interposita reiectione devenire convenerit. <reg>in</reg> quo ego
-				vos, iudices<note>vos iudices <hi rend="italic">TE</hi>: iudices vos <hi
-						rend="italic">cett</hi></note>, quantum meus in vos amor<note>in vos amor
-						<hi rend="italic">TE</hi>: amor in vos <hi rend="italic">cett.</hi></note>
+				vos, iudices<note>vos iudices <hi rend="italic">TE</hi>: iudices vos <hi rend="italic">cett</hi>
+                  </note>, quantum meus in vos amor<note>in vos amor
+						<hi rend="italic">TE</hi>: amor in vos <hi rend="italic">cett.</hi>
+                  </note>
 				postulat, tantum hortor ut communi studio, quoniam in re publica coniuncti sumus,
-				mansuetudine et misericordia nostra<note>nostra <hi rend="italic"><foreign
-							xml:lang="grc">S</foreign>k</hi>: vestra <hi rend="italic"
-					>cett.</hi></note> falsam a nobis<note>vobis <hi rend="italic"><foreign
-							xml:lang="grc">px</foreign>c2, ed. R</hi></note> crudelitatis famam
-				repellamus.</p></div>
-		</div>
-	</body></text>
+				mansuetudine et misericordia nostra<note>nostra <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>k</hi>: vestra <hi rend="italic">cett.</hi>
+                  </note> falsam a nobis<note>vobis <hi rend="italic">
+                        <foreign xml:lang="grc">πχ</foreign>c2, ed. R</hi>
+                  </note> crudelitatis famam
+				repellamus.</p>
+            </div>
+         </div>
+      </body>
+   </text>
 </TEI>

--- a/data/phi0474/phi016/phi0474.phi016.perseus-lat2.xml
+++ b/data/phi0474/phi016/phi0474.phi016.perseus-lat2.xml
@@ -1,67 +1,66 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-	<teiHeader xml:lang="eng">
-		<fileDesc>
-			<titleStmt>
-				<title>For Aulus Licinius Archias</title>
-				<title>Pro Tullio, Pro Fonteio, Pro Sulla, Pro Archia, Pro Plancio, Pro
+   <teiHeader xml:lang="eng">
+      <fileDesc>
+         <titleStmt>
+            <title>For Aulus Licinius Archias</title>
+            <title>Pro Tullio, Pro Fonteio, Pro Sulla, Pro Archia, Pro Plancio, Pro
 					Scauro</title>
-				<title type="sub">Machine readable text</title>
-				<author n="Cic.">M. Tullius Cicero</author>
-				<editor role="editor" n="OCT">Albert Clark</editor>
-				<sponsor>Perseus Project, Tufts University</sponsor>
-				<principal>Gregory Crane</principal>
-				<respStmt>
-					<resp>Prepared under the supervision of</resp>
-					<name>Bridget Almas</name>
-					<name>Lisa Cerrato</name>
-					<name>William Merrill</name>
-					<name>David Mimno</name>
-					<name>Rashmi Singhal</name>
-					<name>David Smith</name>
-				</respStmt>
-				<funder n="org:NEH">National Endowment For The Humanities (NEH)</funder> 
-			</titleStmt>
-			<publicationStmt>
-				<publisher>Trustees of Tufts University</publisher>
-				<pubPlace>Medford, MA</pubPlace>
-				<authority>Perseus Project</authority>
-				<date type="release">1997-10-28</date>
-			</publicationStmt> 
-			
-			<sourceDesc>
-				<biblStruct>
-					<monogr>
-						<author>M. Tullius Cicero</author>
-						<title>M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica
+            <title type="sub">Machine readable text</title>
+            <author n="Cic.">M. Tullius Cicero</author>
+            <editor role="editor" n="OCT">Albert Clark</editor>
+            <sponsor>Perseus Project, Tufts University</sponsor>
+            <principal>Gregory Crane</principal>
+            <respStmt>
+               <resp>Prepared under the supervision of</resp>
+               <name>Bridget Almas</name>
+               <name>Lisa Cerrato</name>
+               <name>William Merrill</name>
+               <name>David Mimno</name>
+               <name>Rashmi Singhal</name>
+               <name>David Smith</name>
+            </respStmt>
+            <funder n="org:NEH">National Endowment For The Humanities (NEH)</funder>
+         </titleStmt>
+         <publicationStmt>
+            <publisher>Trustees of Tufts University</publisher>
+            <pubPlace>Medford, MA</pubPlace>
+            <authority>Perseus Project</authority>
+            <date type="release">1997-10-28</date>
+         </publicationStmt>
+         <sourceDesc>
+            <biblStruct>
+               <monogr>
+                  <author>M. Tullius Cicero</author>
+                  <title>M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica
 							instruxit Albertus Curtis Clark</title>
-						<editor role="editor">Albert Clark</editor>
-						<imprint>
-							<pubPlace>Oxonii</pubPlace>
-							<publisher>e Typographeo Clarendoniano</publisher>
-							<date>1909</date>
-						</imprint>
-					</monogr>
-					<series>
-						<title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
-					</series>
-				</biblStruct>
-			</sourceDesc>
-		</fileDesc>
-		
-		<encodingDesc>
-			<refsDecl n="CTS">
-				<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
-					<p>This pointer pattern extracts section</p>
-				</cRefPattern>
-			</refsDecl>
-			<refsDecl>
-				<refState unit="section"/>
-			</refsDecl>
-		</encodingDesc>
-		
-		<!--<encodingDesc>
+                  <editor role="editor">Albert Clark</editor>
+                  <imprint>
+                     <pubPlace>Oxonii</pubPlace>
+                     <publisher>e Typographeo Clarendoniano</publisher>
+                     <date>1909</date>
+                  </imprint>
+               </monogr>
+               <series>
+                  <title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
+               </series>
+            </biblStruct>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <refsDecl n="CTS">
+            <cRefPattern n="section"
+                         matchPattern="(\w+)"
+                         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+               <p>This pointer pattern extracts section</p>
+            </cRefPattern>
+         </refsDecl>
+         <refsDecl>
+            <refState unit="section"/>
+         </refsDecl>
+      </encodingDesc>
+      <!--<encodingDesc>
 			<refsDecl>
 				<refState delim=" " unit="text"/>
 				<refState unit="section"/>
@@ -72,101 +71,148 @@
 				<refState unit="section"/>
 			</refsDecl>
 		</encodingDesc>-->
-		
-		<profileDesc>
-			<langUsage>
-				<language ident="lat">Latin</language>
-				<language ident="grc">Greek</language>
-			</langUsage>
-		</profileDesc>
-		
-		<revisionDesc>
-			<change when="2016-05-20" who="Lisa Cerrato">Minor changes merging new work. EpiDoc and CTS check.</change>
-			<change when="2016-03-16" who="Zach Himes">Changed section milestones to divs.</change>
-			<change when="2015-12-17" who="Zach Himes">Cleaned up teiHeader.</change>
-			<change when="2014-08-01" who="Stella Dee">edited markup</change>
-			<change when="2014-07-01" who="Stella Dee">split composite text and converted to unicode</change>
-			<change when="2013-09-13" who="balmas01">reverting texts back to pre_cts_reorg tagged version</change>
-			<change when="2011-07-19" who="gcrane">removed the earlier persName/placeName tags</change>
-			<change when="2011-01-15" who="gcrane">base SDL file</change>
-			<change when="2009-10-09" who="rsingh04">more reorganizing of texts module by collection</change>
-			<change when="2006-08-11" who="gcrane">small mods</change>
-			<change when="2006-04-21" who="gcrane">these now have the app crit entered as notes</change>
-			<change when="2005-08-01" who="packel">removed stray item tags</change>
-			<change when="2005-07-25" who="packel">Converted to XML</change>
-			<change when="2005-04-08" who="mimno">added default chunks</change>
-			<change when="2003-07-01" who="yorkc">Updated texts to TEI P4 and Perseus P4 extensions; minor cleanup (esp. character encodings and typos.)</change>
-			<change when="2002-12-02" who="amahoney">correct spelling of Quirites, improperly 'regularized'</change>
-			<change when="2000-03-04" who="dasmith">Added separate funder entity to TEI header.</change>
-			<change when="1999-10-14" who="dasmith">Added explanatory subtitles to titleStmt</change>
-			<change when="1999-08-12" who="dasmith">Fixed refsDecl</change>
-			<change when="1999-08-04" who="textgod">Random changes over a period of months.</change>
-			<change when="1997-10-17" who="textgod">Added CVS log.</change>
-			<change when="1997-03-26" who="DAS">ed.</change>
-		</revisionDesc>
-	</teiHeader>
-	
-	<text xml:lang="lat">
-		<body>
-			<div type="edition" xml:lang="lat" n="urn:cts:latinLit:phi0474.phi016.perseus-lat2" subtype="edition">
-			<head>PRO ARCHIA POETA ORATIO</head>
-			<milestone n="1" unit="chapter"/>
-			<div type="textpart" subtype="section" n="1"><p>
-			<milestone unit="para"/><reg>si</reg> quid est in me ingeni, iudices, quod<note>est ingenii in me quod <hi rend="italic">Quintil.</hi> xi. 1. 19, 3. 97</note> sentio quam sit
+      <profileDesc>
+         <langUsage>
+            <language ident="lat">Latin</language>
+            <language ident="grc">Greek</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2016-05-20" who="Lisa Cerrato">Minor changes merging new work. EpiDoc and CTS check.</change>
+         <change when="2016-03-16" who="Zach Himes">Changed section milestones to divs.</change>
+         <change when="2015-12-17" who="Zach Himes">Cleaned up teiHeader.</change>
+         <change when="2014-08-01" who="Stella Dee">edited markup</change>
+         <change when="2014-07-01" who="Stella Dee">split composite text and converted to unicode</change>
+         <change when="2013-09-13" who="balmas01">reverting texts back to pre_cts_reorg tagged version</change>
+         <change when="2011-07-19" who="gcrane">removed the earlier persName/placeName tags</change>
+         <change when="2011-01-15" who="gcrane">base SDL file</change>
+         <change when="2009-10-09" who="rsingh04">more reorganizing of texts module by collection</change>
+         <change when="2006-08-11" who="gcrane">small mods</change>
+         <change when="2006-04-21" who="gcrane">these now have the app crit entered as notes</change>
+         <change when="2005-08-01" who="packel">removed stray item tags</change>
+         <change when="2005-07-25" who="packel">Converted to XML</change>
+         <change when="2005-04-08" who="mimno">added default chunks</change>
+         <change when="2003-07-01" who="yorkc">Updated texts to TEI P4 and Perseus P4 extensions; minor cleanup (esp. character encodings and typos.)</change>
+         <change when="2002-12-02" who="amahoney">correct spelling of Quirites, improperly 'regularized'</change>
+         <change when="2000-03-04" who="dasmith">Added separate funder entity to TEI header.</change>
+         <change when="1999-10-14" who="dasmith">Added explanatory subtitles to titleStmt</change>
+         <change when="1999-08-12" who="dasmith">Fixed refsDecl</change>
+         <change when="1999-08-04" who="textgod">Random changes over a period of months.</change>
+         <change when="1997-10-17" who="textgod">Added CVS log.</change>
+         <change when="1997-03-26" who="DAS">ed.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text xml:lang="lat">
+      <body>
+         <div type="edition"
+              xml:lang="lat"
+              n="urn:cts:latinLit:phi0474.phi016.perseus-lat2"
+              subtype="edition">
+            <head>PRO ARCHIA POETA ORATIO</head>
+            <milestone n="1" unit="chapter"/>
+            <div type="textpart" subtype="section" n="1">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>si</reg> quid est in me ingeni, iudices, quod<note>est ingenii in me quod <hi rend="italic">Quintil.</hi> xi. 1. 19, 3. 97</note> sentio quam sit
 				exiguum, aut si qua exercitatio dicendi, in qua me non infitior mediocriter esse
-				versatum, aut si huiusce<note>huiuscemodi <hi rend="italic">ag</hi></note> rei
+				versatum, aut si huiusce<note>huiuscemodi <hi rend="italic">ag</hi>
+                  </note> rei
 				ratio aliqua ab optimarum artium studiis ac disciplina profecta, a qua ego nullum
 				confiteor aetatis meae tempus abhorruisse, earum rerum omnium vel in primis hic A.
-						Licinius<note><app><lem>Licinius</lem></app> Archia <hi rend="italic">add.
-					Ga</hi></note> fructum a me repetere<note>petere <hi rend="italic">E</hi></note> prope suo iure debet. <reg>nam</reg> quoad longissime potest mens
+						Licinius<note>
+                     <app>
+                        <lem>Licinius</lem>
+                     </app> Archia <hi rend="italic">add.
+					Ga</hi>
+                  </note> fructum a me repetere<note>petere <hi rend="italic">E</hi>
+                  </note> prope suo iure debet. <reg>nam</reg> quoad longissime potest mens
 				mea respicere spatium praeteriti temporis et pueritiae memoriam recordari ultimam,
 				inde usque repetens hunc video mihi principem et ad suscipiendam et ad ingrediendam
 				rationem horum studiorum exstitisse. <reg>quod</reg> si haec vox huius hortatu
 				praeceptisque conformata non nullis aliquando saluti fuit, a quo id accepimus quo
 				ceteris opitulari et alios servare possemus<note>possumus <hi rend="italic">GEe</hi> (<hi rend="italic">peiore numero</hi>)</note>, huic profecto
-				ipsi, quantum est situm in nobis, et opem et salutem ferre debemus. </p></div>
-			<div type="textpart" subtype="section" n="2"><p><reg>ac</reg> ne quis a nobis hoc ita dici forte miretur, quod
+				ipsi, quantum est situm in nobis, et opem et salutem ferre debemus. </p>
+            </div>
+            <div type="textpart" subtype="section" n="2">
+               <p>
+                  <reg>ac</reg> ne quis a nobis hoc ita dici forte miretur, quod
 				alia quaedam in hoc facultas sit ingeni neque haec dicendi ratio
-						aut<note><app><lem>aut</lem></app> ac <hi rend="italic"><foreign xml:lang="grc">S</foreign>b</hi></note> disciplina, ne<note>ne <hi rend="italic">GEeb</hi>: nec <hi rend="italic">cett.</hi></note> nos quidem huic
-					uni<note>huic uni <hi rend="italic">Lambinus</hi>: huic cuncti <hi rend="italic">codd.</hi>: huicce uni <hi rend="italic">Puteanus</hi></note> studio penitus umquam dediti fuimus. <reg>etenim</reg>
+						aut<note>
+                     <app>
+                        <lem>aut</lem>
+                     </app> ac <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>b</hi>
+                  </note> disciplina, ne<note>ne <hi rend="italic">GEeb</hi>: nec <hi rend="italic">cett.</hi>
+                  </note> nos quidem huic
+					uni<note>huic uni <hi rend="italic">Lambinus</hi>: huic cuncti <hi rend="italic">codd.</hi>: huicce uni <hi rend="italic">Puteanus</hi>
+                  </note> studio penitus umquam dediti fuimus. <reg>etenim</reg>
 				omnes artes quae ad humanitatem pertinent habent quoddam commune
-					vinclum<note>vinclum <hi rend="italic">G<foreign xml:lang="grc">S</foreign>gp</hi>: vinculum <hi rend="italic">cett.</hi></note> et quasi
-				cognatione quadam inter se continentur. </p></div><milestone n="2" unit="chapter"/>
-			<div type="textpart" subtype="section" n="3"><p><reg>sed</reg> ne cui vestrum mirum esse videatur, me in
-				quaestione legitima et in iudicio publico, cum res agatur<note>res agitatur <hi rend="italic">Schol.</hi></note> apud praetorem populi Romani,
-					lectissimum<note>rectissimum <hi rend="italic">Schol.</hi></note> virum, et
+					vinclum<note>vinclum <hi rend="italic">G<foreign xml:lang="grc">ς</foreign>gp</hi>: vinculum <hi rend="italic">cett.</hi>
+                  </note> et quasi
+				cognatione quadam inter se continentur. </p>
+            </div>
+            <milestone n="2" unit="chapter"/>
+            <div type="textpart" subtype="section" n="3">
+               <p>
+                  <reg>sed</reg> ne cui vestrum mirum esse videatur, me in
+				quaestione legitima et in iudicio publico, cum res agatur<note>res agitatur <hi rend="italic">Schol.</hi>
+                  </note> apud praetorem populi Romani,
+					lectissimum<note>rectissimum <hi rend="italic">Schol.</hi>
+                  </note> virum, et
 				apud severissimos iudices, tanto conventu hominum ac frequentia hoc uti genere
 				dicendi quod non modo a consuetudine iudiciorum verum etiam a forensi sermone
-				abhorreat, quaeso a vobis ut in hac<note>hac <hi rend="italic">om. e</hi></note>
+				abhorreat, quaeso a vobis ut in hac<note>hac <hi rend="italic">om. e</hi>
+                  </note>
 				causa mihi detis hanc veniam accommodatam huic reo, vobis, quem ad modum spero, non
 				molestam, ut me pro summo poeta atque eruditissimo homine dicentem hoc concursu
 				hominum litteratissimorum, hac vestra humanitate, hoc denique praetore exercente
 				iudicium, patiamini de studiis humanitatis ac litterarum paulo loqui liberius, et in
 				eius modi persona quae propter otium ac studium minime in iudiciis periculisque
-				tractata est uti prope novo quodam et inusitato genere dicendi. </p></div>
-			<div type="textpart" subtype="section" n="4"><p><reg>quod</reg> si mihi<note>mihi <hi rend="italic">om.
-					Ee</hi></note> a vobis tribui concedique sentiam, perficiam profecto ut hunc A.
+				tractata est uti prope novo quodam et inusitato genere dicendi. </p>
+            </div>
+            <div type="textpart" subtype="section" n="4">
+               <p>
+                  <reg>quod</reg> si mihi<note>mihi <hi rend="italic">om.
+					Ee</hi>
+                  </note> a vobis tribui concedique sentiam, perficiam profecto ut hunc A.
 				Licinium non modo non segregandum, cum sit civis, a numero civium verum etiam, si
 				non esset, putetis asciscendum fuisse. <milestone n="3" unit="chapter"/>
-			<milestone unit="para"/><reg>nam</reg> ut primum ex pueris excessit Archias atque ab eis<note>iis <foreign xml:lang="grc">s</foreign>: his <hi rend="italic">cett.</hi></note> artibus
+                  <milestone unit="para"/>
+                  <reg>nam</reg> ut primum ex pueris excessit Archias atque ab eis<note>iis <foreign xml:lang="grc">ς</foreign>: his <hi rend="italic">cett.</hi>
+                  </note> artibus
 				quibus aetas puerilis ad humanitatem informari solet, se ad scribendi studium
 				contulit, primum Antiochiae— nam ibi natus est loco nobili—celebri quondam
-					urbe<note>in urbe <hi rend="italic">Rinkes</hi></note> et copiosa atque
+					urbe<note>in urbe <hi rend="italic">Rinkes</hi>
+                  </note> et copiosa atque
 				eruditissimis hominibus liberalissimisque studiis adfluenti, celeriter antecellere
 				omnibus ingeni gloria coepit<note>coepit <hi rend="italic">Ernesti</hi>: contigit
-					(-ingit <hi rend="italic">e</hi>) <hi rend="italic">codd.</hi></note>.
+					(-ingit <hi rend="italic">e</hi>) <hi rend="italic">codd.</hi>
+                  </note>.
 					<reg>post</reg> in ceteris Asiae partibus cunctaque Graecia<note>cunctaeque
 					Graeciae <hi rend="italic">codd.</hi>: <hi rend="italic">corr.
-					Puteanus</hi></note> sic eius adventus celebrabantur<note>celebrabatur <hi rend="italic">ap2</hi>: celebrantur <hi rend="italic">Eeb</hi></note> ut
+					Puteanus</hi>
+                  </note> sic eius adventus celebrabantur<note>celebrabatur <hi rend="italic">ap2</hi>: celebrantur <hi rend="italic">Eeb</hi>
+                  </note> ut
 				famam ingeni exspectatio hominis, exspectationem ipsius adventus
-					admiratioque<note>admirationemque <hi rend="italic">GEe</hi></note> superaret.
-					</p></div>
-			<div type="textpart" subtype="section" n="5"><p><reg>erat</reg> Italia tum<note>tum <hi rend="italic">GEeb1g</hi>: tunc <hi rend="italic">cett.</hi></note> plena
+					admiratioque<note>admirationemque <hi rend="italic">GEe</hi>
+                  </note> superaret.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="5">
+               <p>
+                  <reg>erat</reg> Italia tum<note>tum <hi rend="italic">GEeb1g</hi>: tunc <hi rend="italic">cett.</hi>
+                  </note> plena
 				Graecarum artium ac disciplinarum, studiaque haec et in Latio vehementius tum
 				colebantur quam nunc isdem in oppidis, et hic Romae propter tranquillitatem rei
-					publicae<note>rei p. <hi rend="italic">b2, ed. R</hi>: populi R. <hi rend="italic">cett.</hi></note> non neglegebantur. <reg>itaque</reg>
-						hunc<note><app><lem>hunc</lem></app> unum <hi rend="italic">Schol.</hi></note> et
-				Tarentini <add>et Locrenses</add><note>et Locrenses <hi rend="italic">suppl.
+					publicae<note>rei p. <hi rend="italic">b2, ed. R</hi>: populi R. <hi rend="italic">cett.</hi>
+                  </note> non neglegebantur. <reg>itaque</reg>
+						hunc<note>
+                     <app>
+                        <lem>hunc</lem>
+                     </app> unum <hi rend="italic">Schol.</hi>
+                  </note> et
+				Tarentini <add>et Locrenses</add>
+                  <note>et Locrenses <hi rend="italic">suppl.
 						Luterbacher e</hi> § 10 (<hi rend="italic">om. Schol.</hi>)</note> et
 				Regini et Neapolitani civitate ceterisque praemiis donarunt, et omnes qui aliquid de
 				ingeniis poterant iudicare cognitione atque hospitio dignum existimarunt.
@@ -174,371 +220,729 @@
 				venit Mario consule et Catulo. <reg>nactus</reg> est primum consules eos quorum
 				alter res ad scribendum maximas, alter cum res gestas tum etiam studium atque auris
 				adhibere posset. <reg>statim</reg> Luculli, cum praetextatus etiam tum Archias
-				esset, eum domum<note>domum <hi rend="italic">Geab2</hi>: in domum <hi rend="italic">cett.</hi></note> suam receperunt. <reg>dedit</reg> etiam
-					hoc<note>dedit etiam hoc <hi rend="italic">scripsi</hi>: sed etiam (est <hi rend="italic">b2,</hi> et <foreign xml:lang="grc">s</foreign>) hoc <hi rend="italic">codd.</hi>: est iam hoc <hi rend="italic">Garatoni</hi>:
-					specimen etiam hoc <hi rend="italic">Madvig</hi></note> non solum
-					<add>lumen</add><note>lumen (<hi rend="italic">i. e.</hi> lum~) <hi rend="italic">supplevi</hi></note> ingeni ac litterarum verum etiam naturae
-				atque virtutis ut domus, quae huius adulescentiae prima favit<note>favit <hi rend="italic">Madvig</hi>: fuerit (fuit <hi rend="italic"><foreign xml:lang="grc">S</foreign>b1gp<foreign xml:lang="grc">s</foreign></hi>)
-						<hi rend="italic">codd.</hi>: faverit <hi rend="italic">Weiske</hi></note>, eadem esset familiarissima senectuti. </p></div>
-			<div type="textpart" subtype="section" n="6"><p><reg>erat</reg> temporibus illis iucundus Q. Metello illi
+				esset, eum domum<note>domum <hi rend="italic">Geab2</hi>: in domum <hi rend="italic">cett.</hi>
+                  </note> suam receperunt. <reg>dedit</reg> etiam
+					hoc<note>dedit etiam hoc <hi rend="italic">scripsi</hi>: sed etiam (est <hi rend="italic">b2,</hi> et <foreign xml:lang="grc">ς</foreign>) hoc <hi rend="italic">codd.</hi>: est iam hoc <hi rend="italic">Garatoni</hi>:
+					specimen etiam hoc <hi rend="italic">Madvig</hi>
+                  </note> non solum
+					<add>lumen</add>
+                  <note>lumen (<hi rend="italic">i. e.</hi> lum~) <hi rend="italic">supplevi</hi>
+                  </note> ingeni ac litterarum verum etiam naturae
+				atque virtutis ut domus, quae huius adulescentiae prima favit<note>favit <hi rend="italic">Madvig</hi>: fuerit (fuit <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>b1gp<foreign xml:lang="grc">ς</foreign>
+                     </hi>)
+						<hi rend="italic">codd.</hi>: faverit <hi rend="italic">Weiske</hi>
+                  </note>, eadem esset familiarissima senectuti. </p>
+            </div>
+            <div type="textpart" subtype="section" n="6">
+               <p>
+                  <reg>erat</reg> temporibus illis iucundus Q. Metello illi
 				Numidico et eius Pio<note>Pio eius <hi rend="italic">Lambinus</hi> (<hi rend="italic">contra Schol.</hi>)</note> filio, audiebatur a M. Aemilio,
 				vivebat cum Q. Catulo et patre et filio, a L. Crasso colebatur, Lucullos vero et
 				Drusum et Octavios et Catonem et totam Hortensiorum domum devinctam consuetudine cum
 				teneret, adficiebatur summo honore, quod eum non solum colebant qui aliquid
-				percipere atque audire studebant verum etiam si qui forte simulabant. <milestone n="4" unit="chapter"/><reg>interim</reg> satis longo<note>longo satis <hi rend="italic"><foreign xml:lang="grc">S</foreign>g</hi></note> intervallo,
-				cum esset cum M. Lucullo<note>M. <hi rend="italic">Schütz</hi>: L. <hi rend="italic">codd.</hi></note> in Siciliam profectus et cum<note><app><lem>et
-						cum</lem></app> et <hi rend="italic">Lag.</hi> 9</note> ex ea provincia cum
+				percipere atque audire studebant verum etiam si qui forte simulabant. <milestone n="4" unit="chapter"/>
+                  <reg>interim</reg> satis longo<note>longo satis <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>g</hi>
+                  </note> intervallo,
+				cum esset cum M. Lucullo<note>M. <hi rend="italic">Schütz</hi>: L. <hi rend="italic">codd.</hi>
+                  </note> in Siciliam profectus et cum<note>
+                     <app>
+                        <lem>et
+						cum</lem>
+                     </app> et <hi rend="italic">Lag.</hi> 9</note> ex ea provincia cum
 				eodem Lucullo decederet, venit Heracleam. <reg>quae</reg> cum esset civitas
 				aequissimo iure ac foedere, ascribi se in eam civitatem voluit idque, cum ipse per
 				se dignus putaretur, tum auctoritate et gratia Luculli ab Heracliensibus impetravit.
-					</p></div>
-			<div type="textpart" subtype="section" n="7"><p><reg>data</reg> est civitas
-					Silvani<note>Sillani (Sila-<hi rend="italic">G</hi>) <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Hotoman</hi></note> lege et Carbonis:
-						<quote><reg>si</reg> qui foederatis civitatibus ascripti fuissent, si tum
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="7">
+               <p>
+                  <reg>data</reg> est civitas
+					Silvani<note>Sillani (Sila-<hi rend="italic">G</hi>) <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Hotoman</hi>
+                  </note> lege et Carbonis:
+						<quote>
+                     <reg>si</reg> qui foederatis civitatibus ascripti fuissent, si tum
 					cum lex ferebatur in Italia domicilium habuissent et si sexaginta diebus apud
 					praetorem essent professi.</quote> Cum hic domicilium Romae multos iam annos
-				haberet, professus est apud praetorem </p></div>
-			<div type="textpart" subtype="section" n="8"><p>Q. Metellum,
+				haberet, professus est apud praetorem </p>
+            </div>
+            <div type="textpart" subtype="section" n="8">
+               <p>Q. Metellum,
 				familiarissimum suum. <reg>si</reg> nihil aliud nisi de civitate
-						ac<note><app><lem>ac</lem></app> hac <hi rend="italic">Puteanus</hi></note> lege
+						ac<note>
+                     <app>
+                        <lem>ac</lem>
+                     </app> hac <hi rend="italic">Puteanus</hi>
+                  </note> lege
 				dicimus, nihil dico amplius; causa dicta est. <reg>quid</reg> enim horum infirmari,
 					Gratti<note>Gratti <hi rend="italic">Bücheler</hi> (<hi rend="italic">ita</hi>
 					§ 12 <hi rend="italic">GEe</hi>): gratis (gracche <hi rend="italic">b2</hi>: a
-					gracchis <foreign xml:lang="grc">s</foreign>) <hi rend="italic">codd.</hi></note>, potest? Heracleaene esse tum<note><app><lem>tum</lem></app> tamen
-						<hi rend="italic">a</hi>: eum <hi rend="italic">c</hi>: civem eum <hi rend="italic">k</hi>: tu eum <hi rend="italic">Halm</hi></note> ascriptum
+					gracchis <foreign xml:lang="grc">ς</foreign>) <hi rend="italic">codd.</hi>
+                  </note>, potest? Heracleaene esse tum<note>
+                     <app>
+                        <lem>tum</lem>
+                     </app> tamen
+						<hi rend="italic">a</hi>: eum <hi rend="italic">c</hi>: civem eum <hi rend="italic">k</hi>: tu eum <hi rend="italic">Halm</hi>
+                  </note> ascriptum
 				negabis? <reg>adest</reg> vir summa auctoritate et religione et fide, M. Lucullus;
 				qui se non opinari sed scire, non audisse<note>audisse <hi rend="italic">GEe</hi>:
-					audivisse <hi rend="italic">cett.</hi></note> sed vidisse, non interfuisse sed
+					audivisse <hi rend="italic">cett.</hi>
+                  </note> sed vidisse, non interfuisse sed
 				egisse dicit. <reg>adsunt</reg> Heraclienses legati, nobilissimi homines,
 					huius<note>qui huius <hi rend="italic">Naugerius</hi> (2)</note> iudici causa
-				cum mandatis et cum publico testimonio venerunt<note>venerunt <hi rend="italic">del. Mommsen</hi></note>; qui hunc ascriptum Heracliae esse<note>Heracliae
-					esse <hi rend="italic">Lambinus</hi>: Heracliensem <hi rend="italic">codd.</hi></note> dicunt. <reg>hic</reg> tu tabulas<note>tabulas <hi rend="italic"><foreign xml:lang="grc">S</foreign>b1p, Schol.</hi>: tabellas
-						<hi rend="italic">cett.</hi></note> desideras<note>desideres <hi rend="italic">Schol.</hi></note> Heracliensium publicas<note>publicas <hi rend="italic">om. Schol.</hi></note>, quas Italico bello incenso tabulario
+				cum mandatis et cum publico testimonio venerunt<note>venerunt <hi rend="italic">del. Mommsen</hi>
+                  </note>; qui hunc ascriptum Heracliae esse<note>Heracliae
+					esse <hi rend="italic">Lambinus</hi>: Heracliensem <hi rend="italic">codd.</hi>
+                  </note> dicunt. <reg>hic</reg> tu tabulas<note>tabulas <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>b1p, Schol.</hi>: tabellas
+						<hi rend="italic">cett.</hi>
+                  </note> desideras<note>desideres <hi rend="italic">Schol.</hi>
+                  </note> Heracliensium publicas<note>publicas <hi rend="italic">om. Schol.</hi>
+                  </note>, quas Italico bello incenso tabulario
 				interisse scimus omnes? <reg>est</reg> ridiculum ad ea quae
-						habemus<note><app><lem>habemus</lem></app> videmus <hi rend="italic">G</hi></note>
+						habemus<note>
+                     <app>
+                        <lem>habemus</lem>
+                     </app> videmus <hi rend="italic">G</hi>
+                  </note>
 				nihil dicere, quaerere quae habere non possumus, et de hominum memoria tacere,
 				litterarum memoriam flagitare et, cum habeas amplissimi viri religionem, integerrimi
 				municipi ius iurandum fidemque, ea quae depravari nullo modo possunt repudiare,
-				tabulas quas idem dicis solere corrumpi desiderare. </p></div>
-			<div type="textpart" subtype="section" n="9"><p><reg>an</reg><note>an <hi rend="italic">GEe</hi>: at (ad <hi rend="italic">a</hi>) <hi rend="italic">cett.</hi></note> domicilium Romae non habuit is
-				qui tot annis <add>ante</add><note>ante <foreign xml:lang="grc">x</foreign>: <hi rend="italic">om. cett.</hi> civitatem datam <hi rend="italic">GEea</hi>:
-					civitate data (-am <hi rend="italic">p1</hi>) <hi rend="italic">cett.</hi></note> civitatem datam sedem omnium rerum ac fortunarum suarum Romae
-				conlocavit? <reg>an</reg><note>an <hi rend="italic">G1Eepk</hi>: at <hi rend="italic">cett.</hi></note> non est professus? <reg>immo</reg> vero
-					eis<note>iis <hi rend="italic">Manutius</hi>: his <hi rend="italic">codd.</hi></note> tabulis professus quae solae ex illa professione conlegioque
-				praetorum obtinent publicarum tabularum auctoritatem. <milestone n="5" unit="chapter"/><reg>nam</reg>, cum Appi tabulae neglegentius adservatae
-				dicerentur, Gabini<note>Gabini <hi rend="italic">GEe</hi>: Gabii <hi rend="italic">cett.</hi></note>, quam diu incolumis fuit, levitas, post damnationem
+				tabulas quas idem dicis solere corrumpi desiderare. </p>
+            </div>
+            <div type="textpart" subtype="section" n="9">
+               <p>
+                  <reg>an</reg>
+                  <note>an <hi rend="italic">GEe</hi>: at (ad <hi rend="italic">a</hi>) <hi rend="italic">cett.</hi>
+                  </note> domicilium Romae non habuit is
+				qui tot annis <add>ante</add>
+                  <note>ante <foreign xml:lang="grc">χ</foreign>: <hi rend="italic">om. cett.</hi> civitatem datam <hi rend="italic">GEea</hi>:
+					civitate data (-am <hi rend="italic">p1</hi>) <hi rend="italic">cett.</hi>
+                  </note> civitatem datam sedem omnium rerum ac fortunarum suarum Romae
+				conlocavit? <reg>an</reg>
+                  <note>an <hi rend="italic">G1Eepk</hi>: at <hi rend="italic">cett.</hi>
+                  </note> non est professus? <reg>immo</reg> vero
+					eis<note>iis <hi rend="italic">Manutius</hi>: his <hi rend="italic">codd.</hi>
+                  </note> tabulis professus quae solae ex illa professione conlegioque
+				praetorum obtinent publicarum tabularum auctoritatem. <milestone n="5" unit="chapter"/>
+                  <reg>nam</reg>, cum Appi tabulae neglegentius adservatae
+				dicerentur, Gabini<note>Gabini <hi rend="italic">GEe</hi>: Gabii <hi rend="italic">cett.</hi>
+                  </note>, quam diu incolumis fuit, levitas, post damnationem
 				calamitas omnem tabularum fidem resignasset, Metellus, homo sanctissimus
 				modestissimusque omnium, tanta diligentia fuit ut ad L. Lentulum praetorem et ad
 				iudices venerit et unius nominis litura se commotum esse dixerit. <reg>his</reg>
-				igitur <add>in</add><note>in <hi rend="italic">suppl. Eberhard</hi></note> tabulis
-				nullam lituram in nomine<note>nomine <hi rend="italic">e<foreign xml:lang="grc">S</foreign>bg<foreign xml:lang="grc">x2</foreign></hi>: nomen <hi rend="italic">cett.</hi></note> A. Licini videtis. </p></div>
-			<div type="textpart" subtype="section" n="10"><p><reg>quae</reg> cum ita sint, quid est quod de eius civitate
-					dubitetis<note>dubitatis <hi rend="italic">GEa</hi></note>, praesertim cum
-				aliis quoque in<note>in <hi rend="italic">om. <foreign xml:lang="grc">x1</foreign>,
-						del. Lambinus</hi></note> civitatibus fuerit ascriptus? <reg>etenim</reg>
-				cum mediocribus multis et<note>et <hi rend="italic">om. E<foreign xml:lang="grc">x</foreign></hi></note> aut nulla aut humili aliqua arte praeditis
-						gratuito<note><app><lem>gratuito</lem></app> gravat in (<hi rend="italic">sup.
+				igitur <add>in</add>
+                  <note>in <hi rend="italic">suppl. Eberhard</hi>
+                  </note> tabulis
+				nullam lituram in nomine<note>nomine <hi rend="italic">e<foreign xml:lang="grc">ς</foreign>bg<foreign xml:lang="grc">χ2</foreign>
+                     </hi>: nomen <hi rend="italic">cett.</hi>
+                  </note> A. Licini videtis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="10">
+               <p>
+                  <reg>quae</reg> cum ita sint, quid est quod de eius civitate
+					dubitetis<note>dubitatis <hi rend="italic">GEa</hi>
+                  </note>, praesertim cum
+				aliis quoque in<note>in <hi rend="italic">om. <foreign xml:lang="grc">χ1</foreign>,
+						del. Lambinus</hi>
+                  </note> civitatibus fuerit ascriptus? <reg>etenim</reg>
+				cum mediocribus multis et<note>et <hi rend="italic">om. E<foreign xml:lang="grc">χ</foreign>
+                     </hi>
+                  </note> aut nulla aut humili aliqua arte praeditis
+						gratuito<note>
+                     <app>
+                        <lem>gratuito</lem>
+                     </app> gravat in (<hi rend="italic">sup.
 						lin.</hi> vel gratuito) <hi rend="italic">G</hi>: vel gratuito gravat <hi rend="italic">Ee</hi>: haud gravatim <hi rend="italic">E.
-					Thomas</hi></note> civitatem in Graecia<note><app><lem>in Graecia</lem></app> Graii <hi rend="italic">Madvig</hi></note> homines impertiebant, Reginos credo aut
-				Locrensis aut Neapolitanos aut Tarentinos, quod scaenicis<note>scaen. <hi rend="italic">G2<foreign xml:lang="grc">s</foreign></hi>: scen. <hi rend="italic">cett.</hi></note> artificibus largiri solebant, id huic summa
-				ingeni praedito gloria noluisse<note>noluisse sed credendum est <hi rend="italic">Ee</hi></note>! <reg>quid</reg>? cum<note>cum <hi rend="italic">del.
-						Eberhard</hi></note> ceteri non modo post civitatem datam sed etiam post
+					Thomas</hi>
+                  </note> civitatem in Graecia<note>
+                     <app>
+                        <lem>in Graecia</lem>
+                     </app> Graii <hi rend="italic">Madvig</hi>
+                  </note> homines impertiebant, Reginos credo aut
+				Locrensis aut Neapolitanos aut Tarentinos, quod scaenicis<note>scaen. <hi rend="italic">G2<foreign xml:lang="grc">ς</foreign>
+                     </hi>: scen. <hi rend="italic">cett.</hi>
+                  </note> artificibus largiri solebant, id huic summa
+				ingeni praedito gloria noluisse<note>noluisse sed credendum est <hi rend="italic">Ee</hi>
+                  </note>! <reg>quid</reg>? cum<note>cum <hi rend="italic">del.
+						Eberhard</hi>
+                  </note> ceteri non modo post civitatem datam sed etiam post
 				legem Papiam aliquo modo in eorum municipiorum tabulas inrepserunt<note>irrepserint
-						<hi rend="italic">Manutius</hi></note>, hic qui ne<note>ne <hi rend="italic">c</hi>: nec (non <hi rend="italic">a</hi>) <hi rend="italic">cett.</hi></note> utitur quidem illis in quibus est scriptus,
-				quod semper se Heracliensem esse voluit, reicietur? </p></div>
-			<div type="textpart" subtype="section" n="11"><p><reg>census</reg> nostros requiris. <reg>scilicet</reg><note>requiris
-					scilicet.</note>; est<note>Est <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Manutius</hi></note> enim obscurum proximis censoribus hunc cum
+						<hi rend="italic">Manutius</hi>
+                  </note>, hic qui ne<note>ne <hi rend="italic">c</hi>: nec (non <hi rend="italic">a</hi>) <hi rend="italic">cett.</hi>
+                  </note> utitur quidem illis in quibus est scriptus,
+				quod semper se Heracliensem esse voluit, reicietur? </p>
+            </div>
+            <div type="textpart" subtype="section" n="11">
+               <p>
+                  <reg>census</reg> nostros requiris. <reg>scilicet</reg>
+                  <note>requiris
+					scilicet.</note>; est<note>Est <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Manutius</hi>
+                  </note> enim obscurum proximis censoribus hunc cum
 				clarissimo imperatore L. Lucullo apud exercitum fuisse, superioribus cum eodem
 				quaestore fuisse in Asia, primis Iulio et Crasso nullam populi partem esse
-					censam<note>censeam <hi rend="italic">GEea</hi></note>. <reg>sed</reg>, quoniam
+					censam<note>censeam <hi rend="italic">GEea</hi>
+                  </note>. <reg>sed</reg>, quoniam
 				census non ius civitatis confirmat ac tantum modo indicat eum qui sit census ita se
 				iam tum gessisse, pro cive<note>pro cive <hi rend="italic">del.
-				Richter</hi></note>, eis<note>iis <hi rend="italic">Manutius</hi>: his <hi rend="italic">codd.</hi> is <hi rend="italic">suppl. C. Fr.
-					Müller</hi></note> temporibus <add>is</add> quem<note>quem <hi rend="italic">Garatoni</hi>: quae (-e) <hi rend="italic">codd.</hi></note> tu criminaris
+				Richter</hi>
+                  </note>, eis<note>iis <hi rend="italic">Manutius</hi>: his <hi rend="italic">codd.</hi> is <hi rend="italic">suppl. C. Fr.
+					Müller</hi>
+                  </note> temporibus <add>is</add> quem<note>quem <hi rend="italic">Garatoni</hi>: quae (-e) <hi rend="italic">codd.</hi>
+                  </note> tu criminaris
 				ne ipsius quidem iudicio in civium Romanorum iure esse versatum et testamentum saepe
 				fecit nostris legibus, et adiit hereditates civium Romanorum, et in beneficiis ad
 				aerarium delatus est a L. Lucullo pro consule<note>pro consule <hi rend="italic">Graevius</hi>: praetore consule <hi rend="italic">E</hi>: praetore (p. r.
-						<hi rend="italic">Ge</hi>) et consule <hi rend="italic">cett.</hi></note>.
-					<milestone n="6" unit="chapter"/><reg>quaere</reg> argumenta, si quae<note>quae
-						<hi rend="italic">GEe</hi>: qua <hi rend="italic">cett.</hi></note> potes;
-				numquam enim hic<note>hic <hi rend="italic">om. Ea</hi></note> neque suo neque
-				amicorum iudicio revincetur<note>convincetur <hi rend="italic">Lambinus</hi></note>. </p></div>
-			<div type="textpart" subtype="section" n="12"><p>
-			<milestone unit="para"/><reg>quaeres</reg><note>quaeris <hi rend="italic">ab</hi></note> a nobis,
-					Gratti<note>Gratti <hi rend="italic">GEe</hi>: grachi <hi rend="italic">a</hi>: gracche (-ce <hi rend="italic"><foreign xml:lang="grc">S</foreign>bg</hi>) <hi rend="italic">cett.</hi></note>, cur tanto
-					opere<note>tanto opere <hi rend="italic">Ge</hi>: tantopere <hi rend="italic">cett.</hi></note> hoc homine<note>hoc nomine <hi rend="italic">E</hi></note> delectemur. <reg>quia</reg> suppeditat nobis ubi et animus
-					ex<note>et animus ex (<hi rend="italic">om.</hi> ex <foreign xml:lang="grc">x1</foreign>) <hi rend="italic">b2<foreign xml:lang="grc">x2</foreign></hi>: et (<hi rend="italic">om. ea</hi>) enim lex <hi rend="italic">GEeagp</hi>: et enim (<hi rend="italic">om.</hi> enim <hi rend="italic">k</hi>) vox <hi rend="italic">cett.</hi></note> hoc forensi
+						<hi rend="italic">Ge</hi>) et consule <hi rend="italic">cett.</hi>
+                  </note>.
+					<milestone n="6" unit="chapter"/>
+                  <reg>quaere</reg> argumenta, si quae<note>quae
+						<hi rend="italic">GEe</hi>: qua <hi rend="italic">cett.</hi>
+                  </note> potes;
+				numquam enim hic<note>hic <hi rend="italic">om. Ea</hi>
+                  </note> neque suo neque
+				amicorum iudicio revincetur<note>convincetur <hi rend="italic">Lambinus</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="12">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>quaeres</reg>
+                  <note>quaeris <hi rend="italic">ab</hi>
+                  </note> a nobis,
+					Gratti<note>Gratti <hi rend="italic">GEe</hi>: grachi <hi rend="italic">a</hi>: gracche (-ce <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>bg</hi>) <hi rend="italic">cett.</hi>
+                  </note>, cur tanto
+					opere<note>tanto opere <hi rend="italic">Ge</hi>: tantopere <hi rend="italic">cett.</hi>
+                  </note> hoc homine<note>hoc nomine <hi rend="italic">E</hi>
+                  </note> delectemur. <reg>quia</reg> suppeditat nobis ubi et animus
+					ex<note>et animus ex (<hi rend="italic">om.</hi> ex <foreign xml:lang="grc">χ1</foreign>) <hi rend="italic">b2<foreign xml:lang="grc">χ2</foreign>
+                     </hi>: et (<hi rend="italic">om. ea</hi>) enim lex <hi rend="italic">GEeagp</hi>: et enim (<hi rend="italic">om.</hi> enim <hi rend="italic">k</hi>) vox <hi rend="italic">cett.</hi>
+                  </note> hoc forensi
 				strepitu reficiatur et aures convicio defessae conquiescant. <reg>an</reg> tu
 				existimas aut suppetere nobis posse quod cotidie dicamus in tanta varietate rerum,
 				nisi animos nostros doctrina excolamus, aut ferre animos tantam posse contentionem,
 				nisi eos doctrina eadem relaxemus? <reg>ego</reg> vero fateor me his studiis esse
-				deditum. <reg>ceteros</reg> pudeat, si qui ita se<note>se ita <hi rend="italic"><foreign xml:lang="grc">S</foreign>bgp<foreign xml:lang="grc">s</foreign></hi></note> litteris abdiderunt ut nihil possint ex
-					eis<note>iis <hi rend="italic">c2, Madvig</hi>: his <hi rend="italic">cett.</hi></note> neque ad communem adferre fructum neque in aspectum
+				deditum. <reg>ceteros</reg> pudeat, si qui ita se<note>se ita <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>bgp<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> litteris abdiderunt ut nihil possint ex
+					eis<note>iis <hi rend="italic">c2, Madvig</hi>: his <hi rend="italic">cett.</hi>
+                  </note> neque ad communem adferre fructum neque in aspectum
 				lucemque proferre; me autem quid pudeat qui tot annos ita vivo, iudices, ut a
 				nullius umquam me tempore aut commodo aut otium meum abstraxerit aut voluptas
-					avocarit<note>avocaverit <hi rend="italic">G</hi></note> aut denique somnus
-				retardarit? </p></div>
-			<div type="textpart" subtype="section" n="13"><p><reg>qua</reg> re quis tandem me
+					avocarit<note>avocaverit <hi rend="italic">G</hi>
+                  </note> aut denique somnus
+				retardarit? </p>
+            </div>
+            <div type="textpart" subtype="section" n="13">
+               <p>
+                  <reg>qua</reg> re quis tandem me
 				reprehendat, aut quis mihi iure suscenseat, si, quantum ceteris ad suas res
 				obeundas, quantum ad festos dies ludorum celebrandos, quantum ad alias voluptates et
-				ad ipsam requiem animi et corporis conceditur temporum<note>temporis <hi rend="italic">b1</hi></note>, quantum alii tribuunt tempestivis conviviis,
-				quantum denique alveolo<note>alveolo <hi rend="italic">GEe</hi>: aleae <hi rend="italic">cett.</hi></note>, quantum pilae, tantum mihi egomet ad haec
-				studia recolenda sumpsero? <reg>atque</reg> id eo<note>id eo <hi rend="italic">Nauck</hi>: hoc adeo <hi rend="italic">GEea</hi>: hoc ideo <hi rend="italic">cett.</hi></note> mihi concedendum est magis quod ex his
+				ad ipsam requiem animi et corporis conceditur temporum<note>temporis <hi rend="italic">b1</hi>
+                  </note>, quantum alii tribuunt tempestivis conviviis,
+				quantum denique alveolo<note>alveolo <hi rend="italic">GEe</hi>: aleae <hi rend="italic">cett.</hi>
+                  </note>, quantum pilae, tantum mihi egomet ad haec
+				studia recolenda sumpsero? <reg>atque</reg> id eo<note>id eo <hi rend="italic">Nauck</hi>: hoc adeo <hi rend="italic">GEea</hi>: hoc ideo <hi rend="italic">cett.</hi>
+                  </note> mihi concedendum est magis quod ex his
 				studiis haec quoque crescit oratio et facultas quae, quantacumque
-					<add>est</add><note>est <hi rend="italic"><foreign xml:lang="grc">x</foreign>k</hi>: <hi rend="italic">om. cett.</hi> (<hi rend="italic">post</hi> me <hi rend="italic">suppl. Angelius</hi>)</note> in me, numquam
+					<add>est</add>
+                  <note>est <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>k</hi>: <hi rend="italic">om. cett.</hi> (<hi rend="italic">post</hi> me <hi rend="italic">suppl. Angelius</hi>)</note> in me, numquam
 				amicorum periculis defuit. <reg>quae</reg> si cui levior videtur, illa quidem certe
-				quae summa sunt ex quo fonte hauriam sentio. </p></div>
-			<div type="textpart" subtype="section" n="14"><p><reg>nam</reg> nisi multorum praeceptis multisque litteris mihi ab
+				quae summa sunt ex quo fonte hauriam sentio. </p>
+            </div>
+            <div type="textpart" subtype="section" n="14">
+               <p>
+                  <reg>nam</reg> nisi multorum praeceptis multisque litteris mihi ab
 				adulescentia suasissem nihil esse in vita magno opere expetendum nisi laudem atque
 				honestatem, in ea autem persequenda omnis cruciatus corporis, omnia pericula mortis
-				atque exsili<note>exilia <hi rend="italic">GEe</hi></note> parvi esse ducenda,
+				atque exsili<note>exilia <hi rend="italic">GEe</hi>
+                  </note> parvi esse ducenda,
 				numquam me pro salute vestra in tot ac tantas dimicationes atque in hos
-				profligatorum hominum cotidianos impetus obiecissem<note>coniecissem <hi rend="italic">Halm</hi></note>. <reg>sed</reg> pleni omnes sunt<note>sunt
-					omnes <hi rend="italic">Ee<foreign xml:lang="grc">x</foreign></hi> sapientium
-						<hi rend="italic">Gep</hi>: sapientum <hi rend="italic">cett.</hi></note>
+				profligatorum hominum cotidianos impetus obiecissem<note>coniecissem <hi rend="italic">Halm</hi>
+                  </note>. <reg>sed</reg> pleni omnes sunt<note>sunt
+					omnes <hi rend="italic">Ee<foreign xml:lang="grc">χ</foreign>
+                     </hi> sapientium
+						<hi rend="italic">Gep</hi>: sapientum <hi rend="italic">cett.</hi>
+                  </note>
 				libri, plenae sapientium voces, plena exemplorum vetustas; quae iacerent in tenebris
-				omnia, nisi litterarum lumen accederet<note>accenderet <hi rend="italic">Ee<foreign xml:lang="grc">xs</foreign></hi></note>. <reg>quam</reg> multas nobis
+				omnia, nisi litterarum lumen accederet<note>accenderet <hi rend="italic">Ee<foreign xml:lang="grc">χς</foreign>
+                     </hi>
+                  </note>. <reg>quam</reg> multas nobis
 				imagines non solum ad intuendum verum etiam ad imitandum fortissimorum virorum
 				expressas scriptores et Graeci et Latini reliquerunt! quas ego mihi semper in
 				administranda re publica proponens animum et mentem meam ipsa cogitatione hominum
-				excellentium conformabam. </p></div><milestone n="7" unit="chapter"/>
-			<div type="textpart" subtype="section" n="15"><p>
-			<milestone unit="para"/><reg>quaeret</reg> quispiam: 'quid? illi ipsi summi viri quorum virtutes litteris
+				excellentium conformabam. </p>
+            </div>
+            <milestone n="7" unit="chapter"/>
+            <div type="textpart" subtype="section" n="15">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>quaeret</reg> quispiam: 'quid? illi ipsi summi viri quorum virtutes litteris
 				proditae sunt istane doctrina quam tu effers laudibus eruditi fuerunt?'
 					<reg>difficile</reg> est hoc de omnibus confirmare, sed tamen est certum
-					quid<note>quod <hi rend="italic">GEea</hi></note> respondeam. <reg>ego</reg>
+					quid<note>quod <hi rend="italic">GEea</hi>
+                  </note> respondeam. <reg>ego</reg>
 				multos homines excellenti animo ac virtute fuisse sine doctrina, et<note>sine
 					doctrina et <hi rend="italic">Schütz</hi>: et (<hi rend="italic">om. p</hi>:
-					etiam <hi rend="italic">b<foreign xml:lang="grc">x1</foreign></hi>) sine
-					doctrina <hi rend="italic">codd.</hi></note> naturae ipsius habitu prope divino
+					etiam <hi rend="italic">b<foreign xml:lang="grc">χ1</foreign>
+                     </hi>) sine
+					doctrina <hi rend="italic">codd.</hi>
+                  </note> naturae ipsius habitu prope divino
 				per se ipsos et moderatos et gravis exstitisse fateor; etiam illud adiungo, saepius
-				ad laudem atque virtutem naturam sine doctrina<note>naturae ... doctrina <hi rend="italic">om. Ee</hi></note> quam sine natura valuisse doctrinam.
-					<reg>atque</reg> idem ego hoc<note>hoc <hi rend="italic">GEe</hi>: <hi rend="italic">om. cett.</hi></note> contendo, cum ad naturam eximiam
-					et<note>et <hi rend="italic">GEe</hi>: atque <hi rend="italic">cett.</hi></note> inlustrem accesserit ratio quaedam conformatioque<note>oratio
-						<hi rend="italic"><foreign xml:lang="grc">S</foreign>b1gp</hi> conformatio
-						<hi rend="italic">GE</hi>: confirmatio <hi rend="italic">cett.</hi></note>
+				ad laudem atque virtutem naturam sine doctrina<note>naturae ... doctrina <hi rend="italic">om. Ee</hi>
+                  </note> quam sine natura valuisse doctrinam.
+					<reg>atque</reg> idem ego hoc<note>hoc <hi rend="italic">GEe</hi>: <hi rend="italic">om. cett.</hi>
+                  </note> contendo, cum ad naturam eximiam
+					et<note>et <hi rend="italic">GEe</hi>: atque <hi rend="italic">cett.</hi>
+                  </note> inlustrem accesserit ratio quaedam conformatioque<note>oratio
+						<hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>b1gp</hi> conformatio
+						<hi rend="italic">GE</hi>: confirmatio <hi rend="italic">cett.</hi>
+                  </note>
 				doctrinae, tum illud nescio quid praeclarum ac singulare solere exsistere.
-					</p></div>
-			<div type="textpart" subtype="section" n="16"><p><reg>ex</reg> hoc esse<note>esse <hi rend="italic">om. e</hi></note> hunc<note><app><lem>hunc</lem></app> illum <hi rend="italic">Garatoni</hi></note> numero quem patres nostri viderunt,
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="16">
+               <p>
+                  <reg>ex</reg> hoc esse<note>esse <hi rend="italic">om. e</hi>
+                  </note> hunc<note>
+                     <app>
+                        <lem>hunc</lem>
+                     </app> illum <hi rend="italic">Garatoni</hi>
+                  </note> numero quem patres nostri viderunt,
 				divinum hominem, Africanum, ex hoc C. Laelium, L. Furium,
-					moderatissimos<note>modestissimos <hi rend="italic"><foreign xml:lang="grc">S</foreign>bg</hi></note> homines et continentissimos, ex hoc
-				fortissimum virum et illis temporibus doctissimum, <add>M.</add><note>M. <hi rend="italic">suppl. Manutius</hi></note> Catonem illum senem; qui profecto
+					moderatissimos<note>modestissimos <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>bg</hi>
+                  </note> homines et continentissimos, ex hoc
+				fortissimum virum et illis temporibus doctissimum, <add>M.</add>
+                  <note>M. <hi rend="italic">suppl. Manutius</hi>
+                  </note> Catonem illum senem; qui profecto
 				si nihil ad percipiendam colendamque<note>-que <hi rend="italic">om.
-					GEe</hi></note> virtutem litteris adiuvarentur, numquam se ad earum studium
+					GEe</hi>
+                  </note> virtutem litteris adiuvarentur, numquam se ad earum studium
 				contulissent. <reg>quod</reg> si non hic tantus fructus ostenderetur, et si ex his
 				studiis delectatio sola peteretur, tamen, ut opinor, hanc animi
 					remissionem<note>animadversionem (animi adv. <hi rend="italic">e</hi>) <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Bonamicus</hi> (<hi rend="italic">Muretus Var. Lect.</hi> xii. 15)</note> humanissimam ac
 				liberalissimam iudicaretis. <reg>nam</reg> ceterae neque temporum sunt neque aetatum
 				omnium neque locorum; at<note>at <hi rend="italic">GEe</hi>: <hi rend="italic">om.
-						cett.</hi></note> haec studia adulescentiam acuunt<note>acuunt <hi rend="italic">Gulielmius</hi>: agunt <hi rend="italic">codd.</hi>: alunt
-						<hi rend="italic">ed. Hervag.</hi></note>, senectutem oblectant, secundas
-				res ornant, adversis perfugium<note>profugium <hi rend="italic">Gap</hi></note> ac
+						cett.</hi>
+                  </note> haec studia adulescentiam acuunt<note>acuunt <hi rend="italic">Gulielmius</hi>: agunt <hi rend="italic">codd.</hi>: alunt
+						<hi rend="italic">ed. Hervag.</hi>
+                  </note>, senectutem oblectant, secundas
+				res ornant, adversis perfugium<note>profugium <hi rend="italic">Gap</hi>
+                  </note> ac
 				solacium praebent, delectant domi, non impediunt foris, pernoctant nobiscum,
-				peregrinantur, rusticantur. </p></div>
-			<div type="textpart" subtype="section" n="17"><p>
-			<milestone unit="para"/><reg>quod</reg> si ipsi haec neque attingere neque sensu nostro gustare possemus,
-				tamen ea mirari deberemus, etiam cum in aliis videremus. <milestone n="8" unit="chapter"/><reg>quis</reg> nostrum tam animo agresti<note>quis animo tam
-					agresti et <hi rend="italic">Schol.</hi></note> ac duro fuit ut Rosci morte
-				nuper non commoveretur<note>morte non moveretur <hi rend="italic">Schol.</hi></note>? qui cum esset senex mortuus, tamen propter excellentem
+				peregrinantur, rusticantur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="17">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>quod</reg> si ipsi haec neque attingere neque sensu nostro gustare possemus,
+				tamen ea mirari deberemus, etiam cum in aliis videremus. <milestone n="8" unit="chapter"/>
+                  <reg>quis</reg> nostrum tam animo agresti<note>quis animo tam
+					agresti et <hi rend="italic">Schol.</hi>
+                  </note> ac duro fuit ut Rosci morte
+				nuper non commoveretur<note>morte non moveretur <hi rend="italic">Schol.</hi>
+                  </note>? qui cum esset senex mortuus, tamen propter excellentem
 				artem ac venustatem videbatur omnino mori non debuisse. <reg>ergo</reg> ille
 				corporis motu tantum amorem sibi conciliarat a nobis omnibus;
-						nos<note><app><lem>nos</lem></app> hos <hi rend="italic">Ernesti</hi></note>
-				animorum incredibilis motus celeritatemque ingeniorum neglegemus<note>negligimus <hi rend="italic">a<foreign xml:lang="grc">S</foreign>gp</hi></note>?
-					</p></div>
-			<div type="textpart" subtype="section" n="18"><p><reg>quotiens</reg> ego hunc Archiam vidi,
+						nos<note>
+                     <app>
+                        <lem>nos</lem>
+                     </app> hos <hi rend="italic">Ernesti</hi>
+                  </note>
+				animorum incredibilis motus celeritatemque ingeniorum neglegemus<note>negligimus <hi rend="italic">a<foreign xml:lang="grc">ς</foreign>gp</hi>
+                  </note>?
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="18">
+               <p>
+                  <reg>quotiens</reg> ego hunc Archiam vidi,
 				iudices,—utar enim vestra benignitate, quoniam me in hoc novo genere dicendi tam
 				diligenter attenditis—quotiens ego hunc vidi, cum litteram scripsisset nullam,
-				magnum numerum optimorum versuum de eis<note>iis <hi rend="italic"><foreign xml:lang="grc">x</foreign>k, ed. V</hi>: his <hi rend="italic">cett.</hi></note> ipsis rebus quae tum agerentur<note>agebantur <hi rend="italic">b2</hi></note> dicere ex tempore, quotiens<note>quotiens ego
-						<hi rend="italic">G</hi></note> revocatum eandem rem dicere commutatis
+				magnum numerum optimorum versuum de eis<note>iis <hi rend="italic">
+                        <foreign xml:lang="grc">χ</foreign>k, ed. V</hi>: his <hi rend="italic">cett.</hi>
+                  </note> ipsis rebus quae tum agerentur<note>agebantur <hi rend="italic">b2</hi>
+                  </note> dicere ex tempore, quotiens<note>quotiens ego
+						<hi rend="italic">G</hi>
+                  </note> revocatum eandem rem dicere commutatis
 				verbis atque sententiis! <reg>quae</reg> vero accurate cogitateque scripsisset, ea
-				sic vidi probari ut ad veterum scriptorum laudem perveniret<note>perveniret <hi rend="italic">GEe</hi>: pervenirent <hi rend="italic">cett.</hi></note>.
+				sic vidi probari ut ad veterum scriptorum laudem perveniret<note>perveniret <hi rend="italic">GEe</hi>: pervenirent <hi rend="italic">cett.</hi>
+                  </note>.
 					<reg>hunc</reg> ego non diligam, non admirer, non omni ratione defendendum
-				putem? <reg>atque</reg><note>atque <hi rend="italic">GEe</hi>: atqui <hi rend="italic">cett.</hi></note> sic a summis hominibus eruditissimisque
-				accepimus, ceterarum rerum studia ex<note>ex <hi rend="italic">Müller</hi>: et <hi rend="italic">codd.</hi></note> doctrina et praeceptis et arte constare,
+				putem? <reg>atque</reg>
+                  <note>atque <hi rend="italic">GEe</hi>: atqui <hi rend="italic">cett.</hi>
+                  </note> sic a summis hominibus eruditissimisque
+				accepimus, ceterarum rerum studia ex<note>ex <hi rend="italic">Müller</hi>: et <hi rend="italic">codd.</hi>
+                  </note> doctrina et praeceptis et arte constare,
 				poetam natura ipsa valere et mentis viribus excitari et quasi divino quodam spiritu
-					inflari<note>inflammari <hi rend="italic">b2</hi>: afflari <hi rend="italic">ed. V</hi></note>. <reg>qua</reg> re suo iure noster ille Ennius 'sanctos'
+					inflari<note>inflammari <hi rend="italic">b2</hi>: afflari <hi rend="italic">ed. V</hi>
+                  </note>. <reg>qua</reg> re suo iure noster ille Ennius 'sanctos'
 				appellat poetas, quod quasi deorum aliquo dono atque munere
-					commendati<note>commodati <hi rend="italic">Gulielmius</hi></note> nobis esse
-					videantur<note>videntur <hi rend="italic">Ee</hi></note>. </p></div>
-			<div type="textpart" subtype="section" n="19"><p><reg>sit</reg> igitur, iudices, sanctum apud vos, humanissimos
+					commendati<note>commodati <hi rend="italic">Gulielmius</hi>
+                  </note> nobis esse
+					videantur<note>videntur <hi rend="italic">Ee</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="19">
+               <p>
+                  <reg>sit</reg> igitur, iudices, sanctum apud vos, humanissimos
 				homines, hoc poetae nomen quod nulla umquam barbaria violavit. Saxa atque<note>atque
 						<hi rend="italic">Quintil.</hi> (<hi rend="italic">quinque locis</hi>): et
-						<hi rend="italic">codd.</hi></note> solitudines voci<note>voci <hi rend="italic">Quintil.</hi>: voce <hi rend="italic">codd.</hi></note>
+						<hi rend="italic">codd.</hi>
+                  </note> solitudines voci<note>voci <hi rend="italic">Quintil.</hi>: voce <hi rend="italic">codd.</hi>
+                  </note>
 				respondent, bestiae saepe immanes cantu flectuntur atque consistunt; nos instituti
 				rebus optimis non poetarum voce moveamur? Homerum Colophonii civem esse dicunt suum,
-				Chii suum<note><app><lem>Chii suum</lem></app> Chii sibi <hi rend="italic">P.
-					Thomas</hi></note> vindicant, Salaminii repetunt, Smyrnaei vero suum esse
-				confirmant itaque etiam delubrum eius<note><app><lem>eius</lem></app> ei <hi rend="italic">Lambinus</hi></note> in oppido dedicaverunt, permulti alii praeterea
-				pugnant inter se atque contendunt. <milestone n="9" unit="chapter"/><reg>ergo</reg>
+				Chii suum<note>
+                     <app>
+                        <lem>Chii suum</lem>
+                     </app> Chii sibi <hi rend="italic">P.
+					Thomas</hi>
+                  </note> vindicant, Salaminii repetunt, Smyrnaei vero suum esse
+				confirmant itaque etiam delubrum eius<note>
+                     <app>
+                        <lem>eius</lem>
+                     </app> ei <hi rend="italic">Lambinus</hi>
+                  </note> in oppido dedicaverunt, permulti alii praeterea
+				pugnant inter se atque contendunt. <milestone n="9" unit="chapter"/>
+                  <reg>ergo</reg>
 				illi alienum, quia poeta fuit, post mortem etiam expetunt; nos hunc vivum qui
 					et<note>qui et <hi rend="italic">b2k</hi>: qui <hi rend="italic">ab1</hi>: et
-					qui <hi rend="italic">cett.</hi></note> voluntate et legibus noster est
+					qui <hi rend="italic">cett.</hi>
+                  </note> voluntate et legibus noster est
 					repudiamus<note>repudiabimus <hi rend="italic">Lag.</hi> 9, <hi rend="italic">Naugerius</hi> (1)</note>, praesertim cum omne olim studium atque omne
 				ingenium contulerit Archias ad populi Romani gloriam laudemque celebrandam?
 					<reg>nam</reg> et Cimbricas res adulescens attigit et ipsi illi C. Mario qui
-				durior ad haec studia videbatur iucundus fuit. </p></div>
-			<div type="textpart" subtype="section" n="20"><p><reg>neque</reg> enim quisquam est<note>est <hi rend="italic">om. e,
-						post</hi> enim <hi rend="italic">hab. <foreign xml:lang="grc">S</foreign>bg</hi></note> tam aversus a Musis qui non mandari versibus
+				durior ad haec studia videbatur iucundus fuit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="20">
+               <p>
+                  <reg>neque</reg> enim quisquam est<note>est <hi rend="italic">om. e,
+						post</hi> enim <hi rend="italic">hab. <foreign xml:lang="grc">ς</foreign>bg</hi>
+                  </note> tam aversus a Musis qui non mandari versibus
 				aeternum suorum laborum praeconium<note>praeconium facile <hi rend="italic">k,
 						Angelius</hi>: facile praeconium <hi rend="italic">cett.</hi> (<hi rend="italic">cf. Zielinski p.</hi> 204)</note> facile patiatur.
 				Themistoclem illum, summum Athenis virum, dixisse aiunt, cum ex eo quaereretur
-						quod<note><app><lem>quod</lem></app> qualia carmina quod <hi rend="italic">Ee</hi></note> acroama<note>ACROAMA <foreign xml:lang="grc">S</foreign>:
-						<foreign xml:lang="grc">a)kro/ama</foreign>
-					<hi rend="italic">b mg.</hi>: <hi rend="italic">om. p in lac.</hi></note> aut
+						quod<note>
+                     <app>
+                        <lem>quod</lem>
+                     </app> qualia carmina quod <hi rend="italic">Ee</hi>
+                  </note> acroama<note>ACROAMA <foreign xml:lang="grc">ς</foreign>:
+						<foreign xml:lang="grc">ἀκρόαμα</foreign>
+                     <hi rend="italic">b mg.</hi>: <hi rend="italic">om. p in lac.</hi>
+                  </note> aut
 				cuius vocem libentissime audiret: 'eius a quo sua virtus optime praedicaretur.'
-					<reg>itaque</reg> ille Marius item<note>item <hi rend="italic">om. <foreign xml:lang="grc">S</foreign>bg<foreign xml:lang="grc">s</foreign></hi></note> eximie L. Plotium dilexit, cuius ingenio putabat ea
-				quae gesserat posse celebrari. </p></div>
-			<div type="textpart" subtype="section" n="21"><p>Mithridaticum vero
+					<reg>itaque</reg> ille Marius item<note>item <hi rend="italic">om. <foreign xml:lang="grc">ς</foreign>bg<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> eximie L. Plotium dilexit, cuius ingenio putabat ea
+				quae gesserat posse celebrari. </p>
+            </div>
+            <div type="textpart" subtype="section" n="21">
+               <p>Mithridaticum vero
 				bellum magnum atque difficile et in multa varietate terra marique<note>mari terraque
-						<hi rend="italic">G</hi></note> versatum totum ab hoc expressum est; qui
+						<hi rend="italic">G</hi>
+                  </note> versatum totum ab hoc expressum est; qui
 				libri non modo L. Lucullum, fortissimum et clarissimum virum, verum etiam populi
 				Romani nomen inlustrant. <reg>populus</reg> enim Romanus aperuit Lucullo imperante
-				Pontum et regiis quondam opibus et ipsa natura et<note>natura et <hi rend="italic">Mommsen</hi>: naturae (-ra <hi rend="italic">eb<foreign xml:lang="grc">xs</foreign></hi>) <hi rend="italic">codd.</hi></note>
-					regione<note>regionis <hi rend="italic">b<foreign xml:lang="grc">xs</foreign></hi></note> vallatum, populi Romani exercitus eodem duce non
+				Pontum et regiis quondam opibus et ipsa natura et<note>natura et <hi rend="italic">Mommsen</hi>: naturae (-ra <hi rend="italic">eb<foreign xml:lang="grc">χς</foreign>
+                     </hi>) <hi rend="italic">codd.</hi>
+                  </note>
+					regione<note>regionis <hi rend="italic">b<foreign xml:lang="grc">χς</foreign>
+                     </hi>
+                  </note> vallatum, populi Romani exercitus eodem duce non
 				maxima manu innumerabilis Armeniorum copias fudit, populi Romani laus est urbem
-				amicissimam Cyzicenorum eiusdem consilio ex omni impetu regio atque<note>atque <hi rend="italic">GEeb</hi>: ac <hi rend="italic">cett.</hi>: atque e <hi rend="italic">Halm</hi></note> totius belli ore ac faucibus ereptam esse
+				amicissimam Cyzicenorum eiusdem consilio ex omni impetu regio atque<note>atque <hi rend="italic">GEeb</hi>: ac <hi rend="italic">cett.</hi>: atque e <hi rend="italic">Halm</hi>
+                  </note> totius belli ore ac faucibus ereptam esse
 				atque servatam; nostra semper feretur et praedicabitur L. Lucullo dimicante, cum
-				interfectis ducibus depressa hostium classis est<note>est <hi rend="italic">Heumann</hi>: et <hi rend="italic">codd.</hi></note>, incredibilis apud
+				interfectis ducibus depressa hostium classis est<note>est <hi rend="italic">Heumann</hi>: et <hi rend="italic">codd.</hi>
+                  </note>, incredibilis apud
 				Tenedum pugna illa navalis, nostra sunt tropaea, nostra monumenta, nostri triumphi.
-					<reg>quae</reg><note>quae <hi rend="italic">G1Ee</hi>: quia <hi rend="italic">cett.</hi> (<hi rend="italic">G2</hi>)</note> quorum ingeniis
-					efferuntur<note>efferuntur <hi rend="italic">Görenz</hi>: haec (hec <hi rend="italic">a<foreign xml:lang="grc">S</foreign>bg</hi>) feruntur <hi rend="italic">codd.</hi>: ecferuntur <hi rend="italic">Stürenberg</hi></note>, ab eis populi Romani fama celebratur. </p></div>
-			<div type="textpart" subtype="section" n="22"><p><reg>carus</reg> fuit Africano superiori noster Ennius, itaque
+					<reg>quae</reg>
+                  <note>quae <hi rend="italic">G1Ee</hi>: quia <hi rend="italic">cett.</hi> (<hi rend="italic">G2</hi>)</note> quorum ingeniis
+					efferuntur<note>efferuntur <hi rend="italic">Görenz</hi>: haec (hec <hi rend="italic">a<foreign xml:lang="grc">ς</foreign>bg</hi>) feruntur <hi rend="italic">codd.</hi>: ecferuntur <hi rend="italic">Stürenberg</hi>
+                  </note>, ab eis populi Romani fama celebratur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="22">
+               <p>
+                  <reg>carus</reg> fuit Africano superiori noster Ennius, itaque
 				etiam in sepulcro Scipionum putatur is esse constitutus ex marmore. <reg>at</reg>
 					eis<note>ex marmore. At iis <hi rend="italic">Fascitellus</hi>: et marmoratis
-						<hi rend="italic">codd.</hi>: ex marmore; cuius <hi rend="italic">Mommsen</hi></note> laudibus certe non solum ipse qui laudatur<note>ipse
-					... laudatur <hi rend="italic">GEeab2</hi>: ipsi ... laudantur (-atur <hi rend="italic">p</hi>) <hi rend="italic">cett.</hi></note> sed etiam populi
+						<hi rend="italic">codd.</hi>: ex marmore; cuius <hi rend="italic">Mommsen</hi>
+                  </note> laudibus certe non solum ipse qui laudatur<note>ipse
+					... laudatur <hi rend="italic">GEeab2</hi>: ipsi ... laudantur (-atur <hi rend="italic">p</hi>) <hi rend="italic">cett.</hi>
+                  </note> sed etiam populi
 				Romani nomen ornatur. <reg>in</reg> caelum huius proavus Cato tollitur; magnus honos
 				populi Romani rebus adiungitur. <reg>omnes</reg> denique illi <reg>maximi</reg>,
-				Marcelli, Fulvii non sine communi omnium nostrum laude decorantur. <milestone n="10" unit="chapter"/><reg>ergo</reg> illum qui haec fecerat, Rudinum<note>Rudinum <hi rend="italic">Schol., A. Augustinus</hi>: rudem tum (tu <hi rend="italic">Ee</hi>: tamen <hi rend="italic"><foreign xml:lang="grc">S</foreign>gp<foreign xml:lang="grc">s</foreign></hi>) <hi rend="italic">codd.</hi></note> hominem, maiores nostri in civitatem
-				receperunt; nos hunc Heracliensem multis<note>a multis <hi rend="italic">Lambinus</hi></note> civitatibus expetitum, in hac autem legibus
+				Marcelli, Fulvii non sine communi omnium nostrum laude decorantur. <milestone n="10" unit="chapter"/>
+                  <reg>ergo</reg> illum qui haec fecerat, Rudinum<note>Rudinum <hi rend="italic">Schol., A. Augustinus</hi>: rudem tum (tu <hi rend="italic">Ee</hi>: tamen <hi rend="italic">
+                        <foreign xml:lang="grc">ς</foreign>gp<foreign xml:lang="grc">ς</foreign>
+                     </hi>) <hi rend="italic">codd.</hi>
+                  </note> hominem, maiores nostri in civitatem
+				receperunt; nos hunc Heracliensem multis<note>a multis <hi rend="italic">Lambinus</hi>
+                  </note> civitatibus expetitum, in hac autem legibus
 				constitutum de nostra civitate eiciamus<note>eiciamus <hi rend="italic">G</hi>:
-					eiecimus <hi rend="italic">e</hi>: eiciemus <hi rend="italic">cett.</hi></note>? </p></div>
-			<div type="textpart" subtype="section" n="23"><p>
-			<milestone unit="para"/><reg>nam</reg> si quis minorem gloriae fructum putat ex Graecis versibus percipi quam
+					eiecimus <hi rend="italic">e</hi>: eiciemus <hi rend="italic">cett.</hi>
+                  </note>? </p>
+            </div>
+            <div type="textpart" subtype="section" n="23">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>nam</reg> si quis minorem gloriae fructum putat ex Graecis versibus percipi quam
 				ex Latinis, vehementer errat, propterea quod Graeca leguntur in omnibus fere
 				gentibus, Latina suis finibus exiguis sane continentur. <reg>qua</reg> re, si res
 				eae quas gessimus orbis terrae regionibus definiuntur, cupere debemus, quo hominum
-					nostrorum<note>hominum nostrorum <hi rend="italic">Bases</hi>: minus (<hi rend="italic">om. c2k, del. Madvig</hi>) manuum nostrarum <hi rend="italic">codd.</hi></note> tela pervenerint,
-						eodem<note><app><lem>eodem</lem></app> eandem <hi rend="italic">G</hi>: <hi rend="italic">om. e</hi></note> gloriam famamque penetrare, quod cum ipsis
-				populis de quorum rebus scribitur haec ampla sunt, tum eis<note>iis <foreign xml:lang="grc">xs</foreign>: his <hi rend="italic">cett.</hi></note> certe
+					nostrorum<note>hominum nostrorum <hi rend="italic">Bases</hi>: minus (<hi rend="italic">om. c2k, del. Madvig</hi>) manuum nostrarum <hi rend="italic">codd.</hi>
+                  </note> tela pervenerint,
+						eodem<note>
+                     <app>
+                        <lem>eodem</lem>
+                     </app> eandem <hi rend="italic">G</hi>: <hi rend="italic">om. e</hi>
+                  </note> gloriam famamque penetrare, quod cum ipsis
+				populis de quorum rebus scribitur haec ampla sunt, tum eis<note>iis <foreign xml:lang="grc">χς</foreign>: his <hi rend="italic">cett.</hi>
+                  </note> certe
 				qui de vita gloriae causa dimicant hoc maximum et periculorum incitamentum est et
-				laborum. </p></div>
-			<div type="textpart" subtype="section" n="24"><p><reg>quam</reg> multos scriptores rerum
+				laborum. </p>
+            </div>
+            <div type="textpart" subtype="section" n="24">
+               <p>
+                  <reg>quam</reg> multos scriptores rerum
 				suarum magnus ille Alexander secum habuisse dicitur! <reg>atque</reg> is tamen, cum
 				in Sigeo ad Achillis tumulum astitisset: 'o fortunate,' inquit, 'adulescens, qui
-				tuae virtutis Homerum praeconem inveneris<note>inveneris <hi rend="italic">eb<foreign xml:lang="grc">x</foreign>c</hi>: inveneras (-nisti <hi rend="italic">k</hi>) <hi rend="italic">cett.</hi></note>!' <reg>et</reg>
+				tuae virtutis Homerum praeconem inveneris<note>inveneris <hi rend="italic">eb<foreign xml:lang="grc">χ</foreign>c</hi>: inveneras (-nisti <hi rend="italic">k</hi>) <hi rend="italic">cett.</hi>
+                  </note>!' <reg>et</reg>
 				vere. <reg>nam</reg>, nisi Ilias<note>Ilias <hi rend="italic">Naugerius</hi> (2):
-					illi (illa <hi rend="italic">a</hi>: <hi rend="italic">om. E</hi>) ars <hi rend="italic">codd.</hi></note> illa exstitisset, idem tumulus qui corpus
+					illi (illa <hi rend="italic">a</hi>: <hi rend="italic">om. E</hi>) ars <hi rend="italic">codd.</hi>
+                  </note> illa exstitisset, idem tumulus qui corpus
 				eius contexerat nomen etiam obruisset. <reg>quid</reg>? noster hic Magnus qui cum
 				virtute fortunam adaequavit, nonne Theophanem Mytilenaeum, scriptorem rerum suarum,
 				in contione militum civitate donavit, et nostri illi fortes viri, sed rustici ac
 				milites, dulcedine quadam gloriae commoti quasi participes eiusdem laudis magno
-				illud clamore approbaverunt? </p></div>
-			<div type="textpart" subtype="section" n="25"><p><reg>itaque</reg>,
+				illud clamore approbaverunt? </p>
+            </div>
+            <div type="textpart" subtype="section" n="25">
+               <p>
+                  <reg>itaque</reg>,
 				credo, si civis Romanus Archias legibus non esset, ut ab aliquo imperatore civitate
 				donaretur perficere non potuit. Sulla cum Hispanos et Gallos donaret<note>donaret et
-					Gallos <hi rend="italic">E</hi></note>, credo, hunc petentem repudiasset; quem
-						nos<note><app><lem>nos</lem></app> in contione <hi rend="italic">add. codd. e
+					Gallos <hi rend="italic">E</hi>
+                  </note>, credo, hunc petentem repudiasset; quem
+						nos<note>
+                     <app>
+                        <lem>nos</lem>
+                     </app> in contione <hi rend="italic">add. codd. e
 						v.</hi> 18 (<hi rend="italic">malo numero</hi>): <hi rend="italic">ego
-						delevi</hi> videmus <hi rend="italic">GEea</hi></note> vidimus, cum ei
+						delevi</hi> videmus <hi rend="italic">GEea</hi>
+                  </note> vidimus, cum ei
 				libellum malus poeta de populo subiecisset, quod epigramma in eum fecisset tantum
-				modo alternis versibus longiusculis, statim ex eis<note>iis <hi rend="italic">Manutius</hi>: his <hi rend="italic">codd., Schol.</hi></note> rebus quas
+				modo alternis versibus longiusculis, statim ex eis<note>iis <hi rend="italic">Manutius</hi>: his <hi rend="italic">codd., Schol.</hi>
+                  </note> rebus quas
 					tum<note>tum <hi rend="italic">GEe</hi>: tamen <hi rend="italic">a</hi>: tunc
-						<hi rend="italic">cett.</hi>: <hi rend="italic">om. Schol.</hi></note>
-				vendebat iubere<note><app><lem>iubere</lem></app> iussit <hi rend="italic">a,
-					Schol.</hi></note> ei praemium tribui, sed<note>sed <hi rend="italic">Schol.</hi>: sub <hi rend="italic">codd.</hi></note> ea condicione ne quid
-				postea scriberet. <reg>qui</reg> sedulitatem mali poetae duxerit<note>deduxerit <hi rend="italic">GEe</hi></note> aliquo tamen praemio dignam, huius<note>huius
-						<foreign xml:lang="grc">s</foreign>: cuius <hi rend="italic">cett.</hi></note> ingenium et virtutem in scribendo et copiam
-						non<note><app><lem>non</lem></app> tamen non <hi rend="italic">Ee</hi></note>
-				expetisset? </p></div>
-			<div type="textpart" subtype="section" n="26"><p><reg>quid</reg>? a Q.
-						Metello<note><app><lem>Q.</lem></app> P. <hi rend="italic">Ee</hi></note> Pio,
+						<hi rend="italic">cett.</hi>: <hi rend="italic">om. Schol.</hi>
+                  </note>
+				vendebat iubere<note>
+                     <app>
+                        <lem>iubere</lem>
+                     </app> iussit <hi rend="italic">a,
+					Schol.</hi>
+                  </note> ei praemium tribui, sed<note>sed <hi rend="italic">Schol.</hi>: sub <hi rend="italic">codd.</hi>
+                  </note> ea condicione ne quid
+				postea scriberet. <reg>qui</reg> sedulitatem mali poetae duxerit<note>deduxerit <hi rend="italic">GEe</hi>
+                  </note> aliquo tamen praemio dignam, huius<note>huius
+						<foreign xml:lang="grc">ς</foreign>: cuius <hi rend="italic">cett.</hi>
+                  </note> ingenium et virtutem in scribendo et copiam
+						non<note>
+                     <app>
+                        <lem>non</lem>
+                     </app> tamen non <hi rend="italic">Ee</hi>
+                  </note>
+				expetisset? </p>
+            </div>
+            <div type="textpart" subtype="section" n="26">
+               <p>
+                  <reg>quid</reg>? a Q.
+						Metello<note>
+                     <app>
+                        <lem>Q.</lem>
+                     </app> P. <hi rend="italic">Ee</hi>
+                  </note> Pio,
 				familiarissimo suo, qui civitate multos donavit, neque per se neque per Lucullos
 				impetravisset? qui praesertim usque eo de suis rebus scribi cuperet ut etiam
 				Cordubae natis poetis pingue quiddam sonantibus atque peregrinum tamen auris suas
 					dederet<note>cederet <hi rend="italic">E2e</hi>: dederit <hi rend="italic">c,
-						Fleckeisen</hi></note>. <milestone n="11" unit="chapter"/><reg>neque</reg>
+						Fleckeisen</hi>
+                  </note>. <milestone n="11" unit="chapter"/>
+                  <reg>neque</reg>
 				enim est hoc dissimulandum quod obscurari non potest, sed prae nobis ferendum:
 				trahimur omnes studio laudis, et optimus quisque maxime gloria ducitur.
 					<reg>ipsi</reg> illi philosophi etiam in eis<note>in iis <hi rend="italic">Madvig</hi>: in his <hi rend="italic">Ammianus</hi> xxii. 7: illis (in
-					illis <hi rend="italic"><foreign xml:lang="grc">x2</foreign>k</hi>) <hi rend="italic">codd.</hi></note> libellis quos de contemnenda gloria
-				scribunt nomen suum inscribunt; in eo ipso in quo<note>ut in eo ipso quo <hi rend="italic">Ammianus</hi></note> praedicationem nobilitatemque despiciunt
-				praedicari de se<note><app><lem>de se</lem></app> se <hi rend="italic">Lambinus</hi></note> ac <add>se</add><note>se <hi rend="italic">Ammianus</hi>:
-						<hi rend="italic">om. codd.</hi></note> nominari volunt<note>velint <hi rend="italic">Ammianus</hi></note>. </p></div>
-			<div type="textpart" subtype="section" n="27"><p>Decimus quidem Brutus, summus vir et imperator, Acci, amicissimi sui, carminibus
-				templorum ac monumentorum<note>monu. <hi rend="italic">eabpc</hi>: moni. <hi rend="italic">cett.</hi></note> aditus exornavit suorum. <reg>iam</reg>
+					illis <hi rend="italic">
+                        <foreign xml:lang="grc">χ2</foreign>k</hi>) <hi rend="italic">codd.</hi>
+                  </note> libellis quos de contemnenda gloria
+				scribunt nomen suum inscribunt; in eo ipso in quo<note>ut in eo ipso quo <hi rend="italic">Ammianus</hi>
+                  </note> praedicationem nobilitatemque despiciunt
+				praedicari de se<note>
+                     <app>
+                        <lem>de se</lem>
+                     </app> se <hi rend="italic">Lambinus</hi>
+                  </note> ac <add>se</add>
+                  <note>se <hi rend="italic">Ammianus</hi>:
+						<hi rend="italic">om. codd.</hi>
+                  </note> nominari volunt<note>velint <hi rend="italic">Ammianus</hi>
+                  </note>. </p>
+            </div>
+            <div type="textpart" subtype="section" n="27">
+               <p>Decimus quidem Brutus, summus vir et imperator, Acci, amicissimi sui, carminibus
+				templorum ac monumentorum<note>monu. <hi rend="italic">eabpc</hi>: moni. <hi rend="italic">cett.</hi>
+                  </note> aditus exornavit suorum. <reg>iam</reg>
 				vero ille qui cum Aetolis Ennio comite bellavit Fulvius non dubitavit Martis
 				manubias Musis consecrare. <reg>qua</reg> re, in qua urbe imperatores prope armati
 				poetarum nomen et Musarum delubra coluerunt, in ea non debent togati<note>togati
-						<foreign xml:lang="grc">Sxs</foreign>, <hi rend="italic">p mg.</hi>: locati
-						<hi rend="italic">cett.</hi></note> iudices a Musarum honore et a poetarum
-				salute abhorrere. </p></div>
-			<div type="textpart" subtype="section" n="28"><p>
-			<milestone unit="para"/><reg>atque</reg> ut id libentius faciatis, iam me vobis, iudices, indicabo et de meo
+						<foreign xml:lang="grc">σχς</foreign>, <hi rend="italic">p mg.</hi>: locati
+						<hi rend="italic">cett.</hi>
+                  </note> iudices a Musarum honore et a poetarum
+				salute abhorrere. </p>
+            </div>
+            <div type="textpart" subtype="section" n="28">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>atque</reg> ut id libentius faciatis, iam me vobis, iudices, indicabo et de meo
 				quodam amore gloriae nimis acri fortasse, verum tamen honesto vobis confitebor.
 					<reg>nam</reg> quas res nos in consulatu nostro vobiscum simul pro salute huius
-					<add>urbis</add><note>huiusce <foreign xml:lang="grc">S</foreign> urbis <hi rend="italic">suppl. Naugerius</hi> (1)</note> atque<note>atque <hi rend="italic">E</hi>: aeque (<hi rend="italic">om. <foreign xml:lang="grc">S</foreign>k</hi>) <hi rend="italic">cett.</hi></note> imperi et pro
+					<add>urbis</add>
+                  <note>huiusce <foreign xml:lang="grc">ς</foreign> urbis <hi rend="italic">suppl. Naugerius</hi> (1)</note> atque<note>atque <hi rend="italic">E</hi>: aeque (<hi rend="italic">om. <foreign xml:lang="grc">ς</foreign>k</hi>) <hi rend="italic">cett.</hi>
+                  </note> imperi et pro
 				vita civium proque universa re publica gessimus, attigit hic versibus atque
 				inchoavit. <reg>quibus</reg> auditis, quod mihi magna res et iucunda visa est, hunc
 				ad perficiendum adornavi<note>adornavi <hi rend="italic">Klotz</hi>: adoravi <hi rend="italic">schol.</hi>: adortavi <hi rend="italic">Ge</hi>: adhortatus
-					sum <hi rend="italic">E</hi>: hortavi <hi rend="italic">a<foreign xml:lang="grc">S</foreign>b1gp</hi>: hortatus sum (fui <foreign xml:lang="grc">s</foreign>) <hi rend="italic">b2<foreign xml:lang="grc">xs</foreign></hi></note>. <reg>nullam</reg><note>nulla <hi rend="italic">codd</hi>: <hi rend="italic">corr. ed. V</hi></note> enim
+					sum <hi rend="italic">E</hi>: hortavi <hi rend="italic">a<foreign xml:lang="grc">ς</foreign>b1gp</hi>: hortatus sum (fui <foreign xml:lang="grc">ς</foreign>) <hi rend="italic">b2<foreign xml:lang="grc">χς</foreign>
+                     </hi>
+                  </note>. <reg>nullam</reg>
+                  <note>nulla <hi rend="italic">codd</hi>: <hi rend="italic">corr. ed. V</hi>
+                  </note> enim
 				virtus aliam mercedem laborum periculorumque desiderat praeter hanc laudis et
-				gloriae; qua quidem detracta, iudices<note><app><lem>iudices</lem></app> unum <hi rend="italic">G</hi></note>, quid est quod in hoc tam exiguo vitae
+				gloriae; qua quidem detracta, iudices<note>
+                     <app>
+                        <lem>iudices</lem>
+                     </app> unum <hi rend="italic">G</hi>
+                  </note>, quid est quod in hoc tam exiguo vitae
 				curriculo et tam brevi tantis nos in<note>in <hi rend="italic">om.</hi>
-					<foreign xml:lang="grc">x</foreign></note> laboribus exerceamus? </p></div>
-			<div type="textpart" subtype="section" n="29"><p><reg>certe</reg>, si nihil animus praesentiret in
-				posterum, et si, quibus regionibus vitae spatium circumscriptum est<note><app><lem>est
-						isdem</lem></app> iste isdem (in idem <hi rend="italic">a</hi>) <hi rend="italic">GEea</hi></note>, isdem omnis cogitationes terminaret suas,
+                     <foreign xml:lang="grc">χ</foreign>
+                  </note> laboribus exerceamus? </p>
+            </div>
+            <div type="textpart" subtype="section" n="29">
+               <p>
+                  <reg>certe</reg>, si nihil animus praesentiret in
+				posterum, et si, quibus regionibus vitae spatium circumscriptum est<note>
+                     <app>
+                        <lem>est
+						isdem</lem>
+                     </app> iste isdem (in idem <hi rend="italic">a</hi>) <hi rend="italic">GEea</hi>
+                  </note>, isdem omnis cogitationes terminaret suas,
 				nec tantis se laboribus frangeret neque tot curis vigiliisque angeretur nec totiens
 				de ipsa vita dimicaret. <reg>nunc</reg> insidet quaedam in optimo quoque virtus,
 				quae noctes ac dies animum gloriae stimulis concitat atque admonet non cum vitae
-				tempore esse dimittendam<note>dimetiendam <hi rend="italic">Manutius</hi></note>
-				commemorationem nominis nostri, sed cum omni posteritate adaequandam. </p></div><milestone n="12" unit="chapter"/>
-			<div type="textpart" subtype="section" n="30"><p><reg>an</reg> vero tam
-					parvi<note>pravi <hi rend="italic">Ee</hi></note> animi videamur esse<note>esse
-						<hi rend="italic">om. E</hi></note> omnes qui in re publica atque in his
+				tempore esse dimittendam<note>dimetiendam <hi rend="italic">Manutius</hi>
+                  </note>
+				commemorationem nominis nostri, sed cum omni posteritate adaequandam. </p>
+            </div>
+            <milestone n="12" unit="chapter"/>
+            <div type="textpart" subtype="section" n="30">
+               <p>
+                  <reg>an</reg> vero tam
+					parvi<note>pravi <hi rend="italic">Ee</hi>
+                  </note> animi videamur esse<note>esse
+						<hi rend="italic">om. E</hi>
+                  </note> omnes qui in re publica atque in his
 				vitae periculis laboribusque versamur ut, cum usque ad extremum spatium nullum
 				tranquillum atque otiosum spiritum duxerimus, nobiscum simul moritura omnia
-				arbitremur? <reg>an</reg><note><app><lem>an</lem></app> an cum <hi rend="italic">b2<foreign xml:lang="grc">x</foreign></hi></note> statuas et imagines,
+				arbitremur? <reg>an</reg>
+                  <note>
+                     <app>
+                        <lem>an</lem>
+                     </app> an cum <hi rend="italic">b2<foreign xml:lang="grc">χ</foreign>
+                     </hi>
+                  </note> statuas et imagines,
 				non animorum simulacra, sed corporum, studiose multi summi homines
-					reliquerunt<note>reliquerint <hi rend="italic">Manutius</hi></note>;
+					reliquerunt<note>reliquerint <hi rend="italic">Manutius</hi>
+                  </note>;
 				consiliorum relinquere ac virtutum nostrarum effigiem
-						nonne<note><app><lem>nonne</lem></app> non <hi rend="italic">Lambinus</hi></note>
+						nonne<note>
+                     <app>
+                        <lem>nonne</lem>
+                     </app> non <hi rend="italic">Lambinus</hi>
+                  </note>
 				multo malle debemus summis ingeniis expressam et politam? <reg>ego</reg> vero omnia
 				quae gerebam iam tum in gerendo spargere me ac disseminare arbitrabar in orbis
-				terrae memoriam sempiternam. <reg>haec</reg> vero sive<note>sive <hi rend="italic">om. GEea</hi></note> a meo sensu post mortem afutura<note>afut. <hi rend="italic">G</hi>: abfut. (affut. <hi rend="italic">Ee</hi>) <hi rend="italic">cett.</hi></note> est<note>est <hi rend="italic">GEea</hi>:
-					sunt <hi rend="italic">cett.</hi></note>, sive, ut sapientissimi homines
+				terrae memoriam sempiternam. <reg>haec</reg> vero sive<note>sive <hi rend="italic">om. GEea</hi>
+                  </note> a meo sensu post mortem afutura<note>afut. <hi rend="italic">G</hi>: abfut. (affut. <hi rend="italic">Ee</hi>) <hi rend="italic">cett.</hi>
+                  </note> est<note>est <hi rend="italic">GEea</hi>:
+					sunt <hi rend="italic">cett.</hi>
+                  </note>, sive, ut sapientissimi homines
 				putaverunt, ad aliquam animi<note>animi <hi rend="italic">om. cod.
-					Vrsini</hi></note> mei partem pertinebit<note>pertinebunt <hi rend="italic">bp2<foreign xml:lang="grc">xs</foreign></hi></note>, nunc quidem certe
-				cogitatione quadam speque delector. </p></div>
-			<div type="textpart" subtype="section" n="31"><p>
-			<milestone unit="para"/><reg>qua</reg> re conservate, iudices, hominem pudore eo quem amicorum videtis
-				comprobari cum dignitate, tum etiam vetustate<note>venustate <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Muretus</hi></note>, ingenio autem
-				tanto quantum<note>quantum <foreign xml:lang="grc">S</foreign>
-					<hi rend="italic">mg., <foreign xml:lang="grc">s</foreign>, Sylvius</hi>:
-					quanto <hi rend="italic">cett.</hi></note> id convenit existimari, quod
-				summorum hominum iudiciis<note>iudiciis <hi rend="italic">Madvig</hi>: ingeniis <hi rend="italic">codd.</hi></note> expetitum esse videatis, causa vero
-					eius<note>huius <hi rend="italic">E</hi></note> modi quae beneficio legis,
+					Vrsini</hi>
+                  </note> mei partem pertinebit<note>pertinebunt <hi rend="italic">bp2<foreign xml:lang="grc">χς</foreign>
+                     </hi>
+                  </note>, nunc quidem certe
+				cogitatione quadam speque delector. </p>
+            </div>
+            <div type="textpart" subtype="section" n="31">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>qua</reg> re conservate, iudices, hominem pudore eo quem amicorum videtis
+				comprobari cum dignitate, tum etiam vetustate<note>venustate <hi rend="italic">codd.</hi>: <hi rend="italic">corr. Muretus</hi>
+                  </note>, ingenio autem
+				tanto quantum<note>quantum <foreign xml:lang="grc">ς</foreign>
+                     <hi rend="italic">mg., <foreign xml:lang="grc">ς</foreign>, Sylvius</hi>:
+					quanto <hi rend="italic">cett.</hi>
+                  </note> id convenit existimari, quod
+				summorum hominum iudiciis<note>iudiciis <hi rend="italic">Madvig</hi>: ingeniis <hi rend="italic">codd.</hi>
+                  </note> expetitum esse videatis, causa vero
+					eius<note>huius <hi rend="italic">E</hi>
+                  </note> modi quae beneficio legis,
 				auctoritate municipi, testimonio Luculli, tabulis Metelli comprobetur.
 					<reg>quae</reg> cum ita sint, petimus<note>petimus <hi rend="italic">om.
-					G</hi></note> a vobis, iudices, si qua non modo humana verum etiam divina in
-				tantis ingeniis<note>ingeniis <hi rend="italic">GEe</hi>: negotiis <hi rend="italic">cett.</hi></note> commendatio debet esse, ut eum qui vos, qui
+					G</hi>
+                  </note> a vobis, iudices, si qua non modo humana verum etiam divina in
+				tantis ingeniis<note>ingeniis <hi rend="italic">GEe</hi>: negotiis <hi rend="italic">cett.</hi>
+                  </note> commendatio debet esse, ut eum qui vos, qui
 				vestros imperatores, qui populi Romani<note>Romani <hi rend="italic">om.
-					G</hi></note> res gestas semper ornavit, qui etiam his recentibus nostris
-				vestrisque domesticis periculis aeternum se testimonium laudis<note>laudis <hi rend="italic">GEea<foreign xml:lang="grc">x2</foreign></hi>: laudum <hi rend="italic">cett.</hi></note> daturum esse profitetur, quique est
-					<add>ex</add><note>quique est ex <hi rend="italic">scripsi</hi>: quique est <hi rend="italic">k, Angelius</hi>: isque est <hi rend="italic">cett.</hi>:
-					estque ex <hi rend="italic">Madvig</hi></note> eo numero qui semper apud omnis
-				sancti sunt habiti itaque<note><app><lem>itaque</lem></app> atque <hi rend="italic">Ek</hi></note> dicti, sic in vestram accipiatis fidem ut humanitate vestra
-				levatus potius quam acerbitate violatus esse videatur. </p></div>
-			<div type="textpart" subtype="section" n="32"><p>
-			<milestone unit="para"/><reg>quae</reg> de causa pro mea consuetudine breviter simpliciterque dixi, iudices,
+					G</hi>
+                  </note> res gestas semper ornavit, qui etiam his recentibus nostris
+				vestrisque domesticis periculis aeternum se testimonium laudis<note>laudis <hi rend="italic">GEea<foreign xml:lang="grc">χ2</foreign>
+                     </hi>: laudum <hi rend="italic">cett.</hi>
+                  </note> daturum esse profitetur, quique est
+					<add>ex</add>
+                  <note>quique est ex <hi rend="italic">scripsi</hi>: quique est <hi rend="italic">k, Angelius</hi>: isque est <hi rend="italic">cett.</hi>:
+					estque ex <hi rend="italic">Madvig</hi>
+                  </note> eo numero qui semper apud omnis
+				sancti sunt habiti itaque<note>
+                     <app>
+                        <lem>itaque</lem>
+                     </app> atque <hi rend="italic">Ek</hi>
+                  </note> dicti, sic in vestram accipiatis fidem ut humanitate vestra
+				levatus potius quam acerbitate violatus esse videatur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="32">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>quae</reg> de causa pro mea consuetudine breviter simpliciterque dixi, iudices,
 				ea confido probata esse omnibus; quae a foro aliena<note>a foro aliena <hi rend="italic">Garatoni</hi>: firme (fer-<hi rend="italic">ak</hi>) a me
 						<hi rend="italic">codd.</hi>: forensi aliena <hi rend="italic">Halm</hi>
-						(<hi rend="italic">cf.</hi> § 3)</note> iudicialique<note>iudiciali (<hi rend="italic">sine</hi> -que) <hi rend="italic">ek</hi></note>
+						(<hi rend="italic">cf.</hi> § 3)</note> iudicialique<note>iudiciali (<hi rend="italic">sine</hi> -que) <hi rend="italic">ek</hi>
+                  </note>
 				consuetudine et de hominis ingenio et communiter de ipso<note>de ipso <hi rend="italic">ed. V</hi>: de ipsius <hi rend="italic">codd.</hi>: de meo
-					atque ipsius <hi rend="italic">Lambinus</hi></note> studio locutus sum, ea,
+					atque ipsius <hi rend="italic">Lambinus</hi>
+                  </note> studio locutus sum, ea,
 				iudices, a vobis spero esse in bonam partem accepta, ab eo qui iudicium exercet
-					certo<note>certo <hi rend="italic">G</hi>: certe <hi rend="italic">cett.</hi></note> scio.</p></div>
-		</div>
-	</body></text>
+					certo<note>certo <hi rend="italic">G</hi>: certe <hi rend="italic">cett.</hi>
+                  </note> scio.</p>
+            </div>
+         </div>
+      </body>
+   </text>
 </TEI>

--- a/data/phi0474/phi019/phi0474.phi019.perseus-lat2.xml
+++ b/data/phi0474/phi019/phi0474.phi019.perseus-lat2.xml
@@ -1,68 +1,66 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-	<teiHeader xml:lang="eng">
-		<fileDesc>
-			<titleStmt>
-				<title>In the Senate after his Return</title>
-				<title>Cum Senatui gratias egit, Cum populo gratias egit, De domo sua, De haruspicum
+   <teiHeader xml:lang="eng">
+      <fileDesc>
+         <titleStmt>
+            <title>In the Senate after his Return</title>
+            <title>Cum Senatui gratias egit, Cum populo gratias egit, De domo sua, De haruspicum
 					responso, Pro Sestio, In Vatinium, De provinciis consularibus, Pro Balbo</title>
-				<title type="sub">Machine readable text</title>
-				<author n="Cic.">M. Tullius Cicero</author>
-				<editor role="editor" n="OCT">Albert Clark</editor>
-				<sponsor>Perseus Project, Tufts University</sponsor>
-				<principal>Gregory Crane</principal>
-				<respStmt>
-					<resp>Prepared under the supervision of</resp>
-					<name>Bridget Almas</name>
-					<name>Lisa Cerrato</name>
-					<name>William Merrill</name>
-					<name>David Mimno</name>
-					<name>Rashmi Singhal</name>
-					<name>David Smith</name>
-				</respStmt>
-				<funder n="org:NEH">National Endowment For The Humanities (NEH)</funder> 
-				
-			</titleStmt>
-			<publicationStmt>
-				<publisher>Trustees of Tufts University</publisher>
-				<pubPlace>Medford, MA</pubPlace>
-				<authority>Perseus Project</authority>
-				<date type="release">1997-10-28</date>
-			</publicationStmt> 
-			
-			<sourceDesc>
-				<biblStruct>
-					<monogr>
-						<author>M. Tullius Cicero</author>
-						<title>M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica
+            <title type="sub">Machine readable text</title>
+            <author n="Cic.">M. Tullius Cicero</author>
+            <editor role="editor" n="OCT">Albert Clark</editor>
+            <sponsor>Perseus Project, Tufts University</sponsor>
+            <principal>Gregory Crane</principal>
+            <respStmt>
+               <resp>Prepared under the supervision of</resp>
+               <name>Bridget Almas</name>
+               <name>Lisa Cerrato</name>
+               <name>William Merrill</name>
+               <name>David Mimno</name>
+               <name>Rashmi Singhal</name>
+               <name>David Smith</name>
+            </respStmt>
+            <funder n="org:NEH">National Endowment For The Humanities (NEH)</funder>
+         </titleStmt>
+         <publicationStmt>
+            <publisher>Trustees of Tufts University</publisher>
+            <pubPlace>Medford, MA</pubPlace>
+            <authority>Perseus Project</authority>
+            <date type="release">1997-10-28</date>
+         </publicationStmt>
+         <sourceDesc>
+            <biblStruct>
+               <monogr>
+                  <author>M. Tullius Cicero</author>
+                  <title>M. Tulli Ciceronis Orationes: Recognovit brevique adnotatione critica
 							instruxit Albertus Curtis Clark</title>
-						<editor role="editor">Albert Clark</editor>
-						<imprint>
-							<pubPlace>Oxonii</pubPlace>
-							<publisher>e Typographeo Clarendoniano</publisher>
-							<date>1909</date>
-						</imprint>
-					</monogr>
-					<series>
-						<title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
-					</series>
-				</biblStruct>
-			</sourceDesc>
-		</fileDesc>
-		
-		<encodingDesc>
-			<refsDecl n="CTS">
-				<cRefPattern n="section" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
-					<p>This pointer pattern extracts section</p>
-				</cRefPattern>
-			</refsDecl>
-			<refsDecl>
-				<refState unit="section"/>
-			</refsDecl>
-		</encodingDesc>
-		
-		<!--		<encodingDesc>
+                  <editor role="editor">Albert Clark</editor>
+                  <imprint>
+                     <pubPlace>Oxonii</pubPlace>
+                     <publisher>e Typographeo Clarendoniano</publisher>
+                     <date>1909</date>
+                  </imprint>
+               </monogr>
+               <series>
+                  <title>Scriptorum Classicorum Bibliotheca Oxoniensis</title>
+               </series>
+            </biblStruct>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <refsDecl n="CTS">
+            <cRefPattern n="section"
+                         matchPattern="(\w+)"
+                         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+               <p>This pointer pattern extracts section</p>
+            </cRefPattern>
+         </refsDecl>
+         <refsDecl>
+            <refState unit="section"/>
+         </refsDecl>
+      </encodingDesc>
+      <!--		<encodingDesc>
 			<refsDecl>
 				<refState delim=" " unit="text"/>
 				<refState unit="section"/>
@@ -73,89 +71,119 @@
 				<refState unit="section"/>
 			</refsDecl>
 		</encodingDesc>-->
-		
-		<profileDesc>
-			<langUsage>
-				<language ident="lat">Latin</language>
-				<language ident="grc">Greek</language>
-			</langUsage>
-		</profileDesc>
-		<revisionDesc>
-			<change when="2016-05-20" who="Lisa Cerrato">Review of EpiDoc and CTS work. Minor edits.</change>
-			<change when="2016-03-17" who="Zach Himes">Changed section milestones to divs.</change>
-			<change when="2015-12-17" who="Zach Himes">Cleaned up teiHeader.</change>
-			<change when="2014-08-01" who="Stella Dee">edited markup</change>
-			<change when="2014-07-01" who="Stella Dee">split composite text and converted to unicode</change>
-			<change when="2013-09-13" who="balmas01">reverting texts back to pre_cts_reorg tagged version</change>
-			<change when="2011-07-19" who="gcrane">removed the earlier persName/placeName tags</change>
-			<change when="2011-07-09" who="gcrane">fixed problems with capitalization</change>
-			<change when="2011-01-15" who="gcrane">base SDL file</change>
-			<change when="2009-10-09" who="rsingh04">more reorganizing of texts module by collection</change>
-			<change when="2006-04-21" who="gcrane">these now have the app crit entered as notes</change>
-			<change when="2005-08-01" who="packel">removed stray item tags</change>
-			<change when="2005-07-25" who="packel">Converted to XML</change>
-			<change when="2005-04-08" who="mimno">added default chunks</change>
-			<change when="2004-12-23" who="mimno">typo: cDe harus... s/b  De harus</change>
-			<change when="2003-07-01" who="yorkc">Updated texts to TEI P4 and Perseus P4 extensions; minor cleanup (esp. character encodings and typos.)</change>
-			<change when="2002-12-02" who="amahoney">correct spelling of Quirites, improperly 'regularized'</change>
-			<change when="2000-03-04" who="dasmith">Added separate funder entity to TEI header.</change>
-			<change when="1999-10-14" who="dasmith">Added explanatory subtitles to titleStmt</change>
-			<change when="1999-08-12" who="dasmith">Fixed refsDecl</change>
-			<change when="1999-08-04" who="textgod">Random changes over a period of months.</change>
-			<change when="1997-10-31" who="textgod">Added QUOTE tags to verse.</change>
-			<change when="1997-08-18" who="textgod">???</change>
-			<change when="1997-05-13" who="cjsu">passed SGML validation</change>
-			<change when="1997-03-26" who="DAS">ed.</change></revisionDesc>
-	</teiHeader>
-	
-	<text xml:lang="lat">
-		<body><div type="edition" xml:lang="lat" n="urn:cts:latinLit:phi0474.phi019.perseus-lat2" subtype="edition">
-			<head>ORATIO CVM SENATVI GRATIAS EGIT</head>
-			<milestone n="1" unit="chapter"/>
-			<div type="textpart" subtype="section" n="1"><p>
-			<milestone unit="para"/><reg>si</reg>, patres conscripti, pro vestris immortalibus in me fratremque meum
+      <profileDesc>
+         <langUsage>
+            <language ident="lat">Latin</language>
+            <language ident="grc">Greek</language>
+         </langUsage>
+      </profileDesc>
+      <revisionDesc>
+         <change when="2016-05-20" who="Lisa Cerrato">Review of EpiDoc and CTS work. Minor edits.</change>
+         <change when="2016-03-17" who="Zach Himes">Changed section milestones to divs.</change>
+         <change when="2015-12-17" who="Zach Himes">Cleaned up teiHeader.</change>
+         <change when="2014-08-01" who="Stella Dee">edited markup</change>
+         <change when="2014-07-01" who="Stella Dee">split composite text and converted to unicode</change>
+         <change when="2013-09-13" who="balmas01">reverting texts back to pre_cts_reorg tagged version</change>
+         <change when="2011-07-19" who="gcrane">removed the earlier persName/placeName tags</change>
+         <change when="2011-07-09" who="gcrane">fixed problems with capitalization</change>
+         <change when="2011-01-15" who="gcrane">base SDL file</change>
+         <change when="2009-10-09" who="rsingh04">more reorganizing of texts module by collection</change>
+         <change when="2006-04-21" who="gcrane">these now have the app crit entered as notes</change>
+         <change when="2005-08-01" who="packel">removed stray item tags</change>
+         <change when="2005-07-25" who="packel">Converted to XML</change>
+         <change when="2005-04-08" who="mimno">added default chunks</change>
+         <change when="2004-12-23" who="mimno">typo: cDe harus... s/b  De harus</change>
+         <change when="2003-07-01" who="yorkc">Updated texts to TEI P4 and Perseus P4 extensions; minor cleanup (esp. character encodings and typos.)</change>
+         <change when="2002-12-02" who="amahoney">correct spelling of Quirites, improperly 'regularized'</change>
+         <change when="2000-03-04" who="dasmith">Added separate funder entity to TEI header.</change>
+         <change when="1999-10-14" who="dasmith">Added explanatory subtitles to titleStmt</change>
+         <change when="1999-08-12" who="dasmith">Fixed refsDecl</change>
+         <change when="1999-08-04" who="textgod">Random changes over a period of months.</change>
+         <change when="1997-10-31" who="textgod">Added QUOTE tags to verse.</change>
+         <change when="1997-08-18" who="textgod">???</change>
+         <change when="1997-05-13" who="cjsu">passed SGML validation</change>
+         <change when="1997-03-26" who="DAS">ed.</change>
+      </revisionDesc>
+   </teiHeader>
+   <text xml:lang="lat">
+      <body>
+         <div type="edition"
+              xml:lang="lat"
+              n="urn:cts:latinLit:phi0474.phi019.perseus-lat2"
+              subtype="edition">
+            <head>ORATIO CVM SENATVI GRATIAS EGIT</head>
+            <milestone n="1" unit="chapter"/>
+            <div type="textpart" subtype="section" n="1">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>si</reg>, patres conscripti, pro vestris immortalibus in me fratremque meum
 				liberosque nostros meritis parum vobis cumulate gratias egero, quaeso obtestorque ne
 				meae naturae potius quam magnitudini vestrorum beneficiorum id tribuendum<note>id
-					trib. <hi rend="italic">HGbk et pler.</hi>: adtrib. <hi rend="italic">PB<foreign xml:lang="grc">Se</foreign></hi></note> putetis.
+					trib. <hi rend="italic">HGbk et pler.</hi>: adtrib. <hi rend="italic">PB<foreign xml:lang="grc">σε</foreign>
+                     </hi>
+                  </note> putetis.
 					<reg>quae</reg> tanta enim potest exsistere ubertas ingeni, quae tanta dicendi
 				copia, quod tam divinum atque incredibile genus orationis, quo quisquam
-					possit<note>posset <hi rend="italic">G1<foreign xml:lang="grc">e</foreign></hi></note> vestra in nos universa promerita non dicam complecti
-				orando, sed percensere numerando<note>enumerando <hi rend="italic">b2s</hi></note>?
+					possit<note>posset <hi rend="italic">G1<foreign xml:lang="grc">ε</foreign>
+                     </hi>
+                  </note> vestra in nos universa promerita non dicam complecti
+				orando, sed percensere numerando<note>enumerando <hi rend="italic">b2s</hi>
+                  </note>?
 				qui mihi fratrem optatissimum, me fratri amantissimo, liberis nostris parentes,
 				nobis liberos, qui dignitatem, qui ordinem, qui fortunas, qui amplissimam rem
-				publicam, qui patriam, qua nihil potest esse iucundius<note>qua ... iucundius <hi rend="italic">s. l. P1</hi></note>, qui denique nosmet ipsos nobis
-				reddidistis. </p></div>
-			<div type="textpart" subtype="section" n="2"><p><reg>quod</reg> si parentes carissimos
+				publicam, qui patriam, qua nihil potest esse iucundius<note>qua ... iucundius <hi rend="italic">s. l. P1</hi>
+                  </note>, qui denique nosmet ipsos nobis
+				reddidistis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="2">
+               <p>
+                  <reg>quod</reg> si parentes carissimos
 				habere debemus, quod ab iis nobis vita, patrimonium, libertas, civitas tradita est,
 				si deos immortalis, quorum beneficio et haec tenuimus et ceteris rebus aucti sumus,
 				si populum Romanum, cuius honoribus in amplissimo consilio et in altissimo gradu
 				dignitatis atque in hac omnium terrarum arce conlocati sumus, si hunc ipsum ordinem,
 				a quo saepe magnificentissimis decretis sumus honestati, immensum quiddam et
 				infinitum est quod vobis debeamus<note>debemus <hi rend="italic">b2
-					Lamb.</hi></note>, qui vestro singulari studio atque consensu parentum
+					Lamb.</hi>
+                  </note>, qui vestro singulari studio atque consensu parentum
 				beneficia, deorum immortalium munera, populi Romani honores, vestra de me multa
 				iudicia nobis uno tempore omnia reddidistis, ut, cum multa vobis, magna populo
 				Romano, innumerabilia parentibus, omnia dis immortalibus debeamus, haec antea
-				singula per illos habuerimus, nunc universa per vos reciperarimus. </p></div><milestone n="2" unit="chapter"/>
-			<div type="textpart" subtype="section" n="3"><p>
-			<milestone unit="para"/><reg>itaque</reg>, patres conscripti, quod ne optandum quidem est homini,
+				singula per illos habuerimus, nunc universa per vos reciperarimus. </p>
+            </div>
+            <milestone n="2" unit="chapter"/>
+            <div type="textpart" subtype="section" n="3">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>itaque</reg>, patres conscripti, quod ne optandum quidem est homini,
 				immortalitatem quandam per vos esse adepti videmur. <reg>quod</reg> enim tempus erit
-				umquam cum<note><app><lem>cum</lem></app> quo <hi rend="italic">Hbk<foreign xml:lang="grc">e</foreign>s</hi></note> vestrorum in nos beneficiorum memoria ac fama
+				umquam cum<note>
+                     <app>
+                        <lem>cum</lem>
+                     </app> quo <hi rend="italic">Hbk<foreign xml:lang="grc">ε</foreign>s</hi>
+                  </note> vestrorum in nos beneficiorum memoria ac fama
 				moriatur? <reg>qui</reg> illo ipso tempore cum vi ferro metu minis obsessi
 				teneremini, non multo post discessum meum me universi revocavistis referente L.
 				Ninnio, fortissimo atque optimo viro, quem habuit ille pestifer annus et maxime
 				fidelem et minime timidum, si dimicare placuisset, defensorem salutis meae: postea
 				quam vobis decernendi potestas non est permissa<note>non est permissa <hi rend="italic">ut Angelius ita H2bk et in P s. l. manus recentissima</hi>:
-					facta non est <foreign xml:lang="grc">e</foreign></note> per eum tribunum plebis
+					facta non est <foreign xml:lang="grc">ε</foreign>
+                  </note> per eum tribunum plebis
 				qui, cum per se rem publicam lacerare non posset, sub alieno scelere
-					delituit<note>delituit <foreign xml:lang="grc">e</foreign>: deluit <hi rend="italic">P1B</hi>: delevit <hi rend="italic">P2Gkt</hi>: diruit <hi rend="italic">Hb2s</hi></note>, numquam de me siluistis, numquam meam
-				salutem non ab iis consulibus qui vendiderant flagitavistis. </p></div>
-			<div type="textpart" subtype="section" n="4"><p><reg>itaque</reg> vestro studio atque auctoritate perfectum est
-					ut<note>ut <foreign xml:lang="grc">e</foreign>
-					<hi rend="italic">Par.</hi> 7774, <hi rend="italic">et in P man. rec.</hi>:
-						<hi rend="italic">om. rell.</hi></note> ipse ille annus, quem ego mihi quam
-				patriae malueram esse fatalem, octo<note>octo <foreign xml:lang="grc">e</foreign>:
-					hoc <hi rend="italic">PB</hi>: hos <hi rend="italic">Gtc</hi>: cum <hi rend="italic">Hk</hi></note> tribunos haberet qui et promulgarent de salute
+					delituit<note>delituit <foreign xml:lang="grc">ε</foreign>: deluit <hi rend="italic">P1B</hi>: delevit <hi rend="italic">P2Gkt</hi>: diruit <hi rend="italic">Hb2s</hi>
+                  </note>, numquam de me siluistis, numquam meam
+				salutem non ab iis consulibus qui vendiderant flagitavistis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="4">
+               <p>
+                  <reg>itaque</reg> vestro studio atque auctoritate perfectum est
+					ut<note>ut <foreign xml:lang="grc">ε</foreign>
+                     <hi rend="italic">Par.</hi> 7774, <hi rend="italic">et in P man. rec.</hi>:
+						<hi rend="italic">om. rell.</hi>
+                  </note> ipse ille annus, quem ego mihi quam
+				patriae malueram esse fatalem, octo<note>octo <foreign xml:lang="grc">ε</foreign>:
+					hoc <hi rend="italic">PB</hi>: hos <hi rend="italic">Gtc</hi>: cum <hi rend="italic">Hk</hi>
+                  </note> tribunos haberet qui et promulgarent de salute
 				mea et ad vos saepe numero referrent. <reg>nam</reg> consules modesti legumque
 				metuentes impediebantur lege, non ea quae de me, sed ea quae de ipsis lata erat,
 					quam<note>quam <hi rend="italic">Lamb.</hi>: cum <hi rend="italic">codd.</hi>
@@ -163,33 +191,48 @@
 				promulgavit ut, si revixissent ii qui haec paene delerunt, tum ego redirem; quo
 				facto utrumque confessus est, et se illorum vitam desiderare, et magno in periculo
 				rem publicam futuram si, cum hostes atque interfectores rei publicae revixissent,
-				ego non revertissem. <reg>idemque</reg><note>Idemque <hi rend="italic">scripsi</hi>: itaque <hi rend="italic">codd. praeter</hi>
-					<foreign xml:lang="grc">e</foreign> (atque)</note> illo ipso tamen<note>tamen
-						<hi rend="italic">om. H</hi>: tum <hi rend="italic">k</hi></note> anno,
+				ego non revertissem. <reg>idemque</reg>
+                  <note>Idemque <hi rend="italic">scripsi</hi>: itaque <hi rend="italic">codd. praeter</hi>
+                     <foreign xml:lang="grc">ε</foreign> (atque)</note> illo ipso tamen<note>tamen
+						<hi rend="italic">om. H</hi>: tum <hi rend="italic">k</hi>
+                  </note> anno,
 				cum ego cessissem, princeps autem civitatis non legum praesidio sed parietum vitam
 				suam tueretur, res publica sine consulibus esset, neque solum parentibus perpetuis
-				verum etiam tutoribus annuis esset orbata, sententias<note>vos <hi rend="italic">ante</hi> sententias <hi rend="italic">add. K. Lehmann</hi></note> dicere
+				verum etiam tutoribus annuis esset orbata, sententias<note>vos <hi rend="italic">ante</hi> sententias <hi rend="italic">add. K. Lehmann</hi>
+                  </note> dicere
 				prohiberemini, caput meae proscriptionis recitaretur, numquam dubitastis meam
-				salutem cum communi salute coniungere. </p></div><milestone n="3" unit="chapter"/>
-			<div type="textpart" subtype="section" n="5"><p><reg>postea</reg> vero quam singulari et praestantissima
+				salutem cum communi salute coniungere. </p>
+            </div>
+            <milestone n="3" unit="chapter"/>
+            <div type="textpart" subtype="section" n="5">
+               <p>
+                  <reg>postea</reg> vero quam singulari et praestantissima
 				virtute P. Lentuli consulis ex superioris anni caligine et tenebris lucem in re
 				publica Kalendis Ianuariis dispicere coepistis, cum Q. Metelli, nobilissimi hominis
 				atque optimi viri, summa dignitas, cum praetorum tribunorum plebis paene omnium
 				virtus et fides rei publicae subvenisset, cum virtute gloria rebus gestis Cn.
 				Pompeius omnium gentium, omnium saeculorum, omnis memoriae facile princeps tuto se
-				venire in senatum arbitraretur<note>non arbitr. <foreign xml:lang="grc">e</foreign></note>, tantus vester consensus de salute mea fuit ut
+				venire in senatum arbitraretur<note>non arbitr. <foreign xml:lang="grc">ε</foreign>
+                  </note>, tantus vester consensus de salute mea fuit ut
 					corpus<note>ut licet corpus <hi rend="italic">Hb2s, ed. R., et in P s. l. man.
-						rec.</hi></note> abesset meum, dignitas iam in patriam revertisset.
-					</p></div>
-			<div type="textpart" subtype="section" n="6"><p><reg>quo</reg> quidem mense quid inter me et
+						rec.</hi>
+                  </note> abesset meum, dignitas iam in patriam revertisset.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="6">
+               <p>
+                  <reg>quo</reg> quidem mense quid inter me et
 				meos inimicos interesset existimare potuistis. <reg>ego</reg> meam salutem deserui,
 				ne propter me civium vulneribus res publica cruentaretur: illi meum reditum non
 				populi Romani suffragiis sed flumine sanguinis intercludendum putaverunt.
 					<reg>itaque</reg> postea nihil vos civibus, nihil sociis, nihil regibus
 				respondistis; nihil iudices sententiis, nihil populus suffragiis, nihil hic ordo
 				auctoritate declaravit; mutum forum, elinguem curiam, tacitam et fractam civitatem
-				videbatis. </p></div>
-			<div type="textpart" subtype="section" n="7"><p><reg>quo</reg> quidem tempore, cum is
+				videbatis. </p>
+            </div>
+            <div type="textpart" subtype="section" n="7">
+               <p>
+                  <reg>quo</reg> quidem tempore, cum is
 				excessisset qui caedi et flammae vobis auctoribus restiterat, cum ferro et facibus
 				homines tota urbe volitantis, magistratuum tecta impugnata, deorum templa
 				inflammata, summi viri et clarissimi consulis fascis fractos, fortissimi atque
@@ -198,9 +241,13 @@
 				partim metu mortis, partim desperatione rei publicae paululum a mea causa
 				recesserunt: reliqui fuerunt quos neque terror nec vis, nec spes nec metus, nec
 				promissa nec minae, nec tela nec faces a vestra auctoritate, a populi Romani
-				dignitate, a mea salute depellerent. </p></div><milestone n="4" unit="chapter"/>
-			<div type="textpart" subtype="section" n="8"><p>
-			<milestone unit="para"/><reg>princeps</reg> P. Lentulus, parens ac deus nostrae vitae fortunae memoriae
+				dignitate, a mea salute depellerent. </p>
+            </div>
+            <milestone n="4" unit="chapter"/>
+            <div type="textpart" subtype="section" n="8">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>princeps</reg> P. Lentulus, parens ac deus nostrae vitae fortunae memoriae
 				nominis, hoc specimen virtutis, hoc indicium animi, hoc lumen consulatus sui fore
 				putavit, si me mihi, si meis, si vobis, si rei publicae reddidisset. <reg>qui</reg>
 				ut est designatus, numquam dubitavit sententiam de salute mea se et re publica
@@ -209,181 +256,275 @@
 				iret, ne scribendo adesset, totam illam, ut ante dixi, proscriptionem non legem
 				putavit, qua civis optime de re publica meritus nominatim sine iudicio una cum
 				senatu rei publicae esset ereptus. Vt vero iniit magistratum, non dicam quid
-					egit<note>egerit <hi rend="italic">Hbks</hi></note> prius, sed quid omnino egit
+					egit<note>egerit <hi rend="italic">Hbks</hi>
+                  </note> prius, sed quid omnino egit
 				aliud nisi ut me conservato vestram in posterum dignitatem auctoritatemque sanciret?
-					</p></div>
-			<div type="textpart" subtype="section" n="9"><p><reg>di</reg> immortales, quantum mihi
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="9">
+               <p>
+                  <reg>di</reg> immortales, quantum mihi
 				beneficium dedisse videmini, quod hoc anno P. Lentulus consul <add>populi
 					Romani</add> fuit<note>p. R. fuit <hi rend="italic">scripsi</hi>: prefuit <hi rend="italic">s. l. Hc, et ita bks</hi>: <hi rend="italic">om. P
-						rell.</hi>: fuit <hi rend="italic">Manutius</hi>: est <foreign xml:lang="grc">e</foreign></note>! quanto<note><app><lem>quanto</lem></app> quo
-					quanto <hi rend="italic">Hbks, ed. R.</hi></note> maius dedissetis si superiore
+						rell.</hi>: fuit <hi rend="italic">Manutius</hi>: est <foreign xml:lang="grc">ε</foreign>
+                  </note>! quanto<note>
+                     <app>
+                        <lem>quanto</lem>
+                     </app> quo
+					quanto <hi rend="italic">Hbks, ed. R.</hi>
+                  </note> maius dedissetis si superiore
 				anno fuisset! <reg>nec</reg> enim eguissem medicina consulari, nisi consulari
 				vulnere concidissem. <reg>audieram</reg> ex sapientissimo homine atque optimo civi
-				et viro, Q. Catulo, non saepe unum consulem improbum, duo<note>duo <hi rend="italic">P1H</hi>: duos <hi rend="italic">B<foreign xml:lang="grc">s</foreign>t</hi></note> vero numquam<note>numquam post Romam conditam
-						<foreign xml:lang="grc">e</foreign>, <hi rend="italic">Kayser</hi></note>
-				excepto illo Cinnano<note>cinnano <foreign xml:lang="grc">e</foreign>: germano <hi rend="italic">P</hi> (<hi rend="italic">dein del.</hi>: <hi rend="italic">om. Bt</hi>): cesonino <hi rend="italic">in mg. PG<foreign xml:lang="grc">s</foreign></hi> (-ini <hi rend="italic">Hs</hi>)</note> tempore
+				et viro, Q. Catulo, non saepe unum consulem improbum, duo<note>duo <hi rend="italic">P1H</hi>: duos <hi rend="italic">B<foreign xml:lang="grc">ς</foreign>t</hi>
+                  </note> vero numquam<note>numquam post Romam conditam
+						<foreign xml:lang="grc">ε</foreign>, <hi rend="italic">Kayser</hi>
+                  </note>
+				excepto illo Cinnano<note>cinnano <foreign xml:lang="grc">ε</foreign>: germano <hi rend="italic">P</hi> (<hi rend="italic">dein del.</hi>: <hi rend="italic">om. Bt</hi>): cesonino <hi rend="italic">in mg. PG<foreign xml:lang="grc">ς</foreign>
+                     </hi> (-ini <hi rend="italic">Hs</hi>)</note> tempore
 				fuisse; qua re meam causam semper fore firmissimam dicere solebat, dum vel unus in
 				re publica consul esset; quod vere dixerat si illud de duobus consulibus, quod ante
-				in re publica non<note>non <hi rend="italic">om. <foreign xml:lang="grc">e</foreign></hi>: <hi rend="italic">Wolfio auct. secl.
-					Kayser</hi></note> fuerat, perenne ac proprium manere potuisset. <reg>quod</reg>
+				in re publica non<note>non <hi rend="italic">om. <foreign xml:lang="grc">ε</foreign>
+                     </hi>: <hi rend="italic">Wolfio auct. secl.
+					Kayser</hi>
+                  </note> fuerat, perenne ac proprium manere potuisset. <reg>quod</reg>
 				si Q. Metellus illo tempore consul fuisset <del>inimicus<note>inimicus <hi rend="italic">secl. Halm</hi>: non inim. <hi rend="italic">Hbks.
-							Num</hi> etsi inim.? (§ 25)</note></del>, dubitatis quo animo fuerit in
+							Num</hi> etsi inim.? (§ 25)</note>
+                  </del>, dubitatis quo animo fuerit in
 				me conservando futurus, cum in restituendo auctorem fuisse adscriptoremque videatis?
-					</p></div>
-			<div type="textpart" subtype="section" n="10"><p><reg>sed</reg> fuerunt
-						ii<note><app><lem>ii</lem></app> duo <hi rend="italic">Hbs</hi></note> consules
-				quorum mentes angustae humiles pravae<note>parvae <hi rend="italic">Gbc<foreign xml:lang="grc">e</foreign></hi></note>, oppletae tenebris ac sordibus,
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="10">
+               <p>
+                  <reg>sed</reg> fuerunt
+						ii<note>
+                     <app>
+                        <lem>ii</lem>
+                     </app> duo <hi rend="italic">Hbs</hi>
+                  </note> consules
+				quorum mentes angustae humiles pravae<note>parvae <hi rend="italic">Gbc<foreign xml:lang="grc">ε</foreign>
+                     </hi>
+                  </note>, oppletae tenebris ac sordibus,
 				nomen ipsum consulatus, splendorem illius honoris, magnitudinem tanti imperi nec
 				intueri nec sustinere nec capere potuerunt,—non consules, sed mercatores
 				provinciarum ac venditores vestrae dignitatis; quorum alter a<note>a <hi rend="italic">s. l. P1, rell.</hi>: <hi rend="italic">auct. Halmio om.
-						edd.</hi></note> me Catilinam, amatorem suum, multis audientibus, alter
+						edd.</hi>
+                  </note> me Catilinam, amatorem suum, multis audientibus, alter
 				Cethegum consobrinum reposcebat; qui me duo sceleratissimi post hominum memoriam non
 				consules sed latrones non modo deseruerunt, in causa praesertim publica et
 				consulari, sed prodiderunt, oppugnarunt, omni auxilio non solum suo sed etiam vestro
 				ceterorumque ordinum spoliatum esse voluerunt. <reg>quorum</reg> alter tamen neque
-				me neque quemquam fefellit. </p></div><milestone n="5" unit="chapter"/>
-			<div type="textpart" subtype="section" n="11"><p><reg>quis</reg> enim ullam ullius boni spem haberet in eo cuius
+				me neque quemquam fefellit. </p>
+            </div>
+            <milestone n="5" unit="chapter"/>
+            <div type="textpart" subtype="section" n="11">
+               <p>
+                  <reg>quis</reg> enim ullam ullius boni spem haberet in eo cuius
 				primum tempus aetatis palam fuisset ad omnis<note>omnes <hi rend="italic">P rell.
-						praeter <foreign xml:lang="grc">e</foreign>e</hi> (omnium)</note> libidines
+						praeter <foreign xml:lang="grc">ε</foreign>e</hi> (omnium)</note> libidines
 				divulgatum? qui ne a sanctissima quidem parte corporis potuisset hominum impuram
 				intemperantiam propulsare? qui cum suam rem non minus strenue quam postea publicam
 				confecisset, egestatem et luxuriem<note>luxuriam <hi rend="italic">Hbks</hi> (<hi rend="italic">verr.</hi> v, § 80)</note> domestico lenocinio sustentavit?
 				qui nisi in aram tribunatus confugisset, neque vim praetoris nec multitudinem
-				creditorum nec bonorum proscriptionem effugere potuisset? qui<note>qui <hi rend="italic">codd. praeter <foreign xml:lang="grc">e</foreign>e</hi>
+				creditorum nec bonorum proscriptionem effugere potuisset? qui<note>qui <hi rend="italic">codd. praeter <foreign xml:lang="grc">ε</foreign>e</hi>
 					(quo)</note> in magistratu nisi rogationem de piratico bello tulisset, profecto
 				egestate et improbitate coactus piraticam ipse fecisset, ac minore quidem cum rei
 				publicae detrimento quam quod<note>quam quo <hi rend="italic">com.
-					Garat.</hi></note> intra moenia nefarius hostis praedoque versatus est? quo
+					Garat.</hi>
+                  </note> intra moenia nefarius hostis praedoque versatus est? quo
 				inspectante ac sedente legem tribunus plebis tulit ne auspiciis obtemperaretur, ne
 				obnuntiare concilio aut comitiis, ne legi intercedere liceret, ut lex Aelia et Fufia
 				ne valeret, quae nostri maiores certissima subsidia rei publicae contra tribunicios
-				furores esse voluerunt? </p></div>
-			<div type="textpart" subtype="section" n="12"><p><reg>idemque</reg> postea,
+				furores esse voluerunt? </p>
+            </div>
+            <div type="textpart" subtype="section" n="12">
+               <p>
+                  <reg>idemque</reg> postea,
 				cum innumerabilis multitudo bonorum de Capitolio supplex ad eum sordidata venisset,
 				cumque adulescentes nobilissimi cunctique equites Romani se ad lenonis impudicissimi
 				pedes abiecissent, quo vultu cincinnatus ganeo non solum civium lacrimas verum etiam
 				patriae preces repudiavit! <reg>neque</reg> eo contentus fuit, sed etiam in
-				contionem escendit<note>escendit <hi rend="italic">P</hi>: descendit <hi rend="italic">B<foreign xml:lang="grc">S</foreign>t</hi>: ascendit <hi rend="italic">GHb<foreign xml:lang="grc">s</foreign>s<foreign xml:lang="grc">e</foreign></hi></note> eaque dixit quae, si eius vir
+				contionem escendit<note>escendit <hi rend="italic">P</hi>: descendit <hi rend="italic">B<foreign xml:lang="grc">ς</foreign>t</hi>: ascendit <hi rend="italic">GHb<foreign xml:lang="grc">ς</foreign>s<foreign xml:lang="grc">ε</foreign>
+                     </hi>
+                  </note> eaque dixit quae, si eius vir
 				Catilina revixisset, dicere non esset ausus, se Nonarum Decembrium quae me consule
 				fuissent clivique Capitolini poenas ab equitibus Romanis esse repetiturum.
 					<reg>neque</reg> solum id dixit, sed quos ei commodum fuit compellavit,
 					Lucium<note>Lucium <hi rend="italic">P rell. praeter s</hi> (L.)</note> vero
-					Lamiam<note>Lamiam <hi rend="italic"><foreign xml:lang="grc">e</foreign>s</hi>:
-					iam <hi rend="italic">PHGc all.</hi></note>, equitem Romanum, praestanti
+					Lamiam<note>Lamiam <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>s</hi>:
+					iam <hi rend="italic">PHGc all.</hi>
+                  </note>, equitem Romanum, praestanti
 				dignitate hominem et saluti meae pro familiaritate, rei publicae pro fortunis suis
-				amicissimum, consul imperiosus exire ex<note>ex <foreign xml:lang="grc">e</foreign>
+				amicissimum, consul imperiosus exire ex<note>ex <foreign xml:lang="grc">ε</foreign>
 						(<hi rend="italic">prob. Zielinski</hi>): <hi rend="italic">om.
-					rell.</hi></note> urbe iussit. <reg>et</reg> cum vos vestem mutandam
+					rell.</hi>
+                  </note> urbe iussit. <reg>et</reg> cum vos vestem mutandam
 				censuissetis cunctique mutassetis atque idem omnes boni iam ante fecissent, ille
 				unguentis oblitus cum toga praetexta, quam omnes praetores aedilesque tum
 				abiecerant, inrisit squalorem vestrum et luctum gratissimae civitatis, fecitque,
 				quod nemo umquam tyrannus, ut quo minus<note>cum (quom) <hi rend="italic">ante</hi>
-					quo minus <hi rend="italic">add. J. S. Reid</hi></note> occulte vestrum malum
+					quo minus <hi rend="italic">add. J. S. Reid</hi>
+                  </note> occulte vestrum malum
 				gemeretis nihil diceret<note>nihil diceret <hi rend="italic">codd.</hi>: nihil
 					terreret <hi rend="italic">Reid</hi>: nihil se intercedere ediceret <hi rend="italic">Madv.</hi>: nihil diceret esse quod obstaret <hi rend="italic">Lahmann</hi>: <hi rend="italic">num</hi> nihil diceret
 					impedire? ne aperte ... ediceret <hi rend="italic">s. l. P2</hi>: <hi rend="italic">om. Madv. Cf. Sest.</hi> xiv: <hi rend="italic">Planc.</hi>
 					§ 87 <hi rend="italic">edictoque suo non luctum patribus conscriptis sed
-						indicia luctus ademerint</hi>: <hi rend="italic">in Pis.</hi> § 18 <hi rend="italic">maerorem relinquis, maeroris aufers insignia</hi></note>, ne
-				aperte incommoda patriae lugeretis ediceret. </p></div><milestone n="6" unit="chapter"/>
-			<div type="textpart" subtype="section" n="13"><p>Cum vero in circo Flaminio non a tribuno
+						indicia luctus ademerint</hi>: <hi rend="italic">in Pis.</hi> § 18 <hi rend="italic">maerorem relinquis, maeroris aufers insignia</hi>
+                  </note>, ne
+				aperte incommoda patriae lugeretis ediceret. </p>
+            </div>
+            <milestone n="6" unit="chapter"/>
+            <div type="textpart" subtype="section" n="13">
+               <p>Cum vero in circo Flaminio non a tribuno
 				plebis consul in contionem, sed a latrone archipirata productus esset, primum
 				processit, qua auctoritate vir! vini somni stupri plenus, madenti coma, composito
-				capillo, gravibus oculis, fluentibus buccis: pressa voce<note>blaesa voce <hi rend="italic">Gertz</hi></note> et temulenta, quod in civis indemnatos
+				capillo, gravibus oculis, fluentibus buccis: pressa voce<note>blaesa voce <hi rend="italic">Gertz</hi>
+                  </note> et temulenta, quod in civis indemnatos
 				esset animadversum, id sibi dixit gravis auctor vehementissime displicere. Vbi nobis
 				haec auctoritas tam diu tanta latuit? cur in lustris et helluationibus huius
 				calamistrati saltatoris tam eximia virtus tam diu cessavit? <reg>nam</reg> ille
 				alter Caesoninus <reg>calventius</reg> ab adulescentia versatus est in foro, cum eum
 				praeter simulatam versutamque<note>versutamque <hi rend="italic">PB</hi>: victamque
-						<hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi>: irritamque <hi rend="italic">HG1bcs</hi>: irritatamque <hi rend="italic">k</hi></note>
+						<hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi>: irritamque <hi rend="italic">HG1bcs</hi>: irritatamque <hi rend="italic">k</hi>
+                  </note>
 				tristitiam nulla res commendaret, non consilium, non dicendi copia, non<note>non
 					consilium, non dicendi copia, non <hi rend="italic">scripsi</hi> (<hi rend="italic">cf.</hi> § 15 non consilio neque eloquentia): non inconsulta
 					(non cos. <hi rend="italic">Gs</hi>) studium non dicendi vitia (iura <hi rend="italic">bs</hi>) <hi rend="italic">PB et pler.</hi>: non iuris
-					studium non dicendi non <hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi>: non vis consilii (non iuris civilis prudentia <hi rend="italic">Muell.</hi>) non dicendi facultas non scientia <hi rend="italic">Lamb.</hi></note> rei militaris, non cognoscendorum hominum
+					studium non dicendi non <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi>: non vis consilii (non iuris civilis prudentia <hi rend="italic">Muell.</hi>) non dicendi facultas non scientia <hi rend="italic">Lamb.</hi>
+                  </note> rei militaris, non cognoscendorum hominum
 				studium, non liberalitas. <reg>quem</reg> praeteriens cum incultum horridum
 				maestumque vidisses, etiam si agrestem et inhumanum existimares, tamen libidinosum
-				et perditum non putares<note>putares <foreign xml:lang="grc">e</foreign>: putasti
-						<hi rend="italic">PBHk</hi>: putasses <hi rend="italic">s</hi></note>.
-					</p></div>
-			<div type="textpart" subtype="section" n="14"><p>Cum hoc homine an cum stipite<note>stipite <hi rend="italic">b2<foreign xml:lang="grc">e</foreign></hi>: stipe <hi rend="italic">P1</hi>: etiope P2: ethiope <hi rend="italic">Bt</hi>: stipe
-					vel aethiope <hi rend="italic">G</hi></note> in foro constitisses, nihil
+				et perditum non putares<note>putares <foreign xml:lang="grc">ε</foreign>: putasti
+						<hi rend="italic">PBHk</hi>: putasses <hi rend="italic">s</hi>
+                  </note>.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="14">
+               <p>Cum hoc homine an cum stipite<note>stipite <hi rend="italic">b2<foreign xml:lang="grc">ε</foreign>
+                     </hi>: stipe <hi rend="italic">P1</hi>: etiope P2: ethiope <hi rend="italic">Bt</hi>: stipe
+					vel aethiope <hi rend="italic">G</hi>
+                  </note> in foro constitisses, nihil
 				crederes interesse: sine sensu, sine sapore, elinguem, tardum, inhumanum negotium,
 				Cappadocem modo abreptum de grege venalium diceres. <reg>idem</reg> domi quam
 				libidinosus, quam impurus, quam intemperans, non ianua receptis sed pseudothyro
-				intromissis voluptatibus! Cum vero etiam litteris<note>litteris <hi rend="italic">cod. Erfurt. G2 <foreign xml:lang="grc">e</foreign>t</hi>: litteras <hi rend="italic">PBH<foreign xml:lang="grc">s</foreign>s</hi> belua <foreign xml:lang="grc">e</foreign>: veluus (<hi rend="italic">corr.</hi> heluus)
-						<hi rend="italic">P</hi>: beluus <hi rend="italic">B</hi>: helluo <hi rend="italic">bs</hi>: <hi rend="italic">om. H</hi></note> studere incipit
+				intromissis voluptatibus! Cum vero etiam litteris<note>litteris <hi rend="italic">cod. Erfurt. G2 <foreign xml:lang="grc">ε</foreign>t</hi>: litteras <hi rend="italic">PBH<foreign xml:lang="grc">ς</foreign>s</hi> belua <foreign xml:lang="grc">ε</foreign>: veluus (<hi rend="italic">corr.</hi> heluus)
+						<hi rend="italic">P</hi>: beluus <hi rend="italic">B</hi>: helluo <hi rend="italic">bs</hi>: <hi rend="italic">om. H</hi>
+                  </note> studere incipit
 				et belua immanis cum Graeculis philosophari, tum est Epicureus non penitus illi
 				disciplinae, quaecumque est, deditus, sed captus uno verbo voluptatis.
 					<reg>habet</reg> autem magistros non ex istis ineptis qui dies totos de officio
 				ac de virtute disserunt, qui ad laborem, ad industriam, ad pericula pro patria
 				subeunda adhortantur, sed eos qui disputent<note>disputant <hi rend="italic">Lamb.
-						in mg.</hi></note> horam nullam vacuam voluptate esse debere, in omni parte
-				corporis semper oportere aliquod gaudium delectationemque versari. </p></div>
-			<div type="textpart" subtype="section" n="15"><p><reg>his</reg> utitur quasi praefectis libidinum suarum, hi
+						in mg.</hi>
+                  </note> horam nullam vacuam voluptate esse debere, in omni parte
+				corporis semper oportere aliquod gaudium delectationemque versari. </p>
+            </div>
+            <div type="textpart" subtype="section" n="15">
+               <p>
+                  <reg>his</reg> utitur quasi praefectis libidinum suarum, hi
 				voluptates omnis vestigant atque odorantur, hi sunt conditores instructoresque
 				convivi, idem expendunt atque aestimant voluptates sententiamque dicunt et iudicant
 				quantum cuique libidini tribuendum esse videatur. Horum ille artibus eruditus ita
-				contempsit hanc prudentissimam<note>pudent. <foreign xml:lang="grc">e</foreign>
-					<hi rend="italic">Halm</hi></note> civitatem ut omnis suas libidines, omnia
+				contempsit hanc prudentissimam<note>pudent. <foreign xml:lang="grc">ε</foreign>
+                     <hi rend="italic">Halm</hi>
+                  </note> civitatem ut omnis suas libidines, omnia
 				flagitia latere posse arbitraretur, si modo vultum importunum in forum detulisset.
-					<milestone n="7" unit="chapter"/><reg>is</reg> nequaquam me quidem<note>Is
+					<milestone n="7" unit="chapter"/>
+                  <reg>is</reg> nequaquam me quidem<note>Is
 					nequaquam me quidem <hi rend="italic">Muell.</hi>: is me, quamquam me quidem
 					(equidem <hi rend="italic">P2BHb</hi>) non <hi rend="italic">codd.,
-					edd.</hi></note>—cognoram enim propter Pisonum adfinitatem quam longe hunc ab
+					edd.</hi>
+                  </note>—cognoram enim propter Pisonum adfinitatem quam longe hunc ab
 				hoc genere cognatio materna Transalpini sanguinis abstulisset— sed vos populumque
 				Romanum non consilio neque eloquentia, quod in multis saepe accidit, sed rugis
-				supercilioque decepit. </p></div>
-			<div type="textpart" subtype="section" n="16"><p>Luci<note>Luci <hi rend="italic">PBG</hi>: L. <hi rend="italic">H<foreign xml:lang="grc">e</foreign>s</hi></note> Piso, tune ausus es isto oculo, non dicam isto
-				animo, ista fronte, non vita<note><app><lem>non vita</lem></app> non ista mente <hi rend="italic">c</hi></note>, tanto supercilio, non enim possum dicere
-				tantis rebus<note>rebus <foreign xml:lang="grc">e</foreign>, <hi rend="italic">om.
+				supercilioque decepit. </p>
+            </div>
+            <div type="textpart" subtype="section" n="16">
+               <p>Luci<note>Luci <hi rend="italic">PBG</hi>: L. <hi rend="italic">H<foreign xml:lang="grc">ε</foreign>s</hi>
+                  </note> Piso, tune ausus es isto oculo, non dicam isto
+				animo, ista fronte, non vita<note>
+                     <app>
+                        <lem>non vita</lem>
+                     </app> non ista mente <hi rend="italic">c</hi>
+                  </note>, tanto supercilio, non enim possum dicere
+				tantis rebus<note>rebus <foreign xml:lang="grc">ε</foreign>, <hi rend="italic">om.
 						rell.</hi> (tantibus gestis <hi rend="italic">P1</hi>: tantis gestis <hi rend="italic">P corr., BHk all.</hi>)</note> gestis, cum A. Gabinio
 				consociare consilia pestis meae? <reg>non</reg> te illius unguentorum odor, non vini
 				anhelitus, non frons calamistri notata vestigiis in eam cogitationem adducebat, ut
-				cum illius re similis fuisses, frontis tibi integimento<note>integum. <foreign xml:lang="grc">e</foreign></note> ad occultanda tanta flagitia diutius uti
-				non liceret? Cum hoc<note>hoc tu <foreign xml:lang="grc">e</foreign></note> coire
+				cum illius re similis fuisses, frontis tibi integimento<note>integum. <foreign xml:lang="grc">ε</foreign>
+                  </note> ad occultanda tanta flagitia diutius uti
+				non liceret? Cum hoc<note>hoc tu <foreign xml:lang="grc">ε</foreign>
+                  </note> coire
 				ausus es ut consularem dignitatem, ut rei publicae statum, ut senatus auctoritatem,
 				ut civis optime meriti fortunas provinciarum foedere addiceres? <reg>te</reg>
 				consule, tuis edictis et imperiis senatui populi Romani non est licitum non modo
 				sententiis atque auctoritate sua, sed ne luctu quidem ac vestitu rei publicae
-				subvenire? </p></div>
-			<div type="textpart" subtype="section" n="17"><p>Capuaene te putabas, in qua urbe
+				subvenire? </p>
+            </div>
+            <div type="textpart" subtype="section" n="17">
+               <p>Capuaene te putabas, in qua urbe
 				domicilium quondam superbiae fuit, consulem esse, sicut eras eo tempore<note>sicut
-					eras eo tempore <hi rend="italic">secl. Garat., Halm</hi></note>, an Romae, in
+					eras eo tempore <hi rend="italic">secl. Garat., Halm</hi>
+                  </note>, an Romae, in
 				qua civitate omnes ante vos consules senatui paruerunt? <reg>tu</reg> es ausus in
-				circo Flaminio productus cum tuo illo pari dicere te semper<note>pare <hi rend="italic">P</hi> semper <hi rend="italic">om. Schol.</hi></note>
+				circo Flaminio productus cum tuo illo pari dicere te semper<note>pare <hi rend="italic">P</hi> semper <hi rend="italic">om. Schol.</hi>
+                  </note>
 				misericordem fuisse? quo verbo senatum atque omnis bonos, tum cum a patria pestem
-						depellerent<note><app><lem>depellerent</lem></app> expellerent <hi rend="italic">ed. R.</hi>: depulissem <hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi>: depulissent <hi rend="italic">t Lamb.</hi>: tum ...
+						depellerent<note>
+                     <app>
+                        <lem>depellerent</lem>
+                     </app> expellerent <hi rend="italic">ed. R.</hi>: depulissem <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi>: depulissent <hi rend="italic">t Lamb.</hi>: tum ...
 					depellerent <hi rend="italic">om. rell., fort. recte. Nam habet Schol.</hi> Quo
 					verbo ceteros demonstrabas crudeles fuisse</note>, crudelis demonstrabas fuisse.
-					<reg>tu</reg> misericors me, adfinem tuum, quem comitiis<note>tuis <hi rend="italic">post</hi> comitiis <hi rend="italic">add. <foreign xml:lang="grc">e</foreign>, ante</hi> com. <hi rend="italic">G</hi></note> praerogativae primum custodem praefeceras, quem Kalendis
-				Ianuariis tertio loco sententiam rogaras<note>rogaras <hi rend="italic">c<foreign xml:lang="grc">e</foreign></hi>: rogabas <hi rend="italic">P
-					rell.</hi></note>, constrictum inimicis rei publicae<note>rei pub. <hi rend="italic">om. Schol.</hi></note> tradidisti; tu meum generum,
+					<reg>tu</reg> misericors me, adfinem tuum, quem comitiis<note>tuis <hi rend="italic">post</hi> comitiis <hi rend="italic">add. <foreign xml:lang="grc">ε</foreign>, ante</hi> com. <hi rend="italic">G</hi>
+                  </note> praerogativae primum custodem praefeceras, quem Kalendis
+				Ianuariis tertio loco sententiam rogaras<note>rogaras <hi rend="italic">c<foreign xml:lang="grc">ε</foreign>
+                     </hi>: rogabas <hi rend="italic">P
+					rell.</hi>
+                  </note>, constrictum inimicis rei publicae<note>rei pub. <hi rend="italic">om. Schol.</hi>
+                  </note> tradidisti; tu meum generum,
 				propinquum tuum, tu adfinem tuam, filiam meam, superbissimis et crudelissimis verbis
 				a genibus tuis reppulisti; idemque tu clementia ac misericordia singulari, cum ego
 				una cum re publica non tribunicio sed consulari ictu concidissem, tanto scelere
 				tantaque intemperantia fuisti ut ne unam quidem horam interesse paterere inter meam
 				pestem et tuam praedam, saltem dum conticisceret illa lamentatio et gemitus urbis!
-					</p></div>
-			<div type="textpart" subtype="section" n="18"><p><reg>nondum</reg> palam factum erat occidisse
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="18">
+               <p>
+                  <reg>nondum</reg> palam factum erat occidisse
 				rem publicam, cum tibi arbitria funeris solvebantur: uno eodemque tempore domus mea
 				diripiebatur, ardebat, bona ad vicinum consulem de Palatio, de Tusculano ad item
 				vicinum alterum consulem deferebantur cum, isdem operis suffragium ferentibus, eodem
 				gladiatore latore, vacuo non modo a bonis sed etiam a liberis atque inani foro,
 				ignaro populo Romano quid ageretur, senatu vero oppresso et adflicto, duobus impiis
 				nefariisque consulibus aerarium provinciae legiones imperia donabantur. <milestone n="8" unit="chapter"/>
-			<milestone unit="para"/>Horum consulum ruinas vos consules vestra virtute fulsistis, summa tribunorum plebis
-				praetorumque fide et diligentia sublevati. </p></div>
-			<div type="textpart" subtype="section" n="19"><p><reg>quid</reg> ego de praestantissimo viro, T. Annio, dicam, aut quis de tali
+                  <milestone unit="para"/>Horum consulum ruinas vos consules vestra virtute fulsistis, summa tribunorum plebis
+				praetorumque fide et diligentia sublevati. </p>
+            </div>
+            <div type="textpart" subtype="section" n="19">
+               <p>
+                  <reg>quid</reg> ego de praestantissimo viro, T. Annio, dicam, aut quis de tali
 				cive satis digne umquam loquetur? <reg>qui</reg> cum videret sceleratum civem aut
 				domesticum potius hostem, si legibus uti liceret, iudicio esse frangendum, sin ipsa
 				iudicia vis impediret ac tolleret, audaciam virtute, furorem fortitudine,
 				temeritatem consilio, manum copiis<note>coiis <hi rend="italic">P, om. Bb</hi>
-					(manum manu <hi rend="italic">Hb<foreign xml:lang="grc">s</foreign></hi>)</note>, vim vi esse superandam, primo de vi postulavit;
+					(manum manu <hi rend="italic">Hb<foreign xml:lang="grc">ς</foreign>
+                     </hi>)</note>, vim vi esse superandam, primo de vi postulavit;
 				postea quam ab eodem iudicia sublata esse vidit, ne ille omnia vi posset efficere
-				curavit; qui docuit neque tecta neque templa neque<note>neque <hi rend="italic">c</hi></note> forum nec curiam sine summa virtute ac maximis opibus et
+				curavit; qui docuit neque tecta neque templa neque<note>neque <hi rend="italic">c</hi>
+                  </note> forum nec curiam sine summa virtute ac maximis opibus et
 				copiis ab intestino latrocinio posse defendi; qui primus post meum discessum metum
-				bonis, spem<note>spem <foreign xml:lang="grc">e</foreign>: set <hi rend="italic">P1</hi>: et <hi rend="italic">P2H et pler.</hi></note> audacibus, timorem
-				huic ordini, servitutem depulit civitati. </p></div>
-			<div type="textpart" subtype="section" n="20"><p><reg>quam</reg> rationem pari virtute animo fide P. Sestius secutus pro mea
+				bonis, spem<note>spem <foreign xml:lang="grc">ε</foreign>: set <hi rend="italic">P1</hi>: et <hi rend="italic">P2H et pler.</hi>
+                  </note> audacibus, timorem
+				huic ordini, servitutem depulit civitati. </p>
+            </div>
+            <div type="textpart" subtype="section" n="20">
+               <p>
+                  <reg>quam</reg> rationem pari virtute animo fide P. Sestius secutus pro mea
 				salute, pro vestra auctoritate, pro statu civitatis nullas sibi inimicitias, nullam
 				vim, nullos impetus, nullum vitae discrimen vitandum umquam putavit; qui causam
 				senatus, exagitatam contionibus improborum, sic sua diligentia multitudini
@@ -392,41 +533,67 @@
 				plebis potuit defendit, tum reliquis officiis, iuxta ac si meus frater esset,
 				sustentavit; cuius ego clientibus, libertis, familia, copiis, litteris ita sum
 				sustentatus ut meae calamitatis non adiutor solum, verum etiam socius videretur.
-					</p></div>
-			<div type="textpart" subtype="section" n="21"><p><reg>iam</reg> ceterorum officia
-					<add>ac</add><note>ac <hi rend="italic">suppl. Halm</hi>: studiaque <hi rend="italic">k et ed. R.</hi>: <del>studia</del>
-					<hi rend="italic">Kays.</hi></note> studia vidistis, quam cupidus mei C.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="21">
+               <p>
+                  <reg>iam</reg> ceterorum officia
+					<add>ac</add>
+                  <note>ac <hi rend="italic">suppl. Halm</hi>: studiaque <hi rend="italic">k et ed. R.</hi>: <del>studia</del>
+                     <hi rend="italic">Kays.</hi>
+                  </note> studia vidistis, quam cupidus mei C.
 				Cestilius, quam studiosus vestri, quam non varius fuerit in causa. <reg>quid</reg>
-				M. Cispius<note>M. Cispius <hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi> (<hi rend="italic">Sest.</hi> § 76): mospius <hi rend="italic">PH</hi></note>? cui ego ipsi parenti fratrique eius sentio
-				quantum debeam; qui, cum a me<note><app><lem>a me</lem></app> mea <hi rend="italic">G</hi>: mihi <hi rend="italic">Hs</hi></note> voluntas eorum in privato
+				M. Cispius<note>M. Cispius <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi> (<hi rend="italic">Sest.</hi> § 76): mospius <hi rend="italic">PH</hi>
+                  </note>? cui ego ipsi parenti fratrique eius sentio
+				quantum debeam; qui, cum a me<note>
+                     <app>
+                        <lem>a me</lem>
+                     </app> mea <hi rend="italic">G</hi>: mihi <hi rend="italic">Hs</hi>
+                  </note> voluntas eorum in privato
 				iudicio esset offensa, publici mei benefici memoria privatam offensionem
 				oblitteraverunt. <reg>iam</reg> T. Fadius, qui mihi quaestor fuit, M. Curtius, cuius
 				ego patri quaestor fui, studio amore animo huic necessitudini non defuerunt.
 					<reg>multa</reg> de me C. Messius et amicitiae et rei publicae causa dixit:
-				legem separatim<note>speratim <hi rend="italic">PB</hi>: speciatim <hi rend="italic">Gb2ks</hi></note> initio de salute mea promulgavit.
-					</p></div>
-			<div type="textpart" subtype="section" n="22"><p>Q. Fabricius si, quae de me agere conatus est,
+				legem separatim<note>speratim <hi rend="italic">PB</hi>: speciatim <hi rend="italic">Gb2ks</hi>
+                  </note> initio de salute mea promulgavit.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="22">
+               <p>Q. Fabricius si, quae de me agere conatus est,
 				ea contra vim et ferrum perficere potuisset, mense Ianuario nostrum statum
 				reciperassemus; quem ad salutem meam voluntas impulit, vis retardavit, auctoritas
-				vestra revocavit. <milestone n="9" unit="chapter"/><reg>iam</reg> vero praetores quo
+				vestra revocavit. <milestone n="9" unit="chapter"/>
+                  <reg>iam</reg> vero praetores quo
 				animo in me fuerint vos existimare potuistis, cum L. Caecilius privatim me suis
 				omnibus copiis studuerit sustentare, publice promulgarit de mea salute cum conlegis
 				paene omnibus, direptoribus autem bonorum meorum in ius adeundi potestatem non
 				fecerit. M. autem Calidius statim designatus sententia sua quam esset cara sibi mea
-				salus declaravit<note><hi rend="italic">Num</hi> fecerit, ... declararit?</note>.
-					</p></div>
-			<div type="textpart" subtype="section" n="23"><p><reg>omnia</reg> officia C. Septimi, Q.
+				salus declaravit<note>
+                     <hi rend="italic">Num</hi> fecerit, ... declararit?</note>.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="23">
+               <p>
+                  <reg>omnia</reg> officia C. Septimi, Q.
 				Valeri, P. Crassi, Sex. Quinctili, C. Cornuti summa et in me et in rem publicam
 				constiterunt. 
-			<milestone unit="para"/><reg>quae</reg> cum libenter commemoro, tum non invitus non nullorum in me nefarie
+			<milestone unit="para"/>
+                  <reg>quae</reg> cum libenter commemoro, tum non invitus non nullorum in me nefarie
 				commissa praetereo. <reg>non</reg> est mei temporis iniurias meminisse, quas ego
 				etiam si ulcisci possem, tamen oblivisci mallem: alio transferenda mea tota vita
-				est, ut bene de me meritis referam gratiam, amicitias igni<note>amicitia segni <hi rend="italic">P2Bt</hi></note> perspectas tuear<note>tuear <hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi>: tuen <hi rend="italic">P</hi> (<hi rend="italic">corr.</hi> tunc): tẽ <hi rend="italic">B</hi> (amicitias ... tuear <hi rend="italic">om.
+				est, ut bene de me meritis referam gratiam, amicitias igni<note>amicitia segni <hi rend="italic">P2Bt</hi>
+                  </note> perspectas tuear<note>tuear <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi>: tuen <hi rend="italic">P</hi> (<hi rend="italic">corr.</hi> tunc): tẽ <hi rend="italic">B</hi> (amicitias ... tuear <hi rend="italic">om.
 					HGs</hi>)</note>, cum apertis hostibus bellum geram, timidis amicis ignoscam,
 				proditores indicem<note>indicem <hi rend="italic">scripsi</hi>: non indicem <hi rend="italic">codd.</hi>: non vindicem <hi rend="italic">ut Hotom. ita
-						b</hi>: vindicem <hi rend="italic">Madv.</hi>: convincam <hi rend="italic">Muell.</hi></note>, dolorem profectionis meae reditus dignitate consoler.
-					</p></div>
-			<div type="textpart" subtype="section" n="24"><p><reg>quod</reg> si mihi nullum aliud esset
+						b</hi>: vindicem <hi rend="italic">Madv.</hi>: convincam <hi rend="italic">Muell.</hi>
+                  </note>, dolorem profectionis meae reditus dignitate consoler.
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="24">
+               <p>
+                  <reg>quod</reg> si mihi nullum aliud esset
 				officium in omni vita reliquum nisi ut erga duces ipsos et principes atque auctores
 				salutis meae satis gratus iudicarer, tamen exiguum reliquae vitae tempus non modo ad
 				referendam verum etiam ad commemorandam gratiam mihi relictum putarem.
@@ -434,109 +601,164 @@
 				referent? <reg>quae</reg> memoria, quae vis ingeni, quae magnitudo observantiae tot
 				tantisque beneficiis respondere poterit? qui mihi primus adflicto et iacenti
 				consularem fidem dextramque porrexit, qui me a morte ad vitam, a desperatione ad
-				spem, ab exitio ad salutem vocavit<note>revocavit <hi rend="italic">b2<foreign xml:lang="grc">s</foreign></hi></note>, qui tanto amore in me, studio in
+				spem, ab exitio ad salutem vocavit<note>revocavit <hi rend="italic">b2<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note>, qui tanto amore in me, studio in
 				rem publicam fuit ut excogitaret quem ad modum calamitatem meam non modo levaret sed
 				etiam honestaret. <reg>quid</reg> enim magnificentius, quid praeclarius mihi
-				accidere potuit quam quod illo referente<note>referente <foreign xml:lang="grc">e</foreign>: rente <hi rend="italic">P</hi>: suffragium ferente <hi rend="italic">B<foreign xml:lang="grc">S</foreign>t</hi>: petente <hi rend="italic">GH<foreign xml:lang="grc">s</foreign>s</hi></note> vos
+				accidere potuit quam quod illo referente<note>referente <foreign xml:lang="grc">ε</foreign>: rente <hi rend="italic">P</hi>: suffragium ferente <hi rend="italic">B<foreign xml:lang="grc">ς</foreign>t</hi>: petente <hi rend="italic">GH<foreign xml:lang="grc">ς</foreign>s</hi>
+                  </note> vos
 				decrevistis, ut cuncti ex omni Italia, qui rem publicam salvam vellent, ad me unum,
 				hominem fractum et prope dissipatum, restituendum et defendendum venirent? ut, qua
 				voce ter omnino post Romam conditam consul usus esset pro universa re publica apud
 				eos solum qui eius vocem exaudire possent, eadem voce senatus omnis ex<note>omnis ex
-						<foreign xml:lang="grc">e</foreign>: ex <hi rend="italic">k</hi>: <hi rend="italic">om. rell.</hi></note> omnibus agris atque oppidis civis
-				totamque Italiam ad unius salutem defendendam excitaret. </p></div><milestone n="10" unit="chapter"/>
-			<div type="textpart" subtype="section" n="25"><p><reg>quid</reg> ego gloriosius
+						<foreign xml:lang="grc">ε</foreign>: ex <hi rend="italic">k</hi>: <hi rend="italic">om. rell.</hi>
+                  </note> omnibus agris atque oppidis civis
+				totamque Italiam ad unius salutem defendendam excitaret. </p>
+            </div>
+            <milestone n="10" unit="chapter"/>
+            <div type="textpart" subtype="section" n="25">
+               <p>
+                  <reg>quid</reg> ego gloriosius
 				meis posteris potui relinquere quam hoc, senatum iudicasse, qui civis me non
 				defendisset, eum rem publicam salvam noluisse? <reg>itaque</reg> tantum vestra
 				auctoritas, tantum eximia consulis dignitas valuit ut dedecus et
-					flagitium<note>dedecus et flagitium <hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi>: deus flagicium <hi rend="italic">PB</hi>: omnis
-					flag. <hi rend="italic">Hs</hi></note> se committere putaret, si qui non
+					flagitium<note>dedecus et flagitium <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi>: deus flagicium <hi rend="italic">PB</hi>: omnis
+					flag. <hi rend="italic">Hs</hi>
+                  </note> se committere putaret, si qui non
 				veniret. <reg>idemque</reg> consul, cum illa incredibilis multitudo Romam et paene
 				Italia ipsa venisset, vos frequentissimos in Capitolium convocavit. <reg>quo</reg>
-				tempore quantam vim naturae bonitas haberet et<note>et <hi rend="italic">G<foreign xml:lang="grc">e</foreign></hi>: ut <hi rend="italic">P1</hi>: aut <hi rend="italic">P2BHb<foreign xml:lang="grc">s</foreign></hi></note> vera
+				tempore quantam vim naturae bonitas haberet et<note>et <hi rend="italic">G<foreign xml:lang="grc">ε</foreign>
+                     </hi>: ut <hi rend="italic">P1</hi>: aut <hi rend="italic">P2BHb<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> vera
 				nobilitas, intellegere potuistis. <reg>nam</reg> Q. Metellus, et inimicus et frater
 				inimici, perspecta vestra voluntate omnia privata odia deposuit: quem P. Servilius,
 				vir cum clarissimus tum vero optimus mihique amicissimus, et auctoritatis et
 				orationis suae divina quadam gravitate ad sui generis communisque sanguinis facta
 				virtutesque revocavit, ut haberet in consilio et fratrem ab inferis<note>ab inferis
-						<hi rend="italic">secl. Lamb.</hi></note>, socium rerum mearum, et omnis
+						<hi rend="italic">secl. Lamb.</hi>
+                  </note>, socium rerum mearum, et omnis
 				Metellos, praestantissimos civis, paene ex Acheronte excitatos, in quibus Numidicum
 				illum <del>Metellum<note>Metellum <hi rend="italic">auct. Manut. del. Halm</hi>
 						honestus omnibus sed luctuosus tamen <hi rend="italic">Halmio auct.
 							Muell</hi>: honestis omnibus ne (in <hi rend="italic">Bt,</hi> sane <hi rend="italic">G, om. Hbks</hi>) luctuosus tandem <hi rend="italic">P
-							rell. praeter <foreign xml:lang="grc">e</foreign>e</hi> (molestus
-						omnibus ipsi ne luctuosus quidem)</note></del>, cuius quondam de patria
-				discessus honestus omnibus, sed luctuosus tamen visus est. </p></div>
-			<div type="textpart" subtype="section" n="26"><p><reg>itaque</reg> divinitus exstitit<note>divinitus ex. <hi rend="italic">Muell.</hi>: extitit <hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi>: dimittit <hi rend="italic">s.</hi>
-					dimittitur <hi rend="italic">rell. praeter<foreign xml:lang="grc">s</foreign></hi> (hic fuit, <hi rend="italic">et ita Angelius</hi>)</note>
+							rell. praeter <foreign xml:lang="grc">ε</foreign>e</hi> (molestus
+						omnibus ipsi ne luctuosus quidem)</note>
+                  </del>, cuius quondam de patria
+				discessus honestus omnibus, sed luctuosus tamen visus est. </p>
+            </div>
+            <div type="textpart" subtype="section" n="26">
+               <p>
+                  <reg>itaque</reg> divinitus exstitit<note>divinitus ex. <hi rend="italic">Muell.</hi>: extitit <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi>: dimittit <hi rend="italic">s.</hi>
+					dimittitur <hi rend="italic">rell. praeter<foreign xml:lang="grc">ς</foreign>
+                     </hi> (hic fuit, <hi rend="italic">et ita Angelius</hi>)</note>
 				non modo salutis defensor, qui ante hoc unum<note>unum <hi rend="italic">codd.
 						praeter</hi>
-					<foreign xml:lang="grc">e</foreign> (suum): unicum <hi rend="italic">coni.
-						Halm</hi>: divinum <hi rend="italic">Koch</hi>: novum <hi rend="italic">Muell.</hi></note> beneficium fuerat inimicus, verum etiam adscriptor
-				dignitatis meae. <reg>quo</reg> quidem die cum<note>cum vos <foreign xml:lang="grc">e</foreign></note> quadringenti decem septem essetis<note>essetis <hi rend="italic">P rell. praeter bks</hi> (senatores essetis, <hi rend="italic">ex</hi> septem, <hi rend="italic">credo</hi>)</note>,
+                     <foreign xml:lang="grc">ε</foreign> (suum): unicum <hi rend="italic">coni.
+						Halm</hi>: divinum <hi rend="italic">Koch</hi>: novum <hi rend="italic">Muell.</hi>
+                  </note> beneficium fuerat inimicus, verum etiam adscriptor
+				dignitatis meae. <reg>quo</reg> quidem die cum<note>cum vos <foreign xml:lang="grc">ε</foreign>
+                  </note> quadringenti decem septem essetis<note>essetis <hi rend="italic">P rell. praeter bks</hi> (senatores essetis, <hi rend="italic">ex</hi> septem, <hi rend="italic">credo</hi>)</note>,
 				magistratus autem omnes adessent, dissensit unus, is qui sua lege coniuratos etiam
 				ab inferis excitandos putarat. <reg>atque</reg> illo die cum rem publicam meis
 				consiliis conservatam gravissimis verbis et plurimis iudicassetis, idem consul
 				curavit ut eadem a principibus civitatis in contione postero die dicerentur; cum
 				quidem ipse egit ornatissime meam causam, perfecitque astante atque audiente Italia
 				tota ut nemo cuiusquam conducti aut perditi vocem acerbam atque inimicam bonis
-				posset audire. </p></div><milestone n="11" unit="chapter"/>
-			<div type="textpart" subtype="section" n="27"><p><reg>ad</reg> haec non modo adiumenta salutis sed etiam ornamenta dignitatis
+				posset audire. </p>
+            </div>
+            <milestone n="11" unit="chapter"/>
+            <div type="textpart" subtype="section" n="27">
+               <p>
+                  <reg>ad</reg> haec non modo adiumenta salutis sed etiam ornamenta dignitatis
 				meae reliqua vos idem addidistis: decrevistis ne quis ulla ratione rem impediret;
-					qui<note>qui id <hi rend="italic">Gb<foreign xml:lang="grc">s</foreign>s</hi></note> impedisset, graviter<note>vos graviter <foreign xml:lang="grc">e</foreign></note> molesteque laturos—illum contra rem
+					qui<note>qui id <hi rend="italic">Gb<foreign xml:lang="grc">ς</foreign>s</hi>
+                  </note> impedisset, graviter<note>vos graviter <foreign xml:lang="grc">ε</foreign>
+                  </note> molesteque laturos—illum contra rem
 				publicam salutemque bonorum concordiamque civium facturum, et ut ad vos de
-					eo<note>de eo <hi rend="italic">G<foreign xml:lang="grc">e</foreign></hi>: eo
-						<hi rend="italic">PB</hi>: ea <hi rend="italic">b<foreign xml:lang="grc">s</foreign>s</hi></note> statim referretur; meque etiam, si diutius
-				calumniarentur, redire iussistis. <reg>quid</reg>? ut<note>ut iis <hi rend="italic">Lamb.</hi></note> agerentur gratiae, qui e municipiis venissent? quid? ut
+					eo<note>de eo <hi rend="italic">G<foreign xml:lang="grc">ε</foreign>
+                     </hi>: eo
+						<hi rend="italic">PB</hi>: ea <hi rend="italic">b<foreign xml:lang="grc">ς</foreign>s</hi>
+                  </note> statim referretur; meque etiam, si diutius
+				calumniarentur, redire iussistis. <reg>quid</reg>? ut<note>ut iis <hi rend="italic">Lamb.</hi>
+                  </note> agerentur gratiae, qui e municipiis venissent? quid? ut
 				ad illam diem, res cum redissent, rogarentur ut pari studio convenirent? quid?
 				denique illo die, quem P. Lentulus mihi fratrique meo liberisque nostris natalem
 				constituit, non modo ad nostram verum etiam ad sempiterni memoriam temporis, quo die
 				nos comitiis centuriatis, quae maxime maiores comitia iusta dici haberique
 				voluerunt, arcessivit in patriam, ut eaedem centuriae quae me consulem fecerant
-				consulatum meum comprobarent— </p></div>
-			<div type="textpart" subtype="section" n="28"><p>eo die<note>eo die
-						<hi rend="italic">Madv.</hi>: quo die <hi rend="italic">codd.</hi></note>
+				consulatum meum comprobarent— </p>
+            </div>
+            <div type="textpart" subtype="section" n="28">
+               <p>eo die<note>eo die
+						<hi rend="italic">Madv.</hi>: quo die <hi rend="italic">codd.</hi>
+                  </note>
 				quis civis fuit qui fas esse putaret, quacumque aut aetate aut valetudine esset, non
 				se de salute mea sententiam ferre? <reg>quando</reg> tantam frequentiam in campo,
 				tantum splendorem Italiae totius ordinumque omnium, quando illa dignitate rogatores
 				diribitores custodesque vidistis? <reg>itaque</reg> P. Lentuli beneficio excellenti
-				atque divino non reducti<note>non solum reducti <hi rend="italic">Hb<foreign xml:lang="grc">s</foreign></hi></note> sumus in patriam sicut<note>sicut
-						<hi rend="italic">codd. pler.</hi>: ita ut <foreign xml:lang="grc">e</foreign>: <hi rend="italic">om. P1</hi> (ut <hi rend="italic">P2 s.
+				atque divino non reducti<note>non solum reducti <hi rend="italic">Hb<foreign xml:lang="grc">ς</foreign>
+                     </hi>
+                  </note> sumus in patriam sicut<note>sicut
+						<hi rend="italic">codd. pler.</hi>: ita ut <foreign xml:lang="grc">ε</foreign>: <hi rend="italic">om. P1</hi> (ut <hi rend="italic">P2 s.
 						l., Bt</hi>)</note> non nulli clarissimi cives, sed equis insignibus et
-				curru aurato reportati. </p></div>
-			<div type="textpart" subtype="section" n="29"><p>
-			<milestone unit="para"/><reg>possum</reg> ego satis in Cn. Pompeium umquam gratus videri? qui non solum apud
+				curru aurato reportati. </p>
+            </div>
+            <div type="textpart" subtype="section" n="29">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>possum</reg> ego satis in Cn. Pompeium umquam gratus videri? qui non solum apud
 				vos, qui omnes idem sentiebatis, sed etiam apud universum populum salutem populi
 				Romani et conservatam per me et coniunctam esse cum mea dixerit; qui causam meam
 				prudentibus commendarit, imperitos edocuerit, eodemque tempore improbos auctoritate
 				sua compresserit, bonos excitarit; qui populum Romanum pro me tamquam pro fratre aut
-				pro parente non solum hortatus sit, verum etiam obsecrarit; qui cum<note>cum <hi rend="italic"><foreign xml:lang="grc">e</foreign>t</hi>: <hi rend="italic">om. P rell.</hi></note> ipse<note>ipse <hi rend="italic">om. t</hi></note>
-				propter metum dimicationis et sanguinis domo se teneret, iam<note>iam <hi rend="italic">PBt</hi>: etiam <hi rend="italic">rell.</hi></note> a
+				pro parente non solum hortatus sit, verum etiam obsecrarit; qui cum<note>cum <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>t</hi>: <hi rend="italic">om. P rell.</hi>
+                  </note> ipse<note>ipse <hi rend="italic">om. t</hi>
+                  </note>
+				propter metum dimicationis et sanguinis domo se teneret, iam<note>iam <hi rend="italic">PBt</hi>: etiam <hi rend="italic">rell.</hi>
+                  </note> a
 				superioribus tribunis petierit ut de salute mea et promulgarent et referrent; qui in
 				colonia nuper constituta cum ipse gereret magistratum, in qua nemo erat emptus
 				intercessor, vim et crudelitatem privilegi auctoritate honestissimorum hominum et
-				publicis litteris consignarit<note>consignavit <hi rend="italic">codd.</hi></note>,
+				publicis litteris consignarit<note>consignavit <hi rend="italic">codd.</hi>
+                  </note>,
 				princepsque Italiae totius praesidium ad meam salutem implorandum putarit; qui cum
 				ipse mihi semper amicissimus fuisset, etiam ut suos necessarios mihi amicos redderet
-				elaborarit. </p></div><milestone n="12" unit="chapter"/>
-			<div type="textpart" subtype="section" n="30"><p><reg>quibus</reg> autem officiis T. Anni beneficia remunerabor? cuius omnis
+				elaborarit. </p>
+            </div>
+            <milestone n="12" unit="chapter"/>
+            <div type="textpart" subtype="section" n="30">
+               <p>
+                  <reg>quibus</reg> autem officiis T. Anni beneficia remunerabor? cuius omnis
 				ratio, cogitatio, totus denique tribunatus nihil aliud fuit nisi constans perpetua
 				fortis invicta defensio salutis meae. <reg>quid</reg> de P. Sestio loquar? qui suam
 				erga me benivolentiam et fidem non solum animi dolore sed etiam corporis vulneribus
 				ostendit. 
-			<milestone unit="para"/><reg>vobis</reg> vero, patres conscripti, singulis et egi et agam gratias: universis
-				egi initio<note>ab initio <hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi></note>, quantum potui, satis ornate agere nullo modo
+			<milestone unit="para"/>
+                  <reg>vobis</reg> vero, patres conscripti, singulis et egi et agam gratias: universis
+				egi initio<note>ab initio <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi>
+                  </note>, quantum potui, satis ornate agere nullo modo
 				possum. <reg>et</reg> quamquam sunt in me praecipua merita multorum, quae
-					sileri<note>sileri <hi rend="italic">BH et pler.</hi>: silere <hi rend="italic">P1 all.</hi></note> nullo modo possunt<note>possunt <hi rend="italic">PBHk all.</hi>: possum <hi rend="italic">codd.
-					pler.</hi></note>, tamen huius temporis ac timoris mei non est conari
+					sileri<note>sileri <hi rend="italic">BH et pler.</hi>: silere <hi rend="italic">P1 all.</hi>
+                  </note> nullo modo possunt<note>possunt <hi rend="italic">PBHk all.</hi>: possum <hi rend="italic">codd.
+					pler.</hi>
+                  </note>, tamen huius temporis ac timoris mei non est conari
 				commemorare beneficia in me singulorum; nam difficile est non aliquem, nefas
 				quemquam praeterire. <reg>ego</reg> vos universos, patres conscripti, deorum numero
 				colere debeo. <reg>sed</reg> ut in ipsis dis immortalibus non semper eosdem atque
 				alias alios solemus et venerari et precari, sic in hominibus de me divinitus
 					meritis<note>meritis: <hi rend="italic">sic distinxi.</hi>
-					<hi rend="italic">'Certe desideratur</hi> conferenda <hi rend="italic">aut</hi> vix satis (erit)' <hi rend="italic">Mueller</hi>: <hi rend="italic">sed cf. ad Quir.</hi> § 9: propinqui ... mihi ad deprecandam
+                     <hi rend="italic">'Certe desideratur</hi> conferenda <hi rend="italic">aut</hi> vix satis (erit)' <hi rend="italic">Mueller</hi>: <hi rend="italic">sed cf. ad Quir.</hi> § 9: propinqui ... mihi ad deprecandam
 					calamitatem meam non fuerunt</note>: omnis erit aetas mihi ad eorum erga me
-				merita praedicanda atque recolenda, </p></div>
-			<div type="textpart" subtype="section" n="31"><p>hodierno autem
+				merita praedicanda atque recolenda, </p>
+            </div>
+            <div type="textpart" subtype="section" n="31">
+               <p>hodierno autem
 				die nominatim a me magistratibus statui gratias esse agendas, et de privatis uni,
 				qui pro salute mea municipia coloniasque adisset, populum Romanum supplex
 				obsecrasset, sententiam dixisset eam quam vos secuti mihi dignitatem meam
@@ -544,89 +766,132 @@
 				vestis et prope luctu vestro, quoad licuit, defendistis. <reg>nostra</reg> memoria
 				senatores ne in suis quidem periculis mutare vestem solebant: in meo periculo
 				senatus veste mutata fuit, quoad licuit per eorum edicta qui mea pericula non modo
-				suo praesidio sed etiam vestra deprecatione nudarunt. </p></div>
-			<div type="textpart" subtype="section" n="32"><p>
-			<milestone unit="para"/><reg>quibus</reg> ego rebus obiectis, cum mihi privato confligendum viderem cum eodem
+				suo praesidio sed etiam vestra deprecatione nudarunt. </p>
+            </div>
+            <div type="textpart" subtype="section" n="32">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>quibus</reg> ego rebus obiectis, cum mihi privato confligendum viderem cum eodem
 				exercitu quem consul non armis sed vestra auctoritate superaram, multa mecum ipse
-				reputavi. <milestone n="13" unit="chapter"/><reg>dixerat</reg> in contione consul se
+				reputavi. <milestone n="13" unit="chapter"/>
+                  <reg>dixerat</reg> in contione consul se
 				clivi Capitolini poenas ab equitibus Romanis repetiturum; nominatim alii
 				compellabantur, alii citabantur, alii relegabantur; aditus templorum erant non solum
 				praesidiis et manu verum etiam demolitione sublati. <reg>alter</reg> consul, ut me
 				et rem publicam non modo desereret sed etiam hostibus rei publicae proderet,
-					pactionibus<note>pactionibus <hi rend="italic">PHbk</hi>: peticionibus <hi rend="italic">Bt</hi></note> se<note>se <hi rend="italic">Halm</hi>: eos
-						<hi rend="italic">codd.</hi></note> suorum praemiorum obligarat.
+					pactionibus<note>pactionibus <hi rend="italic">PHbk</hi>: peticionibus <hi rend="italic">Bt</hi>
+                  </note> se<note>se <hi rend="italic">Halm</hi>: eos
+						<hi rend="italic">codd.</hi>
+                  </note> suorum praemiorum obligarat.
 					<reg>erat</reg> alius ad portas cum imperio in multos annos magnoque exercitu,
 				quem ego inimicum mihi fuisse non dico, tacuisse, cum diceretur esse inimicus, scio.
-					</p></div>
-			<div type="textpart" subtype="section" n="33"><p><reg>duae</reg> partes esse in re publica cum
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="33">
+               <p>
+                  <reg>duae</reg> partes esse in re publica cum
 				putarentur, altera me deposcere propter inimicitias, altera timide defendere propter
 				suspicionem caedis putabatur. <reg>qui</reg> autem me deposcere
-					videbantur<note>dicebantur <foreign xml:lang="grc">e</foreign></note>, in
+					videbantur<note>dicebantur <foreign xml:lang="grc">ε</foreign>
+                  </note>, in
 					hoc<note>in hoc <hi rend="italic">codd. praeter</hi>
-					<foreign xml:lang="grc">e</foreign> (hoc), <hi rend="italic">c</hi> (in huius),
+                     <foreign xml:lang="grc">ε</foreign> (hoc), <hi rend="italic">c</hi> (in huius),
 						<hi rend="italic">b</hi> (ii huius): ii hoc <hi rend="italic">coni.
-						Halm</hi></note> auxerunt dimicationis metum, quod numquam infitiando
+						Halm</hi>
+                  </note> auxerunt dimicationis metum, quod numquam infitiando
 				suspicionem hominum curamque minuerunt. <reg>qua</reg> re cum viderem senatum
 				ducibus orbatum, me a magistratibus partim oppugnatum, partim proditum, partim
 				derelictum, servos simulatione conlegiorum nominatim esse conscriptos, copias omnis
 				Catilinae paene isdem ducibus ad spem caedis et incendiorum esse revocatas, equites
 				Romanos proscriptionis, municipia vastitatis, omnis caedis metu esse permotos,
 				potui, potui, patres conscripti, multis auctoribus fortissimis viris me vi armisque
-				defendere, nec mihi ipsi<note>ipsi <hi rend="italic">Heumann</hi>: ipse <hi rend="italic">codd.</hi></note> ille animus idem meus vobis non incognitus
+				defendere, nec mihi ipsi<note>ipsi <hi rend="italic">Heumann</hi>: ipse <hi rend="italic">codd.</hi>
+                  </note> ille animus idem meus vobis non incognitus
 				defuit. <reg>sed</reg> videbam, si vicissem praesentem adversarium, nimium multos
 				mihi alios esse vincendos; si victus essem, multis bonis et pro me et mecum etiam
 				post me esse pereundum, tribuniciique sanguinis ultores esse praesentis, meae mortis
-				poenas iudicio et posteritati reservari. </p></div><milestone n="14" unit="chapter"/>
-			<div type="textpart" subtype="section" n="34"><p><reg>nolui</reg>, cum consul communem
+				poenas iudicio et posteritati reservari. </p>
+            </div>
+            <milestone n="14" unit="chapter"/>
+            <div type="textpart" subtype="section" n="34">
+               <p>
+                  <reg>nolui</reg>, cum consul communem
 				salutem sine ferro defendissem, meam privatus armis defendere, bonosque viros lugere
-				malui meas fortunas quam suis desperare; ac, si solus<note>at <hi rend="italic">GHks</hi></note> essem interfectus, mihi turpe, si cum multis, rei publicae
+				malui meas fortunas quam suis desperare; ac, si solus<note>at <hi rend="italic">GHks</hi>
+                  </note> essem interfectus, mihi turpe, si cum multis, rei publicae
 				funestum fore videbatur. <reg>quod</reg> si mihi aeternam esse aerumnam propositam
 				arbitrarer, morte me ipse potius quam sempiterno dolore multassem. <reg>sed</reg>
 				cum viderem me non diutius quam ipsam rem publicam ex hac urbe afuturum, neque ego
-				illa exterminata mihi remanendum<note>remanendum amplius <hi rend="italic"><foreign xml:lang="grc">e</foreign>e</hi></note> putavi, et illa, simul atque
-				revocata est<note>est <hi rend="italic">om. PB</hi></note>, me secum pariter
+				illa exterminata mihi remanendum<note>remanendum amplius <hi rend="italic">
+                        <foreign xml:lang="grc">ε</foreign>e</hi>
+                  </note> putavi, et illa, simul atque
+				revocata est<note>est <hi rend="italic">om. PB</hi>
+                  </note>, me secum pariter
 				reportavit. <reg>mecum</reg> leges, mecum quaestiones, mecum iura magistratuum,
 				mecum senatus auctoritas, mecum libertas, mecum etiam frugum ubertas, mecum deorum
 				et hominum sanctitates omnes et religiones afuerunt. <reg>quae</reg> si semper
 				abessent, magis vestras fortunas lugerem quam desiderarem meas; sin aliquando
-				revocarentur, intellegebam mihi cum illis una esse redeundum. </p></div>
-			<div type="textpart" subtype="section" n="35"><p><reg>cuius</reg> mei sensus certissimus testis est hic idem qui
+				revocarentur, intellegebam mihi cum illis una esse redeundum. </p>
+            </div>
+            <div type="textpart" subtype="section" n="35">
+               <p>
+                  <reg>cuius</reg> mei sensus certissimus testis est hic idem qui
 				custos capitis fuit, Cn. Plancius, qui omnibus provincialibus ornamentis commodisque
 				depositis totam suam quaesturam in me sustentando et conservando conlocavit.
 					<reg>qui</reg> si mihi quaestor imperatori<note>imperatori <hi rend="italic">et</hi> 14, 15 cum fuerit ... mei <hi rend="italic">del.
-					Garat.</hi></note> fuisset, in fili loco fuisset; nunc certe erit in parentis,
-				cum fuerit <add>consors</add><note>consors <hi rend="italic">scripsi</hi>: quaestor
+					Garat.</hi>
+                  </note> fuisset, in fili loco fuisset; nunc certe erit in parentis,
+				cum fuerit <add>consors</add>
+                  <note>consors <hi rend="italic">scripsi</hi>: quaestor
 						<hi rend="italic">codd.</hi> (<hi rend="italic">ex</hi> quae <hi rend="italic">s.</hi> que=quaere <hi rend="italic">ortum esse putat A. C.
 						Clark, cf. ad Mur.</hi> § 51: <hi rend="italic">verbum amissum potest
-						esse</hi> consors, particeps, socius): quaestor ⟨anno⟩ non imperi <hi rend="italic">K. Busche</hi></note> non imperi sed doloris mei. </p></div>
-			<div type="textpart" subtype="section" n="36"><p>
-			<milestone unit="para"/><reg>quapropter</reg>, patres conscripti, quoniam in rem publicam sum pariter cum re
-				publica restitutus, non modo in ea defendenda nihil minuam<note>imminuam <foreign xml:lang="grc">e</foreign></note> de libertate mea pristina, sed etiam
-				adaugebo. <milestone n="15" unit="chapter"/><reg>etenim</reg> si eam tum defendebam
+						esse</hi> consors, particeps, socius): quaestor ⟨anno⟩ non imperi <hi rend="italic">K. Busche</hi>
+                  </note> non imperi sed doloris mei. </p>
+            </div>
+            <div type="textpart" subtype="section" n="36">
+               <p>
+                  <milestone unit="para"/>
+                  <reg>quapropter</reg>, patres conscripti, quoniam in rem publicam sum pariter cum re
+				publica restitutus, non modo in ea defendenda nihil minuam<note>imminuam <foreign xml:lang="grc">ε</foreign>
+                  </note> de libertate mea pristina, sed etiam
+				adaugebo. <milestone n="15" unit="chapter"/>
+                  <reg>etenim</reg> si eam tum defendebam
 				cum mihi aliquid illa debebat, quid nunc me facere oportet cum ego illi plurimum
 				debeo? <reg>nam</reg> quid est quod animum meum frangere aut debilitare possit,
 				cuius ipsam calamitatem non modo nullius delicti, sed etiam divinorum<note>divinorum
-						<hi rend="italic">PB</hi>: duorum <foreign xml:lang="grc">e</foreign>:
-					binorum <hi rend="italic">Madv.</hi></note> in rem publicam beneficiorum testem
-				esse videatis? <reg>nam</reg><note>Nam et <foreign xml:lang="grc">e</foreign></note>
+						<hi rend="italic">PB</hi>: duorum <foreign xml:lang="grc">ε</foreign>:
+					binorum <hi rend="italic">Madv.</hi>
+                  </note> in rem publicam beneficiorum testem
+				esse videatis? <reg>nam</reg>
+                  <note>Nam et <foreign xml:lang="grc">ε</foreign>
+                  </note>
 				importata est quia defenderam civitatem, et mea voluntate suscepta est, ne a me
-				defensa res publica per eundem me extremum in discrimen vocaretur. </p></div>
-			<div type="textpart" subtype="section" n="37"><p><reg>pro</reg> me non ut pro P. Popilio, nobilissimo homine,
+				defensa res publica per eundem me extremum in discrimen vocaretur. </p>
+            </div>
+            <div type="textpart" subtype="section" n="37">
+               <p>
+                  <reg>pro</reg> me non ut pro P. Popilio, nobilissimo homine,
 				adulescentes filii, non propinquorum multitudo populum Romanum est deprecata, non ut
 				pro Q. Metello, summo et clarissimo viro, spectata iam adulescentia filius, non L.
 				et C. Metelli, consulares, non eorum liberi, non Q. Metellus Nepos, qui tum
-				consulatum petebat, non Luculli, Servilii, Scipiones, Metellarum<note>Metellarum <hi rend="italic">Manut.</hi>: -orum <hi rend="italic">codd.</hi></note> filii
+				consulatum petebat, non Luculli, Servilii, Scipiones, Metellarum<note>Metellarum <hi rend="italic">Manut.</hi>: -orum <hi rend="italic">codd.</hi>
+                  </note> filii
 				flentes ac sordidati populo Romano supplicaverunt; sed unus frater, qui in me
 				pietate filius, consiliis parens, amore, ut erat, frater inventus est, squalore et
 				lacrimis et cotidianis precibus desiderium mei nominis renovari et rerum gestarum
 				memoriam usurpari coegit. <reg>qui</reg> cum statuisset, nisi per vos me<note>per
-					vos me <hi rend="italic">Hb<foreign xml:lang="grc">s</foreign>s</hi>: me per
-					vos <foreign xml:lang="grc">e</foreign>: me <hi rend="italic">om. P
-					rell.</hi></note> reciperasset, eandem subire fortunam atque idem sibi
-				domicilium et vitae et mortis deposcere<note>deposcere <hi rend="italic">Madv.</hi>: -eret <hi rend="italic">codd.</hi></note>, tamen numquam nec
+					vos me <hi rend="italic">Hb<foreign xml:lang="grc">ς</foreign>s</hi>: me per
+					vos <foreign xml:lang="grc">ε</foreign>: me <hi rend="italic">om. P
+					rell.</hi>
+                  </note> reciperasset, eandem subire fortunam atque idem sibi
+				domicilium et vitae et mortis deposcere<note>deposcere <hi rend="italic">Madv.</hi>: -eret <hi rend="italic">codd.</hi>
+                  </note>, tamen numquam nec
 				magnitudinem negoti nec solitudinem suam nec vim inimicorum ac tela pertimuit.
-					</p></div>
-			<div type="textpart" subtype="section" n="38"><p><reg>alter</reg> fuit propugnator mearum
+					</p>
+            </div>
+            <div type="textpart" subtype="section" n="38">
+               <p>
+                  <reg>alter</reg> fuit propugnator mearum
 				fortunarum et defensor adsiduus, summa virtute et pietate, C. Piso gener, qui minas
 				inimicorum meorum, qui inimicitias adfinis mei, propinqui sui, consulis, qui Pontum
 				et Bithyniam quaestor prae mea salute neglexit. <reg>nihil</reg> umquam senatus de
@@ -637,16 +902,21 @@
 				expulsus est, non modo a senatu non est restitutus, sed reditu suo senatum cunctum
 				paene delevit. <reg>nulla</reg> de illis magistratuum consensio, nulla ad rem
 				publicam defendendam populi Romani convocatio, nullus Italiae motus, nulla decreta
-				municipiorum et coloniarum exstiterunt. </p></div>
-			<div type="textpart" subtype="section" n="39"><p><reg>qua</reg> re, cum me vestra auctoritas arcessierit<note>arcessierit
-						<foreign xml:lang="grc">e</foreign>
-					<hi rend="italic">Par.</hi> 7774: arcesserit <hi rend="italic">PBH</hi>:
-					accersierit <hi rend="italic">Gb2cs</hi></note>, populus Romanus vocarit, res
+				municipiorum et coloniarum exstiterunt. </p>
+            </div>
+            <div type="textpart" subtype="section" n="39">
+               <p>
+                  <reg>qua</reg> re, cum me vestra auctoritas arcessierit<note>arcessierit
+						<foreign xml:lang="grc">ε</foreign>
+                     <hi rend="italic">Par.</hi> 7774: arcesserit <hi rend="italic">PBH</hi>:
+					accersierit <hi rend="italic">Gb2cs</hi>
+                  </note>, populus Romanus vocarit, res
 				publica implorarit, Italia cuncta paene suis umeris reportarit, non committam,
 				patres conscripti, ut, cum ea mihi sint restituta quae in potestate mea non fuerunt,
 				ea non habeam quae ipse praestare possim, praesertim cum illa amissa reciperarim,
-				virtutem et fidem numquam amiserim.</p></div>
-		</div>
-	</body></text>
-
+				virtutem et fidem numquam amiserim.</p>
+            </div>
+         </div>
+      </body>
+   </text>
 </TEI>

--- a/data/phi0893/phi001/__cts__.xml
+++ b/data/phi0893/phi001/__cts__.xml
@@ -1,11 +1,12 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0893.phi001" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0893">
-            <ti:title xml:lang="lat">Odes</ti:title>
+            <ti:title xml:lang="lat">Carmina</ti:title>
+            <ti:title xml:lang="eng">Odes</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi0893.phi001.perseus-lat2" workUrn="urn:cts:latinLit:phi0893.phi001">
-              <ti:label xml:lang="eng">Odes, Horace Odes and epodes</ti:label>
+              <ti:label xml:lang="lat">Carmina</ti:label>
               <ti:description xml:lang="eng">Horace, creator; Shorey, Paul, 1857-1934, editor; Laing, Gordon Jennings, 1869-, joint editor; Laing, Gordon Jennings, 1869-1945, joint editor</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0893.phi001.perseus-eng2" workUrn="urn:cts:latinLit:phi0893.phi001">
-              <ti:label xml:lang="eng">Odes, Carmina</ti:label>
+              <ti:label xml:lang="eng">Odes</ti:label>
               <ti:description xml:lang="eng">Horace, creator; Conington, John, 1825-1869, editor</ti:description>
             </ti:translation>
           </ti:work>

--- a/data/phi0972/phi001/__cts__.xml
+++ b/data/phi0972/phi001/__cts__.xml
@@ -4,7 +4,6 @@
         workUrn="urn:cts:latinLit:phi0972.phi001">
         <label xml:lang="lat">Titi Petroni Arbitri Satyricon</label>
         <description xml:lang="eng">Petronius, with an English translation by Michael Heseltine.
-            Seneca. Apocolocyntosis, with an English translation by W.H.D. Rouse. Petronius Arbiter, creator; 
-            Heseltine, Michael, editor and translator. London: William Heinemann Ltd. New York: G. P. Putnam's Sons. 1913.</description>
+            Petronius Arbiter, creator; Heseltine, Michael, editor and translator. London: William Heinemann Ltd. New York: G. P. Putnam's Sons. 1913.</description>
     </edition>
 </work>

--- a/data/stoa0276/__cts__.xml
+++ b/data/stoa0276/__cts__.xml
@@ -1,4 +1,4 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:cts="http://chs.harvard.edu/xmlns/cts/ti" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:stoa0276">
-          <ti:groupname xml:lang="eng">Tertullian ca. 160-ca. 230</ti:groupname>
+          <ti:groupname xml:lang="eng">Pseudo-Tertullian</ti:groupname>
           </ti:textgroup>
       


### PR DESCRIPTION
1. remove erroneous reference to Seneca in Petronius metadata
2. Corrected author name for stoa0276 to Pseudo-Tertullian
3. Fixed cts title metadata for Caesar's Gallic War and Civil War
4. Converted betacode to unicode in some of Cicero's texts

