### PR TITLE
phi1038.phi001.perseus-lat1

### DIFF
--- a/data/phi1038/__cts__.xml
+++ b/data/phi1038/__cts__.xml
@@ -1,4 +1,4 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:cts="http://chs.harvard.edu/xmlns/cts/ti" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:phi1038">
-          <ti:groupname xml:lang="eng">Paris, Julius</ti:groupname>
+          <ti:groupname xml:lang="lat">Valerius Maximus</ti:groupname>
           </ti:textgroup>
       

--- a/data/phi1038/phi001/__cts__.xml
+++ b/data/phi1038/phi001/__cts__.xml
@@ -1,8 +1,11 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi1038.phi001" xml:lang="lat" groupUrn="urn:cts:latinLit:phi1038">
             <ti:title xml:lang="lat">Facta et Dicta Memorabilia</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi1038.phi001.perseus-lat1" workUrn="urn:cts:latinLit:phi1038.phi001">
-              <ti:label xml:lang="eng">Facta et Dicta Memorabilia, Factorum et dictorum memorabilium libri novem cum Iulii Paridis et Ianuarii Nepotiani epitomis</ti:label>
-              <ti:description xml:lang="eng">Valerius Maximus, creator; Kempf, Karl Friedrich, 1819-, editor</ti:description>
+              <ti:label xml:lang="lat">Facta et Dicta Memorabilia</ti:label>
+              <ti:description xml:lang="mul">Valerius Maximus. Kempf, Karl Friedrich, editor. Factorum et 
+                dictorum memorabilium libri novem cum Iulii Paridis et Ianuarii Nepotiani epitomis. Leipzig: Teubner,
+                1888.
+              </ti:description>
             </ti:edition>
           </ti:work>
         

--- a/data/phi1038/phi001/__cts__.xml
+++ b/data/phi1038/phi001/__cts__.xml
@@ -2,10 +2,7 @@
             <ti:title xml:lang="lat">Facta et Dicta Memorabilia</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi1038.phi001.perseus-lat1" workUrn="urn:cts:latinLit:phi1038.phi001">
               <ti:label xml:lang="lat">Facta et Dicta Memorabilia</ti:label>
-              <ti:description xml:lang="mul">Valerius Maximus. Factorum et 
-                dictorum memorabilium libri novem cum Iulii Paridis et Ianuarii Nepotiani epitomis.
-                Kempf, Karl Friedrich, editor. Leipzig: Teubner, 1888.
-              </ti:description>
+              <ti:description xml:lang="mul">Valerius Maximus. Factorum et dictorum memorabilium libri novem cum Iulii Paridis et Ianuarii Nepotiani epitomis. Kempf, Karl Friedrich, editor. Leipzig: Teubner, 1888.</ti:description>
             </ti:edition>
           </ti:work>
         

--- a/data/phi1038/phi001/__cts__.xml
+++ b/data/phi1038/phi001/__cts__.xml
@@ -2,9 +2,9 @@
             <ti:title xml:lang="lat">Facta et Dicta Memorabilia</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi1038.phi001.perseus-lat1" workUrn="urn:cts:latinLit:phi1038.phi001">
               <ti:label xml:lang="lat">Facta et Dicta Memorabilia</ti:label>
-              <ti:description xml:lang="mul">Valerius Maximus. Kempf, Karl Friedrich, editor. Factorum et 
-                dictorum memorabilium libri novem cum Iulii Paridis et Ianuarii Nepotiani epitomis. Leipzig: Teubner,
-                1888.
+              <ti:description xml:lang="mul">Valerius Maximus. Factorum et 
+                dictorum memorabilium libri novem cum Iulii Paridis et Ianuarii Nepotiani epitomis.
+                Kempf, Karl Friedrich, editor. Leipzig: Teubner, 1888.
               </ti:description>
             </ti:edition>
           </ti:work>

--- a/data/phi1038/phi001/phi1038.phi001.perseus-lat1.xml
+++ b/data/phi1038/phi001/phi1038.phi001.perseus-lat1.xml
@@ -6,8 +6,8 @@
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title type="work">Facta et Dicta Memorabilia</title>
-        <title type="sub">Machine readable text</title><author n="Valerius Maximus">Valerius Maximus</author>
+        <title xml:lang="lat">Facta et Dicta Memorabilia</title>
+        <author>Valerius Maximus</author>
         <editor>Karl Friedrich Kempf</editor>	       
         <funder n="org:Mellon">The Mellon Foundation</funder>
       <sponsor>Perseus Project, Tufts University</sponsor>
@@ -30,10 +30,11 @@
         <biblStruct>
           <monogr>
             <author>Valerius Maximus</author>
-            <title>Factorvm et Dictorvm Memorabilivm, Libri Novem</title>            
-            <editor role="editor" n="Kempf">Karl Friedrich Kempf</editor>            
+            <title xml:lang="lat">Factorum et dictorum memorabilium libri novem
+              cum Iulii Paridis et Ianuarii Nepotiani epitomis</title>            
+            <editor>Karl Friedrich Kempf</editor>            
             <imprint>
-              <pubPlace>Leipsig</pubPlace>
+              <pubPlace>Leipzig</pubPlace>
               <publisher>Teubner</publisher>
               <date>1888</date>
             </imprint>


### PR DESCRIPTION
Renamed main CTS file-text group incorrectly listed as Julius Paris instead of Valerius Maximus
Updated CTS metadata for edition.
Updated header information.

URN has not yet been bumped but file is showing up in Scaife Viewer.