### PR TITLE
(phi0959)_phi0959.phi001._phi0959.phi004.perseus-eng2/lat2

### DIFF
--- a/data/phi0959/phi001/__cts__.xml
+++ b/data/phi0959/phi001/__cts__.xml
@@ -8,10 +8,8 @@
         <ti:memberof collection="Perseus:collection:Greco-Roman" />
     </ti:edition>
     <ti:translation urn="urn:cts:latinLit:phi0959.phi001.perseus-eng2" workUrn="urn:cts:latinLit:phi0959.phi001" xml:lang="eng">
-      <ti:label xml:lang="eng">Amores.</ti:label>
+      <ti:label xml:lang="eng">Amores</ti:label>
         <ti:description xml:lang="eng">Ovid. Ovid's Art of Love (in three Books), the Remedy of Love, the Art of
-            Beauty, the Court of Love, the History of Love, and Amours. Dryden, John; Creech, Thomas; Hopkins, Charles; 
-            Duke, Richard; Cromwell, Henry; Sedley, Charles, Sir; Eusden, Laurence; Rochester, John Wilmot, Earl of,;
-            Rymer, Thomas; Stepney, George; translators. New York: Calvin Blanchard, 1855.</ti:description>
+            Beauty, the Court of Love, the History of Love, and Amours. Dryden, John, et al., translator. New York: Calvin Blanchard, 1855.</ti:description>
     </ti:translation>
 </ti:work>

--- a/data/phi0959/phi001/__cts__.xml
+++ b/data/phi0959/phi001/__cts__.xml
@@ -2,14 +2,16 @@
     <ti:title xml:lang="eng">Amores</ti:title>
     <ti:edition projid="latinLit:perseus-lat2" urn="urn:cts:latinLit:phi0959.phi001.perseus-lat2" workUrn="urn:cts:latinLit:phi0959.phi001">
         <ti:label xml:lang="eng">Amores</ti:label>
-        <ti:description xml:lang="eng">
-            Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
-                    amoris, R. Ehwald, edidit ex Rudolphi Merkelii recognitione, Leipzig, B. G. Teubner, 1907
+        <ti:description xml:lang="mul">Ovid. P. Ovidius Naso, Volume 1: Amores, Epistulae, Medicamina faciei femineae, Ars 
+            amatoria, Remedia amoris. Ehwald, Rudolf; Merkel, Rudolph; editors. Leipzig: B. G. Teubner, 1907.
         </ti:description>
         <ti:memberof collection="Perseus:collection:Greco-Roman" />
     </ti:edition>
     <ti:translation urn="urn:cts:latinLit:phi0959.phi001.perseus-eng2" workUrn="urn:cts:latinLit:phi0959.phi001" xml:lang="eng">
-      <ti:label xml:lang="eng">Amores, The Art of Love in Three Books The remedy of love. The art of beauty. The court of love. The history of love amours.</ti:label>
-      <ti:description xml:lang="eng">Ovid, 43 B.C.-17 or 18 A.D, creator; Dryden, John, 1631-1700, translator; Creech, Thomas, 1659-1700, translator; Hopkins, Charles, 1664?-1700?, translator; Duke, Richard, 1659?-1711, translator; Cromwell, Henry, 1659-1728, translator; Sedley, Charles, Sir, 1639-1701, translator; Eusden, Laurence, 1688-1730, translator; Rochester, John Wilmot, Earl of, 1647-1680, translator; Rymer, Thomas, 1641-1713, translator; Stepney, George, 1663-1707, translator; , editor</ti:description>
+      <ti:label xml:lang="eng">Amores.</ti:label>
+        <ti:description xml:lang="eng">Ovid. Ovid's Art of Love (in three Books), the Remedy of Love, the Art of
+            Beauty, the Court of Love, the History of Love, and Amours. Dryden, John; Creech, Thomas; Hopkins, Charles; 
+            Duke, Richard; Cromwell, Henry; Sedley, Charles, Sir; Eusden, Laurence; Rochester, John Wilmot, Earl of,;
+            Rymer, Thomas; Stepney, George; translators. New York: Calvin Blanchard, 1855.</ti:description>
     </ti:translation>
 </ti:work>

--- a/data/phi0959/phi001/phi0959.phi001.perseus-eng2.xml
+++ b/data/phi0959/phi001/phi0959.phi001.perseus-eng2.xml
@@ -5,8 +5,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 		<fileDesc>
 			<titleStmt>
 				<title>Amours</title>
-				<author>P. Ovidius Naso</author>
-				<editor role="editor">various</editor>
+				<author xml:lang="lat">P. Ovidius Naso</author>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -41,6 +40,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 							<date>1855</date>
 						</imprint>
 					</monogr>
+					<ref target="https://hdl.handle.net/2027/hvd.hn3btg?urlappend=%3Bseq=215%3Bownerid=27021597765686992-225">HathiTrust</ref>
 				</biblStruct>
 			</sourceDesc>
 		</fileDesc>

--- a/data/phi0959/phi001/phi0959.phi001.perseus-eng2.xml
+++ b/data/phi0959/phi001/phi0959.phi001.perseus-eng2.xml
@@ -10,6 +10,7 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 				<principal>Gregory Crane</principal>
 				<respStmt>
 					<resp>Prepared under the supervision of</resp>
+					<name>Anne Mahoney</name>
 					<name>Bridget Almas</name>
 					<name>Lisa Cerrato</name>
 					<name>David Mimno</name>
@@ -27,13 +28,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 			<sourceDesc>
 				<biblStruct>
 					<monogr>
-						<author>P. Ovidius Naso</author>
+						<author xml:lang="lat">P. Ovidius Naso</author>
 						<title>Ovid's Art of Love (in three Books), the Remedy of Love, the Art of
 							Beauty, the Court of Love, the History of Love, and Amours</title>
-						<respStmt>
-							<name>Anne Mahoney</name>
-							<resp>edited for Perseus</resp>
-						</respStmt>
 						<imprint>
 							<pubPlace>New York</pubPlace>
 							<publisher>Calvin Blanchard</publisher>

--- a/data/phi0959/phi001/phi0959.phi001.perseus-lat2.xml
+++ b/data/phi0959/phi001/phi0959.phi001.perseus-lat2.xml
@@ -8,8 +8,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 		    <fileDesc>
 			      <titleStmt>
 				        <title>Amores</title>
-				        <author>P. Ovidius Naso</author>
-				        <editor role="editor">R. Ehwald</editor>
+				        <author xml:lang="lat">P. Ovidius Naso</author>
+				        <editor>Rudolf Ehwald</editor>
 				        <sponsor>Perseus Project, Tufts University</sponsor>
 				        <principal>Gregory Crane</principal>
 				        <respStmt>
@@ -32,19 +32,22 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 				        <biblStruct>
 					          <monogr>
 						            <author>P. Ovidius Naso</author>
-						            <title>Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
-							amoris</title><idno type="lib">PA 6519.A2 1904 v1</idno>
-						            <respStmt>
-							              <name>R. Ehwald</name>
-							              <resp>edidit ex Rudolphi Merkelii recognitione</resp>
-						            </respStmt>
+						            <title>P. Ovidius Naso</title>
+					             <title type="sub">Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
+					                amoris</title>
+					             <editor>
+					                <persName>
+					                   <name>Rudolf Ehwald</name>
+					                </persName>
+					             </editor>
 						            <imprint>
 							              <pubPlace>Leipzig</pubPlace>
 							              <publisher>B. G. Teubner</publisher>
 							              <date>1907</date>
 						            </imprint>
+					             <biblScope unit="volume">1</biblScope>
 					          </monogr>
-					          
+				           <ref target="https://archive.org/details/operaovid03oviduoft/page/n47/mode/2up">Internet Archive</ref>
 				        </biblStruct>
 			      </sourceDesc>
 		    </fileDesc>

--- a/data/phi0959/phi001/phi0959.phi001.perseus-lat2.xml
+++ b/data/phi0959/phi001/phi0959.phi001.perseus-lat2.xml
@@ -31,9 +31,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 			      <sourceDesc>
 				        <biblStruct>
 					          <monogr>
-						            <author>P. Ovidius Naso</author>
+						            <author xml:lang="lat">P. Ovidius Naso</author>
 						            <title>P. Ovidius Naso</title>
-					             <title type="sub">Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
+					             <title type="sub" xml:lang="lat">Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
 					                amoris</title>
 					             <editor>
 					                <persName>

--- a/data/phi0959/phi002/__cts__.xml
+++ b/data/phi0959/phi002/__cts__.xml
@@ -1,12 +1,13 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:latinLit:phi0959" projid="latinLit:phi002" urn="urn:cts:latinLit:phi0959.phi002" xml:lang="lat">
-  <ti:title xml:lang="eng">Epistulae</ti:title>
+  <ti:title xml:lang="lat">Epistulae</ti:title>
   <ti:edition projid="latinLit:perseus-lat2" urn="urn:cts:latinLit:phi0959.phi002.perseus-lat2" workUrn="urn:cts:latinLit:phi0959.phi002" xml:lang="lat">
-    <ti:label xml:lang="eng">Epistulae</ti:label>
-    <ti:description xml:lang="eng">Ovid, 43 B.C.-17 or 18 A.D, creator; Ehwald, Rudolf, 1847-1927, editor; Merkel, Rudolf, 1811-1885, editor</ti:description>
+    <ti:label xml:lang="lat">Epistulae</ti:label>
+    <ti:description xml:lang="mul">Ovid. P. Ovidius Naso, Volume 1: Amores, Epistulae, Medicamina faciei femineae, Ars 
+      amatoria, Remedia amoris. Ehwald, Rudolf; Merkel, Rudolph; editors. Leipzig: B. G. Teubner, 1907.
+    </ti:description>
   </ti:edition>
-
   <ti:translation urn="urn:cts:latinLit:phi0959.phi002.perseus-eng2" workUrn="urn:cts:latinLit:phi0959.phi002" xml:lang="eng">
-    <ti:label xml:lang="eng">Epistulae, The Epistles of Ovid</ti:label>
-    <ti:description xml:lang="eng">Ovid, 43 B.C.-17 or 18 A.D, creator; Various, translator</ti:description>
+    <ti:label xml:lang="eng">Epistles</ti:label>
+    <ti:description xml:lang="mul">Ovid. The Epistles of Ovid. London: J. Nunn, 1813.</ti:description>
   </ti:translation>
 </ti:work>

--- a/data/phi0959/phi002/phi0959.phi002.perseus-eng2.xml
+++ b/data/phi0959/phi002/phi0959.phi002.perseus-eng2.xml
@@ -7,8 +7,8 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
   <teiHeader>
     <fileDesc>
       <titleStmt>
-  <title>The Epistles of Ovid</title>
-        <author>P. Ovidius Naso</author>
+  <title>Epistles</title>
+        <author xml:lang="lat">P. Ovidius Naso</author>
 <sponsor>Perseus Project, Tufts University</sponsor>
     <principal>Gregory Crane</principal>
     <respStmt>
@@ -29,15 +29,17 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
       <sourceDesc>
   <biblStruct>
     <monogr>
-      <author>P. Ovidius Naso</author>
-      <title>The Epistles of Ovid, translated into English prose, as near the original as the different idioms of the Latin and English languages will allow;  with the Latin text and order of construction on the same page;  and critical, historical, geographical, and classical notes in English, from the very best commentators both ancient and modern;  beside a very great number of notes entirely new.
-      </title><imprint>
+      <author xml:lang="lat">P. Ovidius Naso</author>
+      <title>The Epistles of Ovid</title><imprint>
         <pubPlace>London</pubPlace>
-        <publisher>J. Nunn, Great-Queen-Street;  R. Priestly, 143, High-Holborn;  R. Lea, Greek-Street, Soho;  and J. Rodwell, New-Bond-Street</publisher>
+        <publisher>J. Nunn</publisher>
+        <publisher>R. Priestly</publisher>
+        <publisher>R. Lea</publisher>
+        <publisher>J. Rodwell</publisher>
         <date>1813</date>
       </imprint>
     </monogr>
-    <ref target="https://books.google.fr/books?id=0D5WAAAAcAAJ">Google Books</ref>
+    <ref target="https://hdl.handle.net/2027/yul.12473895_000_00">HathiTrust</ref>
   </biblStruct>
       </sourceDesc>
     </fileDesc>

--- a/data/phi0959/phi002/phi0959.phi002.perseus-lat2.xml
+++ b/data/phi0959/phi002/phi0959.phi002.perseus-lat2.xml
@@ -7,9 +7,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 	<teiHeader>
 		<fileDesc>
 			<titleStmt>
-				<title>Epistulae</title>
-				<author>P. Ovidius Naso</author>
-				<editor role="editor">R. Ehwald</editor>
+				<title xml:lang="lat">Epistulae</title>
+				<author xml:lang="lat">P. Ovidius Naso</author>
+				<editor>Rudolf Ehwald</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
@@ -32,18 +32,21 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 			<sourceDesc>
 				<biblStruct>
 					<monogr>
-						<author>P. Ovidius Naso</author>
-						<title>Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
-							amoris</title><idno type="lib">PA 6519.A2 1904 v1</idno>
-						<respStmt>
-							<name>R. Ehwald</name>
-							<resp>edidit ex Rudolphi Merkelii recognitione</resp>
-						</respStmt>
+						<author xml:lang="lat">P. Ovidius Naso</author>
+						<title>P. Ovidius Naso</title>
+						<title type="sub" xml:lang="lat">Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
+							amoris</title>
+						<editor>
+							<persName>
+								<name>Rudolf Ehwald</name>
+							</persName>
+						</editor>
 						<imprint>
 							<pubPlace>Leipzig</pubPlace>
 							<publisher>B. G. Teubner</publisher>
 							<date>1907</date>
 						</imprint>
+						<biblScope unit="volume">1</biblScope>
 					</monogr>
 					
 					<ref target="https://archive.org/stream/povidiusnasoexru01ovid#page/70/mode/2up">Internet Archive</ref>

--- a/data/phi0959/phi003/__cts__.xml
+++ b/data/phi0959/phi003/__cts__.xml
@@ -1,13 +1,14 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:latinLit:phi0959" projid="latinLit:phi003" urn="urn:cts:latinLit:phi0959.phi003" xml:lang="lat">
-  <ti:title xml:lang="eng">Art of Beauty</ti:title>
-  <ti:title xml:lang="fre">Les Fards ou Soins du visage</ti:title>
   <ti:title xml:lang="lat">Medicamina faciei femineae</ti:title>
   <ti:edition projid="latinLit:perseus-lat2" urn="urn:cts:latinLit:phi0959.phi003.perseus-lat2" workUrn="urn:cts:latinLit:phi0959.phi003" xml:lang="lat">
-    <ti:label xml:lang="eng">Art of Beauty</ti:label>
-    <ti:description xml:lang="eng">Ovid, 43 B.C.-17 or 18 A.D, creator; Ehwald, Rudolf, 1847-1927, editor; Merkel, Rudolf, 1811-1885, editor</ti:description>
+    <ti:label xml:lang="lat">Medicamina faciei femineae</ti:label>
+        <ti:description xml:lang="mul">Ovid. P. Ovidius Naso, Volume 1: Amores, Epistulae, Medicamina faciei femineae, Ars 
+      amatoria, Remedia amoris. Ehwald, Rudolf; Merkel, Rudolph; editors. Leipzig: B. G. Teubner, 1907.
+    </ti:description>
   </ti:edition>
   <ti:translation urn="urn:cts:latinLit:phi0959.phi003.perseus-eng2" workUrn="urn:cts:latinLit:phi0959.phi003" xml:lang="eng">
-    <ti:label xml:lang="eng">Medicamina Faciei Femineae, The Art of Love in Three Books The remedy of love. The art of beauty. The court of love. The history of love amours.</ti:label>
-    <ti:description xml:lang="eng">Ovid, 43 B.C.-17 or 18 A.D, creator; Anonymous, translator; , editor</ti:description>
+    <ti:label xml:lang="eng">The Art of Beauty</ti:label>
+   <ti:description xml:lang="eng">Ovid. Ovid's Art of Love (in three Books), the Remedy of Love, the Art of
+      Beauty, the Court of Love, the History of Love, and Amours. Anonymous, translator. New York: Calvin Blanchard, 1855.</ti:description>
   </ti:translation>
 </ti:work>

--- a/data/phi0959/phi003/phi0959.phi003.perseus-eng2.xml
+++ b/data/phi0959/phi003/phi0959.phi003.perseus-eng2.xml
@@ -5,12 +5,13 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 		<fileDesc>
 			<titleStmt>
 				<title>Art of Beauty</title>
-				<author>P. Ovidius Naso</author>
-				<editor role="editor">various</editor>
+				<author xml:lang="lat">P. Ovidius Naso</author>
+				<editor role="translator">Anonymous</editor>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
 					<resp>Prepared under the supervision of</resp>
+					<name>Anne Mahoney</name>
 					<name>Bridget Almas</name>
 					<name>Lisa Cerrato</name>
 					<name>David Mimno</name>
@@ -29,19 +30,16 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 			<sourceDesc>
 				<biblStruct>
 					<monogr>
-						<author>P. Ovidius Naso</author>
+						<author xml:lang="lat">P. Ovidius Naso</author>
 						<title>Ovid's Art of Love (in three Books), the Remedy of Love, the Art of
 							Beauty, the Court of Love, the History of Love, and Amours</title>
-						<respStmt>
-							<name>Anne Mahoney</name>
-							<resp>edited for Perseus</resp>
-						</respStmt>
 						<imprint>
 							<pubPlace>New York</pubPlace>
 							<publisher>Calvin Blanchard</publisher>
 							<date>1855</date>
 						</imprint>
 					</monogr>
+					<ref target="https://hdl.handle.net/2027/hvd.hn3btg?urlappend=%3Bseq=148%3Bownerid=27021597765700373-162">HathiTrust</ref>
 				</biblStruct>
 			</sourceDesc>
 		</fileDesc>

--- a/data/phi0959/phi003/phi0959.phi003.perseus-lat2.xml
+++ b/data/phi0959/phi003/phi0959.phi003.perseus-lat2.xml
@@ -7,9 +7,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 	  <teiHeader>
 		    <fileDesc>
 			      <titleStmt>
-				        <title>Art of Beauty</title>
-				        <author>P. Ovidius Naso</author>
-				        <editor role="editor">R. Ehwald</editor>
+			          <title xml:lang="lat">Medicamina faciei femineae</title>
+				        <author xml:lang="lat">P. Ovidius Naso</author>
+				        <editor>Rudolf Ehwald</editor>
 				        <sponsor>Perseus Project, Tufts University</sponsor>
 				        <principal>Gregory Crane</principal>
 				        <respStmt>
@@ -31,21 +31,24 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
 			      <sourceDesc>
 				        <biblStruct>
-					          <monogr>
-						            <author>P. Ovidius Naso</author>
-						            <title>Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
-							amoris</title><idno type="lib">PA 6519.A2 1904 v1</idno>
-						            <respStmt>
-							              <name>R. Ehwald</name>
-							              <resp>edidit ex Rudolphi Merkelii recognitione</resp>
-						            </respStmt>
-						            <imprint>
-							              <pubPlace>Leipzig</pubPlace>
-							              <publisher>B. G. Teubner</publisher>
-							              <date>1907</date>
-						            </imprint>
-					          </monogr>
-					          
+				            <monogr>
+				                <author xml:lang="lat">P. Ovidius Naso</author>
+				                <title xml:lang="lat">P. Ovidius Naso</title>
+				                <title type="sub" xml:lang="lat">Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
+				                    amoris</title>
+				                <editor>
+				                    <persName>
+				                        <name>Rudolf Ehwald</name>
+				                    </persName>
+				                </editor>
+				                <imprint>
+				                    <pubPlace>Leipzig</pubPlace>
+				                    <publisher>B. G. Teubner</publisher>
+				                    <date>1907</date>
+				                </imprint>
+				                <biblScope unit="volume">1</biblScope>
+				            </monogr>
+				            <ref target="https://archive.org/details/operaovid03oviduoft/page/180/mode/2up">Internet Archive</ref>
 				        </biblStruct>
 			      </sourceDesc>
 		    </fileDesc>

--- a/data/phi0959/phi004/__cts__.xml
+++ b/data/phi0959/phi004/__cts__.xml
@@ -1,16 +1,14 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" groupUrn="urn:cts:latinLit:phi0959" projid="latinLit:phi004" urn="urn:cts:latinLit:phi0959.phi004" xml:lang="lat">
-  <ti:title xml:lang="eng">Art of Love</ti:title>
-  <ti:title xml:lang="fre">L'Art d'Aimer</ti:title>
   <ti:title xml:lang="lat">Ars Amatoria</ti:title>
   <ti:edition projid="latinLit:perseus-lat2" urn="urn:cts:latinLit:phi0959.phi004.perseus-lat2" workUrn="urn:cts:latinLit:phi0959.phi004" xml:lang="lat">
-    <ti:label xml:lang="eng">Art of Love</ti:label>
-    <ti:description xml:lang="eng">Ovid, 43 B.C.-17 or 18 A.D, creator; Ehwald, Rudolf, 1847-1927,
-      editor; Merkel, Rudolf, 1811-1885, editor</ti:description>
+    <ti:label xml:lang="lat">Ars Amatoria</ti:label>
+    <ti:description xml:lang="mul">Ovid. P. Ovidius Naso, Volume 1: Amores, Epistulae, Medicamina faciei femineae, Ars 
+      amatoria, Remedia amoris. Ehwald, Rudolf; Merkel, Rudolph; editors. Leipzig: B. G. Teubner, 1907.
+    </ti:description>    
   </ti:edition>
   <ti:translation urn="urn:cts:latinLit:phi0959.phi004.perseus-eng2" workUrn="urn:cts:latinLit:phi0959.phi004" xml:lang="eng">
-    <ti:label xml:lang="eng">Ars Amatoria, The Art of Love in Three Books The remedy of love. The
-      art of beauty. The court of love. The history of love amours.</ti:label>
-    <ti:description xml:lang="eng">Ovid, 43 B.C.-17 or 18 A.D, creator; Dryden, John, 1631-1700,
-      translator; Congreve, William, 1670-1729, translator; , editor</ti:description>
+    <ti:label xml:lang="eng">The Art of Love</ti:label>
+    <ti:description xml:lang="eng">Ovid. Ovid's Art of Love (in three Books), the Remedy of Love, the Art of
+      Beauty, the Court of Love, the History of Love, and Amours. Dryden, John; Congreve, William; translators. New York: Calvin Blanchard, 1855.</ti:description>    
   </ti:translation>
 </ti:work>

--- a/data/phi0959/phi004/phi0959.phi004.perseus-eng2.xml
+++ b/data/phi0959/phi004/phi0959.phi004.perseus-eng2.xml
@@ -5,12 +5,12 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 		<fileDesc>
 			<titleStmt>
 				<title>Art of Love</title>
-				<author>P. Ovidius Naso</author>
-				<editor role="editor">various</editor>
+				<author xml:lang="lat">P. Ovidius Naso</author>
 				<sponsor>Perseus Project, Tufts University</sponsor>
 				<principal>Gregory Crane</principal>
 				<respStmt>
 					<resp>Prepared under the supervision of</resp>
+					<name>Anne Mahoney</name>
 					<name>Bridget Almas</name>
 					<name>Lisa Cerrato</name>
 					<name>David Mimno</name>
@@ -28,19 +28,16 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-
 			<sourceDesc>
 				<biblStruct>
 					<monogr>
-						<author>P. Ovidius Naso</author>
+						<author xml:lang="lat">P. Ovidius Naso</author>
 						<title>Ovid's Art of Love (in three Books), the Remedy of Love, the Art of
 							Beauty, the Court of Love, the History of Love, and Amours</title>
-						<respStmt>
-							<name>Anne Mahoney</name>
-							<resp>edited for Perseus</resp>
-						</respStmt>
 						<imprint>
 							<pubPlace>New York</pubPlace>
 							<publisher>Calvin Blanchard</publisher>
 							<date>1855</date>
 						</imprint>
 					</monogr>
+					<ref target="https://hdl.handle.net/2027/hvd.hn3btg?urlappend=%3Bseq=28%3Bownerid=27021597765686992-32">HathiTrust</ref>
 				</biblStruct>
 			</sourceDesc>
 		</fileDesc>

--- a/data/phi0959/phi004/phi0959.phi004.perseus-lat2.xml
+++ b/data/phi0959/phi004/phi0959.phi004.perseus-lat2.xml
@@ -7,9 +7,9 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 	  <teiHeader>
 		    <fileDesc>
 			      <titleStmt>
-				        <title>Art of Love</title>
-				        <author>P. Ovidius Naso</author>
-				        <editor role="editor">R. Ehwald</editor>
+				        <title xml:lang="lat">Ars Amatoria</title>
+				        <author xml:lang="lat">P. Ovidius Naso</author>
+				        <editor>Rudolf Ehwald</editor>
 				        <sponsor>Perseus Project, Tufts University</sponsor>
 				        <principal>Gregory Crane</principal>
 				        <respStmt>
@@ -30,21 +30,23 @@ schematypens="http://purl.oclc.org/dsdl/schematron"?>
 
 			      <sourceDesc>
 				        <biblStruct>
-					          <monogr>
-						            <author>P. Ovidius Naso</author>
-						            <title>Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
-							amoris</title><idno type="lib">PA 6519.A2 1904 v1</idno>
-						            <respStmt>
-							              <name>R. Ehwald</name>
-							              <resp>edidit ex Rudolphi Merkelii recognitione</resp>
-						            </respStmt>
-						            <imprint>
-							              <pubPlace>Leipzig</pubPlace>
-							              <publisher>B. G. Teubner</publisher>
-							              <date>1907</date>
-						            </imprint>
-					          </monogr>
-					          
+				            <monogr>
+				                <author xml:lang="lat">P. Ovidius Naso</author>
+				                <title xml:lang="lat">P. Ovidius Naso</title>
+				                <title type="sub" xml:lang="lat">Amores, Epistulae, Medicamina faciei femineae, Ars amatoria, Remedia
+				                    amoris</title>
+				                <editor>
+				                    <persName>
+				                        <name>Rudolf Ehwald</name>
+				                    </persName>
+				                </editor>
+				                <imprint>
+				                    <pubPlace>Leipzig</pubPlace>
+				                    <publisher>B. G. Teubner</publisher>
+				                    <date>1907</date>
+				                </imprint>
+				                <biblScope unit="volume">1</biblScope>
+				            </monogr>					          
 					          <ref target="https://archive.org/stream/povidiusnasoexru01ovid#page/183/mode/2up">Internet Archive</ref>
 				        </biblStruct>
 			      </sourceDesc>


### PR DESCRIPTION
My first efforts at updating Perseus headers for Ovid, and I have already hit several questions for you @lcerrato 

1) Ovid is the name for the textggroup, but I have left the Latin name`<author xml:lang="lat">P. Ovidius Naso</author>`for the author name in these first two files as you recommended using M. Tullius Cicero for Cicero in the headers and bibliographic descriptions for his workis.

2) In phi0959.phi001.perseus-eng2 I found `<respStmt>
							<name>Anne Mahoney</name>
							<resp>edited for Perseus</resp>
						</respStmt>`
within the `<monogr>`section. I'm pretty sure this is incorrect, because shouldn't this section just have bibliographic information regarding the original publication. There is actually no editor for this 1855 publication, or none named. Shouldn't this editor statement regarding Anne be added up to the `respStmt` in the `</titleStmt>`.

3) I'm not sure what to do about the `<ti:description>` for phi0959.phi001.perseus-eng2.  There was originally a full list of the translators with dates and all (there are 10!)  with translator repeated and I've tightened this up. It is still a lot of data for this field and I was wondering if I should just change it to Dryden, John, translators, et. al. or something like that and wanted your thoughts on that. (All of the data on the translators is in the catalog record)

Other than that I just updated the header and cts information to current standards and added in reference links.  Thanks for any and all suggestions. 





