### PR TITLE
(phi1348)-phi1348.abo011_cts_and_tei.xml-first pass

### DIFF
--- a/data/phi1348/__cts__.xml
+++ b/data/phi1348/__cts__.xml
@@ -1,4 +1,4 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:phi1348">
-          <ti:groupname xml:lang="eng">Suetonius ca. 69-ca. 122</ti:groupname>
+          <ti:groupname xml:lang="lat">Suetonius</ti:groupname>
           </ti:textgroup>
       

--- a/data/phi1348/abo011/__cts__.xml
+++ b/data/phi1348/abo011/__cts__.xml
@@ -1,11 +1,12 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi1348.abo011" xml:lang="lat" groupUrn="urn:cts:latinLit:phi1348">
             <ti:title xml:lang="lat">Divus Julius</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi1348.abo011.perseus-lat2" workUrn="urn:cts:latinLit:phi1348.abo011">
-              <ti:label xml:lang="eng">Divus Julius, De Vita Caesarum Libri VIII</ti:label>
-              <ti:description xml:lang="eng">Suetonius, ca. 69-ca. 122, creator; Ihm, Max, 1863-1909, editor</ti:description>
+              <ti:label xml:lang="lat">Divus Julius</ti:label>
+              <ti:description xml:lang="mul">Suetonius. De Vita Caesarum Libri VIII. Ihm, Max, editor; Leipzig: Teubner, 1908.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi1348.abo011.perseus-eng2" workUrn="urn:cts:latinLit:phi1348.abo011">
-              <ti:label xml:lang="eng">Divus Julius, The Lives of the twelve Caesars</ti:label>
-              <ti:description xml:lang="eng">Suetonius, ca. 69-ca. 122, creator; Thomson, Alexander, M.D, translator; Reed, J.E. (J. Eugene), editor</ti:description>
+              <ti:label xml:lang="eng">Julius Caesar</ti:label>
+            <ti:description xml:lang="eng">Suetonius. Suetonius: The Lives of the Twelve Caesars. Thomson, Alexander, M.D, translator; Reed, J.E. (J. Eugene), editor.
+            Philadelphia:  Gebbie &amp; Commpany, 1889.</ti:description>
             </ti:translation>
           </ti:work>

--- a/data/phi1348/abo011/phi1348.abo011.perseus-eng2.xml
+++ b/data/phi1348/abo011/phi1348.abo011.perseus-eng2.xml
@@ -4,9 +4,9 @@
 	<teiHeader>
 		<fileDesc>
 			<titleStmt>
-				<title><rs key="Julius Caesar">Julius Caesar</rs><rs key="Forum of Caesar"/><rs key="Temple of Julius Caesar"/> from The Lives of the Caesars</title>
+				<title><rs key="Julius Caesar">Julius Caesar</rs><rs key="Forum of Caesar"/><rs key="Temple of Julius Caesar"/></title>
 				<author>C. Suetonius Tranquillus</author>
-				<editor role="editor">Alexander Thomson</editor>
+				<editor role="translator">Alexander Thomson</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -33,11 +33,8 @@
 							Augmented with the Biographies of Contemporary Statesmen, Orators,
 							Poets, and Other Associates</title>
 						<author>Suetonius</author>
-						<respStmt>
-							<resp>Publishing Editor</resp>
-							<name>J. Eugene Reed</name>
-						</respStmt>
-						<editor role="editor">Alexander Thomson</editor>
+						<editor>J. Eugene Reed</editor>
+						<editor role="translator">Alexander Thomson</editor>
 						<imprint>
 							<pubPlace>Philadelphia</pubPlace>
 							<publisher>Gebbie &amp; Co.</publisher>

--- a/data/phi1348/abo011/phi1348.abo011.perseus-lat2.xml
+++ b/data/phi1348/abo011/phi1348.abo011.perseus-lat2.xml
@@ -5,10 +5,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title>Divus Julius from De Vita Caesarum</title>
-        <title type="sub">Machine readable text</title>
-        <author>C. Suetonius Tranquillus</author>
-        <editor role="editor">Maximilian Ihm</editor>
+        <title xml:lang="lat">Divus Julius</title>
+        <author xml:lang="lat">C. Suetonius Tranquillus</author>
+        <editor>Maximilian Ihm</editor>
         <sponsor>Perseus Project, Tufts University</sponsor>
         <principal>Gregory Crane</principal>
         <respStmt>
@@ -28,10 +27,19 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
       </publicationStmt>
 
       <sourceDesc>
-        <bibl>
-          <idno type="ISBN">3519018276</idno>
-          <ref target="http://babel.hathitrust.org/cgi/pt?id=njp.32101077774014">HathiTrust</ref>
-        </bibl>
+        <biblStruct>
+          <monogr>
+            <title xml:lang="lat">De Vita Caesarum Libri VIII</title>
+            <author>Suetonius</author>
+            <editor>Maximilian Ihm</editor>
+            <imprint>
+              <pubPlace>Leipzig</pubPlace>
+              <publisher>Teubner</publisher>
+              <date>1908</date>
+            </imprint>
+          </monogr>          
+          <ref target="https://hdl.handle.net/2027/njp.32101077774014?urlappend=%3Bseq=25">HathiTrust</ref>
+        </biblStruct>
       </sourceDesc>
     </fileDesc>
 


### PR DESCRIPTION
For issue #428
So where to begin, I updated the textgroup name to eliminate the dates since I'm pretty sure that is now standard practice.
I have a few questions @lcerrato about these file headers.

1) The title for both phi1348.phi011.opp-lat1 and opp-eng1 had "from De Vita Caesarum" and from The Lives
of the Caesars after the work title and I deleted this in each case. Was that correct to do? 

2) phi1348.phi011.perseus-lat2 didn't have edition information at all, it just had a
 HathiTrust link and the following:
   `<bibl>
               <idno type="ISBN">3519018276</idno>
            </bibl>`
I deleted the ISBN and created a full `</biblstruct>` edition statement and included a page level link to the work instead of the entire edition in Hathi Trust.  If this looks all right I will use this same format for the rest of the Latin works of Suetonius.

3) phi1348.phi011.perseus-eng2
The title for this file reads:
`<title><rs key="Julius Caesar">Julius Caesar</rs><rs key="Forum of Caesar"/><rs key="Temple of Julius `Caesar"/></title>``
I've never seen this `<rs key>`  before in a TEI-XML header and after searching on all of canonical Latin literature it only seems to appear in Suetonius. I wasn't sure if this was something to leave in the XML text or if it should be deleted.  I left it in for the moment since I had no idea what it was a reference to. 

4) In the edition statement section of the phi1348.phi011.perseus-eng 2, I changed
`<respStmt>
		<resp>Publishing Editor</resp>
		<name>J. Eugene Reed</name>
		</respStmt>`
to `	<editor>J. Eugene Reed</editor>`
I've never seen Publishing Editor responsibility statements before and assume that was used a while ago.

5) I didn't add in a online link for the Perseus English edition because I could not find one.

If these changes seem all right I will continue on in editing these headers and editions as I catalog them. Thanks!
