### PR TITLE
phi0472.phi001

### DIFF
--- a/data/phi0472/phi001/phi0472.phi001.perseus-eng3.xml
+++ b/data/phi0472/phi001/phi0472.phi001.perseus-eng3.xml
@@ -6,9 +6,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
       <titleStmt>
         <!--This is the overall file title. It's not really used.-->
         <title xml:lang="lat">Carmina</title>
-        <title type="sub">Machine readable text</title>
         <author xml:lang="lat">C. Valerius Catullus</author>
-        <editor role="editor" n="Burton">Sir Richard Francis Burton</editor>
+        <editor role="translator">Sir Richard Francis Burton</editor>
 <sponsor>Perseus Project, Tufts University</sponsor>
     <principal>Gregory Crane</principal>
         <respStmt>
@@ -32,10 +31,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
     <monogr>
       <author>Catullus</author>
       <title>The Carmina of Gaius Valerius Catullus.</title>
-      <respStmt>
-        <name>Sir Richard Francis Burton</name>
-        <resp>translator</resp>
-      </respStmt>
+      <editor>Leonard C. Smithers</editor>   
+      <editor>Sir Richard Francis Burton</editor>
       <imprint>
               <pubPlace>London</pubPlace>
               <publisher>For translator for private use</publisher>

--- a/data/phi0472/phi001/phi0472.phi001.perseus-eng3.xml
+++ b/data/phi0472/phi001/phi0472.phi001.perseus-eng3.xml
@@ -5,9 +5,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
     <fileDesc>
       <titleStmt>
         <!--This is the overall file title. It's not really used.-->
-        <title>Carmina</title>
+        <title xml:lang="lat">Carmina</title>
         <title type="sub">Machine readable text</title>
-        <author>C. Valerius Catullus</author>
+        <author xml:lang="lat">C. Valerius Catullus</author>
         <editor role="editor" n="Burton">Sir Richard Francis Burton</editor>
 <sponsor>Perseus Project, Tufts University</sponsor>
     <principal>Gregory Crane</principal>
@@ -31,18 +31,18 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
   <biblStruct>
     <monogr>
       <author>Catullus</author>
-      <title>Carmina</title><idno type="OCLC">878062</idno>
+      <title>The Carmina of Gaius Valerius Catullus.</title>
       <respStmt>
         <name>Sir Richard Francis Burton</name>
-        <resp>trans.</resp>
+        <resp>translator</resp>
       </respStmt>
       <imprint>
               <pubPlace>London</pubPlace>
               <publisher>For translator for private use</publisher>
               <date>1894</date>
-      </imprint>
+      </imprint>    
     </monogr>
-    
+    <ref target="HathiTrust">http://hdl.handle.net/2027/uc2.ark:/13960/t5q81d82b</ref>
   </biblStruct>
       </sourceDesc>
     </fileDesc>

--- a/data/phi0472/phi001/phi0472.phi001.perseus-eng3.xml
+++ b/data/phi0472/phi001/phi0472.phi001.perseus-eng3.xml
@@ -31,6 +31,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
     <monogr>
       <author>Catullus</author>
       <title>The Carmina of Gaius Valerius Catullus.</title>
+      <title type="sub">Now first completely Englished into verse and prose, the metrical part by Captain Sir Richard F. Burton,
+        and the prose portion, introduction and notes explanatory and illustrative by Leonard C. Smithers</title>
       <editor>Leonard C. Smithers</editor>   
       <editor>Sir Richard Francis Burton</editor>
       <imprint>

--- a/data/phi0472/phi001/phi0472.phi001.perseus-eng4.xml
+++ b/data/phi0472/phi001/phi0472.phi001.perseus-eng4.xml
@@ -4,9 +4,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
      <teiHeader>
           <fileDesc>
                <titleStmt>
-                    <title>Carmina</title>
+                    <title xml:lang="lat">Carmina</title>
                     <title type="sub">Machine readable text</title>
-                    <author n="Catul.">C. Valerius Catullus</author>
+                    <author xml:lang="lat">C. Valerius Catullus</author>
                     <editor role="editor" n="Smithers">Leonard C. Smithers</editor> 
                     <sponsor>Perseus Project, Tufts University</sponsor>
                    <principal>Gregory Crane</principal>
@@ -27,15 +27,15 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
                     <biblStruct>
                          <monogr>
                               <author>Catullus</author>
-                              <title>The Carmina of Gaius Valerius Catullus.</title><idno type="OCLC">878062</idno>
-                              <editor role="editor">Leonard C. Smithers</editor>
+                              <title>The Carmina of Gaius Valerius Catullus.</title>
+                              <editor role="editor">Leonard C. Smithers</editor>                              
                               <imprint>
                                    <pubPlace>London</pubPlace>
-                                   <publisher>Smithers.</publisher>
+                                   <publisher>For translator for private use</publisher>
                                    <date>1894</date>
                               </imprint>
                          </monogr>
-                         
+                         <ref target="HathiTrust">http://hdl.handle.net/2027/uc2.ark:/13960/t5q81d82b</ref>
                     </biblStruct>
                </sourceDesc>
           </fileDesc>

--- a/data/phi0472/phi001/phi0472.phi001.perseus-eng4.xml
+++ b/data/phi0472/phi001/phi0472.phi001.perseus-eng4.xml
@@ -27,6 +27,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
                          <monogr>
                               <author>Catullus</author>
                               <title>The Carmina of Gaius Valerius Catullus.</title>
+                              <title type="sub">Now first completely Englished into verse and prose, the metrical part by Captain Sir Richard F. Burton,
+                                   and the prose portion, introduction and notes explanatory and illustrative by Leonard C. Smithers</title>
                               <editor>Leonard C. Smithers</editor>   
                               <editor>Sir Richard Francis Burton</editor>                              
                               <imprint>

--- a/data/phi0472/phi001/phi0472.phi001.perseus-eng4.xml
+++ b/data/phi0472/phi001/phi0472.phi001.perseus-eng4.xml
@@ -5,9 +5,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
           <fileDesc>
                <titleStmt>
                     <title xml:lang="lat">Carmina</title>
-                    <title type="sub">Machine readable text</title>
                     <author xml:lang="lat">C. Valerius Catullus</author>
-                    <editor role="editor" n="Smithers">Leonard C. Smithers</editor> 
+                    <editor role="translator">Leonard C. Smithers</editor> 
                     <sponsor>Perseus Project, Tufts University</sponsor>
                    <principal>Gregory Crane</principal>
                     <respStmt>
@@ -28,7 +27,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
                          <monogr>
                               <author>Catullus</author>
                               <title>The Carmina of Gaius Valerius Catullus.</title>
-                              <editor role="editor">Leonard C. Smithers</editor>                              
+                              <editor>Leonard C. Smithers</editor>   
+                              <editor>Sir Richard Francis Burton</editor>                              
                               <imprint>
                                    <pubPlace>London</pubPlace>
                                    <publisher>For translator for private use</publisher>

--- a/data/phi0472/phi001/phi0472.phi001.perseus-lat2.xml
+++ b/data/phi0472/phi001/phi0472.phi001.perseus-lat2.xml
@@ -4,9 +4,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 <teiHeader>
     <fileDesc>
       <titleStmt>
-  <title>Carmina</title>
+  <title xml:lang="lat">Carmina</title>
   <title type="sub">Machine readable text</title>
-  <author>C. Valerius Catullus</author>
+  <author xml:lang="lat">C. Valerius Catullus</author>
   <editor role="editor">E. T. Merrill</editor>
   <sponsor>Perseus Project, Tufts University</sponsor>
     <principal>Gregory Crane</principal>
@@ -38,6 +38,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
               <date>1893</date>
             </imprint>
           </monogr>
+          <ref target="https://archive.org/details/catulluseditedby00catuuoft/">Internet Archive</ref>
         </biblStruct>
       </sourceDesc>
     </fileDesc>


### PR DESCRIPTION
Updated headers to reflect First1K standards.

Also @lcerrato I have a question for you. The two headers for the English translations that are from the same edition have two different ways of showing responsibility in the monogr section. 

phi0472.phi001.perseus-eng3 has:
   <respStmt>
        <name>Sir Richard Francis Burton</name>
        <resp>translator</resp>
      </respStmt>

while phi0472.phi001.perseus-eng4 has:
 <editor role="editor">Leonard C. Smithers</editor>    

I wasn't sure what one should be used. Thanks! 