### PR TITLE
(phi0134)_all files

### DIFF
--- a/data/phi0134/__cts__.xml
+++ b/data/phi0134/__cts__.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0134">
     <ti:groupname xml:lang="eng">Terence</ti:groupname>
-    <ti:groupname xml:lang="lat">Publius Terentius Afer</ti:groupname>
 </ti:textgroup>

--- a/data/phi0134/phi001/__cts__.xml
+++ b/data/phi0134/phi001/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi001.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi001">
-              <ti:label xml:lang="eng">Andria: The Fair Andrian</ti:label>
+              <ti:label xml:lang="eng">Andria; or, The Fair Andrian</ti:label>
               <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
             </ti:translation>

--- a/data/phi0134/phi001/__cts__.xml
+++ b/data/phi0134/phi001/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi001.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi001">
-              <ti:label xml:lang="eng">The Fair Andrian</ti:label>
+              <ti:label xml:lang="eng">Andria: The Fair Andrian</ti:label>
               <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
             </ti:translation>

--- a/data/phi0134/phi001/__cts__.xml
+++ b/data/phi0134/phi001/__cts__.xml
@@ -1,11 +1,13 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0134.phi001" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0134">
             <ti:title xml:lang="lat">Andria</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi0134.phi001.perseus-lat2" workUrn="urn:cts:latinLit:phi0134.phi001">
-              <ti:label xml:lang="eng">Andria, Publii Terentii Comoediae sex</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Parry, Edward St. John, editor</ti:description>
+              <ti:label xml:lang="lat">Andria</ti:label>
+              <ti:description xml:lang="mul">Terence. Publii Terentii Comoediae Sex. Parry, Edward St. John, editor. London: Whittaker and 
+                Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi001.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi001">
-              <ti:label xml:lang="eng">Andria, The comedies of Terence</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Riley, Henry Thomas, 1816-1878, translator; Colman, George, 1732-1794, translator</ti:description>
+              <ti:label xml:lang="eng">The Fair Andrian</ti:label>
+              <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
+              Harper and Brothers, 1872.</ti:description>
             </ti:translation>
           </ti:work>

--- a/data/phi0134/phi001/phi0134.phi001.perseus-eng2.xml
+++ b/data/phi0134/phi001/phi0134.phi001.perseus-eng2.xml
@@ -2,7 +2,7 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Andria: The Fair Andrian</title>
+            <title>Andria; or, The Fair Andrian</title>
             <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0134/phi001/phi0134.phi001.perseus-eng2.xml
+++ b/data/phi0134/phi001/phi0134.phi001.perseus-eng2.xml
@@ -2,7 +2,7 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>The Fair Andrian</title>
+            <title>Andria: The Fair Andrian</title>
             <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0134/phi001/phi0134.phi001.perseus-eng2.xml
+++ b/data/phi0134/phi001/phi0134.phi001.perseus-eng2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Andria:  The Fair Andrian</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="transl">Henry Thomas Riley</editor>
+            <title>The Fair Andrian</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
+            <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -36,13 +36,15 @@
             <biblStruct>
                <monogr>
                   <title>The Comedies of Terence</title>
-                  <editor role="transl">Henry Thomas Riley</editor>
+                  <editor role="translator">Henry Thomas Riley</editor>
+                  <editor role="translator">George Colman</editor>
                   <imprint>
                      <pubPlace>Ney York</pubPlace>
                      <publisher>Harper and Brothers</publisher>
                      <date>1874</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comediesliterall00tereuoft/page/n9/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi001/phi0134.phi001.perseus-lat2.xml
+++ b/data/phi0134/phi001/phi0134.phi001.perseus-lat2.xml
@@ -2,9 +2,9 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Andria</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="editor">Edward St. John Parry</editor>
+            <title xml:lang="lat">Andria</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
+            <editor>Edward St. John Parry</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -29,15 +29,17 @@
          <sourceDesc>
             <biblStruct>
                <monogr>
-                  <title>Publii Terentii Comoediae VI</title>
-                  <author>P. Terentius Afer</author>
-                  <editor role="editor">Edward St. John Parry, M.A.</editor>
+                  <title xml:lang="lat">Publii Terentii Comoediae Sex</title>
+                  <author xml:lang="lat">P. Terentius Afer</author>
+                  <editor>Edward St. John Parry</editor>
                   <imprint>
                      <pubPlace>London</pubPlace>
-                     <publisher>Whitaker and Co., Ave Maria Lane;  George Bell, Fleet Street</publisher>
+                     <publisher>Whitaker and Co</publisher>
+                     <publisher>George Bell</publisher>
                      <date>1857</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comoediaesexwith00tereuoft/page/lxviii/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi002/__cts__.xml
+++ b/data/phi0134/phi002/__cts__.xml
@@ -1,11 +1,13 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0134.phi002" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0134">
-            <ti:title xml:lang="lat">The Self-Tormenter</ti:title>
+            <ti:title xml:lang="lat">Heautontimorumenos</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi0134.phi002.perseus-lat2" workUrn="urn:cts:latinLit:phi0134.phi002">
-              <ti:label xml:lang="eng">The Self-Tormenter, Publii Terentii Comoediae sex</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Parry, Edward St. John, editor</ti:description>
+              <ti:label xml:lang="lat">Heautontimorumenos</ti:label>
+              <ti:description xml:lang="mul">Terence. Publii Terentii Comoediae Sex. Parry, Edward St. John, editor. London: Whittaker and 
+                Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi002.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi002">
-              <ti:label xml:lang="eng">The Self-Tormenter, The comedies of Terence</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Riley, Henry Thomas, 1816-1878, translator; Colman, George, 1732-1794, translator</ti:description>
-            </ti:translation>
+              <ti:label xml:lang="eng">The Self-Tormenter</ti:label>
+            <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
+              Harper and Brothers, 1872.</ti:description>
+          </ti:translation>
           </ti:work>

--- a/data/phi0134/phi002/__cts__.xml
+++ b/data/phi0134/phi002/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi002.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi002">
-              <ti:label xml:lang="eng">The Self-Tormenter</ti:label>
+            <ti:label xml:lang="eng">Heautontimorumenos, The Self-Tormenter</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi002/__cts__.xml
+++ b/data/phi0134/phi002/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi002.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi002">
-            <ti:label xml:lang="eng">Heautontimorumenos, The Self-Tormenter</ti:label>
+            <ti:label xml:lang="eng">Heautontimorumenos; or, The Self-Tormenter</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi002/phi0134.phi002.perseus-eng2.xml
+++ b/data/phi0134/phi002/phi0134.phi002.perseus-eng2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Heautontimorumenos: The Self-Tormenter</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="transl">Henry Thomas Riley</editor>
+            <title>The Self-Tormenter</title>
+            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -26,13 +26,15 @@
             <biblStruct>
                <monogr>
                   <title>The Comedies of Terence</title>
-                  <editor role="transl">Henry Thomas Riley</editor>
+                  <editor role="translator">Henry Thomas Riley</editor>
+                  <editor role="translator">George Colman</editor>
                   <imprint>
                      <pubPlace>Ney York</pubPlace>
                      <publisher>Harper and Brothers</publisher>
                      <date>1874</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comediesliterall00tereuoft/page/132/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi002/phi0134.phi002.perseus-eng2.xml
+++ b/data/phi0134/phi002/phi0134.phi002.perseus-eng2.xml
@@ -2,8 +2,8 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>The Self-Tormenter</title>
-            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <title>Heautontimorumenos, The Self-Tormenter</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>

--- a/data/phi0134/phi002/phi0134.phi002.perseus-eng2.xml
+++ b/data/phi0134/phi002/phi0134.phi002.perseus-eng2.xml
@@ -2,7 +2,7 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Heautontimorumenos, The Self-Tormenter</title>
+            <title>Heautontimorumenos; or, The Self-Tormenter</title>
             <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0134/phi002/phi0134.phi002.perseus-lat2.xml
+++ b/data/phi0134/phi002/phi0134.phi002.perseus-lat2.xml
@@ -3,13 +3,12 @@
 schematypens="http://relaxng.org/ns/structure/1.0"\?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Heautontimorumenos</title>
-            <title type="sub">Machine readable text</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="editor">Edward St. John Parry</editor> 
+            <title xml:lang="lat">Heautontimorumenos</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
+            <editor>Edward St. John Parry</editor> 
             <sponsor>Perseus Project, Tufts University</sponsor>
 <principal>Gregory Crane</principal>
 <respStmt>
@@ -39,16 +38,17 @@ schematypens="http://relaxng.org/ns/structure/1.0"\?>
  <sourceDesc>
             <biblStruct>
                <monogr>
-                  <title>Publii Terentii Comoediae VI</title>
-                  <author>P. Terentius Afer</author>
-                  <editor role="editor">Edward St. John Parry, M.A.</editor>
+                  <title xml:lang="lat">Publii Terentii Comoediae Sex</title>
+                  <author xml:lang="lat">P. Terentius Afer</author>
+                  <editor>Edward St. John Parry</editor>
                   <imprint>
                      <pubPlace>London</pubPlace>
-                     <publisher>Whitaker and Co., Ave Maria Lane; George Bell, Fleet
-                        Street</publisher>
+                     <publisher>Whitaker and Co</publisher>
+                     <publisher>George Bell</publisher>
                      <date>1857</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comoediaesexwith00tereuoft/page/160/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi003/__cts__.xml
+++ b/data/phi0134/phi003/__cts__.xml
@@ -1,11 +1,13 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0134.phi003" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0134">
-            <ti:title xml:lang="lat">The Eunuch</ti:title>
+  <ti:title xml:lang="lat">Eunuchus</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi0134.phi003.perseus-lat2" workUrn="urn:cts:latinLit:phi0134.phi003">
-              <ti:label xml:lang="eng">The Eunuch, Publii Terentii Comoediae sex</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Parry, Edward St. John, editor</ti:description>
+              <ti:label xml:lang="lat">Eunuchus</ti:label>
+              <ti:description xml:lang="mul">Terence. Publii Terentii Comoediae Sex. Parry, Edward St. John, editor. London: Whittaker and 
+                Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi003.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi003">
-              <ti:label xml:lang="eng">The Eunuch, The comedies of Terence</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Riley, Henry Thomas, 1816-1878, translator; Colman, George, 1732-1794, translator</ti:description>
-            </ti:translation>
+              <ti:label xml:lang="eng">The Eunuch</ti:label>
+            <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
+              Harper and Brothers, 1872.</ti:description>
+          </ti:translation>
           </ti:work>

--- a/data/phi0134/phi003/__cts__.xml
+++ b/data/phi0134/phi003/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi003.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi003">
-              <ti:label xml:lang="eng">Eunuchus, The Eunuch</ti:label>
+              <ti:label xml:lang="eng">Eunuchus; or, The Eunuch</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi003/__cts__.xml
+++ b/data/phi0134/phi003/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi003.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi003">
-              <ti:label xml:lang="eng">The Eunuch</ti:label>
+              <ti:label xml:lang="eng">Eunuchus, The Eunuch</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi003/phi0134.phi003.perseus-eng2.xml
+++ b/data/phi0134/phi003/phi0134.phi003.perseus-eng2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
             <title>The Eunuch</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="transl">Henry Thomas Riley</editor>
+            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -36,13 +36,15 @@
             <biblStruct>
                <monogr>
                   <title>The Comedies of Terence</title>
-                  <editor role="transl">Henry Thomas Riley</editor>
+                  <editor role="translator">Henry Thomas Riley</editor>
+                  <editor role="translator">George Colman</editor>
                   <imprint>
                      <pubPlace>Ney York</pubPlace>
                      <publisher>Harper and Brothers</publisher>
                      <date>1874</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comediesliterall00tereuoft/page/62/mode/2up">Internet Archive</ref>               
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi003/phi0134.phi003.perseus-eng2.xml
+++ b/data/phi0134/phi003/phi0134.phi003.perseus-eng2.xml
@@ -2,8 +2,8 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>The Eunuch</title>
-            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <title>Eunuchus; The Eunuch</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>

--- a/data/phi0134/phi003/phi0134.phi003.perseus-eng2.xml
+++ b/data/phi0134/phi003/phi0134.phi003.perseus-eng2.xml
@@ -2,7 +2,7 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Eunuchus; The Eunuch</title>
+            <title>Eunuchus; or, The Eunuch</title>
             <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0134/phi003/phi0134.phi003.perseus-lat2.xml
+++ b/data/phi0134/phi003/phi0134.phi003.perseus-lat2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Eunuchus</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="editor">Edward St. John Parry</editor>
+            <title xml:lang="lat">Eunuchus</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
+            <editor>Edward St. John Parry</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -29,15 +29,17 @@
          <sourceDesc>
             <biblStruct>
                <monogr>
-                  <title>Publii Terentii Comoediae VI</title>
-                  <author>P. Terentius Afer</author>
-                  <editor role="editor">Edward St. John Parry, M.A.</editor>
+                  <title xml:lang="lat">Publii Terentii Comoediae Sex</title>
+                  <author xml:lang="lat">P. Terentius Afer</author>
+                  <editor>Edward St. John Parry</editor>
                   <imprint>
                      <pubPlace>London</pubPlace>
-                     <publisher>Whitaker and Co., Ave Maria Lane;  George Bell, Fleet Street</publisher>
+                     <publisher>Whitaker and Co</publisher>
+                     <publisher>George Bell</publisher>
                      <date>1857</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comoediaesexwith00tereuoft/page/78/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi004/__cts__.xml
+++ b/data/phi0134/phi004/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi004.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi004">
-              <ti:label xml:lang="lat">Phormio, or The Scheming Parasite</ti:label>
+              <ti:label xml:lang="lat">Phormio; or, The Scheming Parasite</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi004/__cts__.xml
+++ b/data/phi0134/phi004/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi004.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi004">
-              <ti:label xml:lang="lat">The Scheming Parasite</ti:label>
+              <ti:label xml:lang="lat">Phormio, or The Scheming Parasite</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi004/__cts__.xml
+++ b/data/phi0134/phi004/__cts__.xml
@@ -1,11 +1,13 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0134.phi004" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0134">
             <ti:title xml:lang="lat">Phormio</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi0134.phi004.perseus-lat2" workUrn="urn:cts:latinLit:phi0134.phi004">
-              <ti:label xml:lang="eng">Phormio, Publii Terentii Comoediae sex</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Parry, Edward St. John, editor</ti:description>
+              <ti:label xml:lang="lat">Phormio</ti:label>
+              <ti:description xml:lang="mul">Terence. Publii Terentii Comoediae Sex. Parry, Edward St. John, editor. London: Whittaker and 
+                Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi004.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi004">
-              <ti:label xml:lang="eng">Phormio, The comedies of Terence</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Riley, Henry Thomas, 1816-1878, translator; Colman, George, 1732-1794, translator</ti:description>
-            </ti:translation>
+              <ti:label xml:lang="lat">The Scheming Parasite</ti:label>
+            <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
+              Harper and Brothers, 1872.</ti:description>
+          </ti:translation>
           </ti:work>

--- a/data/phi0134/phi004/phi0134.phi004.perseus-eng2.xml
+++ b/data/phi0134/phi004/phi0134.phi004.perseus-eng2.xml
@@ -2,9 +2,9 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Phormio, or The Scheming Parasite</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="transl">Henry Thomas Riley</editor>
+            <title>The Scheming Parasite</title>
+            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -31,13 +31,16 @@
             <biblStruct>
                <monogr>
                   <title>The Comedies of Terence</title>
-                  <editor role="transl">Henry Thomas Riley</editor>
+                  <editor role="translator">Henry Thomas Riley</editor>
+                  <editor role="translator">George Colman</editor>
                   <imprint>
                      <pubPlace>Ney York</pubPlace>
                      <publisher>Harper and Brothers</publisher>
                      <date>1874</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comediesliterall00tereuoft/page/300/mode/2up">Internet Archive</ref>               
+               
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi004/phi0134.phi004.perseus-eng2.xml
+++ b/data/phi0134/phi004/phi0134.phi004.perseus-eng2.xml
@@ -2,7 +2,7 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>Phormio, or, The Scheming Parasite</title>
+            <title>Phormio; or, The Scheming Parasite</title>
             <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0134/phi004/phi0134.phi004.perseus-eng2.xml
+++ b/data/phi0134/phi004/phi0134.phi004.perseus-eng2.xml
@@ -2,8 +2,8 @@
    <teiHeader>
       <fileDesc>
          <titleStmt>
-            <title>The Scheming Parasite</title>
-            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <title>Phormio, or, The Scheming Parasite</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>

--- a/data/phi0134/phi004/phi0134.phi004.perseus-lat2.xml
+++ b/data/phi0134/phi004/phi0134.phi004.perseus-lat2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Phormio</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="editor">Edward St. John Parry</editor>
+            <title xml:lang="lat">Phormio</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
+            <editor>Edward St. John Parry</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -29,15 +29,17 @@
          <sourceDesc>
             <biblStruct>
                <monogr>
-                  <title>Publii Terentii Comoediae VI</title>
-                  <author>P. Terentius Afer</author>
-                  <editor role="editor">Edward St. John Parry, M.A.</editor>
+                  <title xml:lang="lat">Publii Terentii Comoediae Sex</title>
+                  <author xml:lang="lat">P. Terentius Afer</author>
+                  <editor>Edward St. John Parry</editor>
                   <imprint>
                      <pubPlace>London</pubPlace>
-                     <publisher>Whitaker and Co., Ave Maria Lane;  George Bell, Fleet Street</publisher>
+                     <publisher>Whitaker and Co</publisher>
+                     <publisher>George Bell</publisher>
                      <date>1857</date>
                   </imprint>
                </monogr>
+               <ref target="http://www.archive.org/stream/comoediaesexwith00tereuoft#page/394/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi005/__cts__.xml
+++ b/data/phi0134/phi005/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi005.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi005">
-              <ti:label xml:lang="eng">The Mother-in-Law</ti:label>
+              <ti:label xml:lang="eng">Hecyra, The Mother-in-Law</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi005/__cts__.xml
+++ b/data/phi0134/phi005/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi005.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi005">
-              <ti:label xml:lang="eng">Hecyra, The Mother-in-Law</ti:label>
+              <ti:label xml:lang="eng">Hecyra; The Mother-in-Law</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi005/__cts__.xml
+++ b/data/phi0134/phi005/__cts__.xml
@@ -1,11 +1,13 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0134.phi005" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0134">
-            <ti:title xml:lang="lat">The Mother-in-Law</ti:title>
+            <ti:title xml:lang="lat">Hecyra</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi0134.phi005.perseus-lat2" workUrn="urn:cts:latinLit:phi0134.phi005">
-              <ti:label xml:lang="eng">The Mother-in-Law, Publii Terentii Comoediae sex</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Parry, Edward St. John, editor</ti:description>
+              <ti:label xml:lang="lat">Hecyra</ti:label>
+              <ti:description xml:lang="mul">Terence. Publii Terentii Comoediae Sex. Parry, Edward St. John, editor. London: Whittaker and 
+                Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi005.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi005">
-              <ti:label xml:lang="eng">The Mother-in-Law, The comedies of Terence</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Riley, Henry Thomas, 1816-1878, translator; Colman, George, 1732-1794, translator</ti:description>
-            </ti:translation>
+              <ti:label xml:lang="eng">The Mother-in-Law</ti:label>
+            <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
+              Harper and Brothers, 1872.</ti:description>
+          </ti:translation>
           </ti:work>

--- a/data/phi0134/phi005/phi0134.phi005.perseus-eng2.xml
+++ b/data/phi0134/phi005/phi0134.phi005.perseus-eng2.xml
@@ -2,8 +2,8 @@
    <teiHeader  xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>The Mother-In-Law</title>
-            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <title>Hecyra, The Mother-In-Law</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>

--- a/data/phi0134/phi005/phi0134.phi005.perseus-eng2.xml
+++ b/data/phi0134/phi005/phi0134.phi005.perseus-eng2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader  xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Hecyra: The Mother-In-Law</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="transl">Henry Thomas Riley</editor>
+            <title>The Mother-In-Law</title>
+            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -31,13 +31,15 @@
             <biblStruct>
                <monogr>
                   <title>The Comedies of Terence</title>
-                  <editor role="transl">Henry Thomas Riley</editor>
+                  <editor role="translator">Henry Thomas Riley</editor>
+                  <editor role="translator">George Colman</editor>
                   <imprint>
                      <pubPlace>Ney York</pubPlace>
                      <publisher>Harper and Brothers</publisher>
                      <date>1874</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comediesliterall00tereuoft/page/254/mode/2up">Internet Archive</ref>                              
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi005/phi0134.phi005.perseus-eng2.xml
+++ b/data/phi0134/phi005/phi0134.phi005.perseus-eng2.xml
@@ -2,7 +2,7 @@
    <teiHeader  xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Hecyra, The Mother-In-Law</title>
+            <title>Hecyra; The Mother-In-Law</title>
             <author xml:lang="lat">P. Terentius Afer</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0134/phi005/phi0134.phi005.perseus-lat2.xml
+++ b/data/phi0134/phi005/phi0134.phi005.perseus-lat2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Hecyra</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="editor">Edward St. John Parry</editor>
+            <title xml:lang="lat">Hecyra</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
+            <editor>Edward St. John Parry</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -24,15 +24,17 @@
          <sourceDesc>
             <biblStruct>
                <monogr>
-                  <title>Publii Terentii Comoediae VI</title>
-                  <author>P. Terentius Afer</author>
-                  <editor role="editor">Edward St. John Parry, M.A.</editor>
+                  <title xml:lang="lat">Publii Terentii Comoediae Sex</title>
+                  <author xml:lang="lat">P. Terentius Afer</author>
+                  <editor>Edward St. John Parry</editor>
                   <imprint>
                      <pubPlace>London</pubPlace>
-                     <publisher>Whitaker and Co., Ave Maria Lane;  George Bell, Fleet Street</publisher>
+                     <publisher>Whitaker and Co</publisher>
+                     <publisher>George Bell</publisher>
                      <date>1857</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comoediaesexwith00tereuoft/page/322/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi006/__cts__.xml
+++ b/data/phi0134/phi006/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi006.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi006">
-              <ti:label xml:lang="eng">Adelphi, The Brothers</ti:label>
+              <ti:label xml:lang="eng">Adelphi; or, The Brothers</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi006/__cts__.xml
+++ b/data/phi0134/phi006/__cts__.xml
@@ -6,7 +6,7 @@
                 Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi006.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi006">
-              <ti:label xml:lang="eng">The Brothers</ti:label>
+              <ti:label xml:lang="eng">Adelphi, The Brothers</ti:label>
             <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
               Harper and Brothers, 1872.</ti:description>
           </ti:translation>

--- a/data/phi0134/phi006/__cts__.xml
+++ b/data/phi0134/phi006/__cts__.xml
@@ -1,11 +1,13 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0134.phi006" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0134">
-            <ti:title xml:lang="lat">The Brothers</ti:title>
+            <ti:title xml:lang="lat">Adelphi</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi0134.phi006.perseus-lat2" workUrn="urn:cts:latinLit:phi0134.phi006">
-              <ti:label xml:lang="eng">The Brothers, Publii Terentii Comoediae sex</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Parry, Edward St. John, editor</ti:description>
+              <ti:label xml:lang="lat">Adelphi</ti:label>
+              <ti:description xml:lang="mul">Terence. Publii Terentii Comoediae Sex. Parry, Edward St. John, editor. London: Whittaker and 
+                Co.; George Bell, 1857.</ti:description>
             </ti:edition>
           <ti:translation xml:lang="eng" urn="urn:cts:latinLit:phi0134.phi006.perseus-eng2" workUrn="urn:cts:latinLit:phi0134.phi006">
-              <ti:label xml:lang="eng">The Brothers, The comedies of Terence</ti:label>
-              <ti:description xml:lang="eng">Terence, creator; Riley, Henry Thomas, 1816-1878, translator; Colman, George, 1732-1794, translator</ti:description>
-            </ti:translation>
+              <ti:label xml:lang="eng">The Brothers</ti:label>
+            <ti:description xml:lang="eng">Terence. The Comedies of Terence. Riley, Henry Thomas; Colman, George, translators. New York:
+              Harper and Brothers, 1872.</ti:description>
+          </ti:translation>
           </ti:work>

--- a/data/phi0134/phi006/phi0134.phi006.perseus-eng2.xml
+++ b/data/phi0134/phi006/phi0134.phi006.perseus-eng2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Adelphi:  The Brothers</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="transl">Henry Thomas Riley</editor>
+            <title>The Brothers</title>
+            <author xml:lang="lat">P. Terentius Afer (Terence)</author>
+            <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -36,13 +36,16 @@
             <biblStruct>
                <monogr>
                   <title>The Comedies of Terence</title>
-                  <editor role="transl">Henry Thomas Riley</editor>
+                  <editor role="translator">Henry Thomas Riley</editor>
+                  <editor role="translator">George Colman</editor>
                   <imprint>
                      <pubPlace>Ney York</pubPlace>
                      <publisher>Harper and Brothers</publisher>
                      <date>1874</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comediesliterall00tereuoft/page/196/mode/2up">Internet Archive</ref>                              
+               
             </biblStruct>
          </sourceDesc>
       </fileDesc>

--- a/data/phi0134/phi006/phi0134.phi006.perseus-eng2.xml
+++ b/data/phi0134/phi006/phi0134.phi006.perseus-eng2.xml
@@ -2,7 +2,7 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>The Brothers</title>
+            <title>Adelphi, The Brothers</title>
             <author xml:lang="lat">P. Terentius Afer (Terence)</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0134/phi006/phi0134.phi006.perseus-eng2.xml
+++ b/data/phi0134/phi006/phi0134.phi006.perseus-eng2.xml
@@ -2,7 +2,7 @@
    <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Adelphi, The Brothers</title>
+            <title>Adelphi; or, The Brothers</title>
             <author xml:lang="lat">P. Terentius Afer (Terence)</author>
             <editor role="translator">Henry Thomas Riley</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0134/phi006/phi0134.phi006.perseus-lat2.xml
+++ b/data/phi0134/phi006/phi0134.phi006.perseus-lat2.xml
@@ -1,10 +1,10 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"	schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title>Adelphi</title>
-            <author>P. Terentius Afer (Terence)</author>
-            <editor role="editor">Edward St. John Parry</editor>
+            <title xml:lang="lat">Adelphi</title>
+            <author xml:lang="lat">P. Terentius Afer</author>
+            <editor>Edward St. John Parry</editor>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -29,15 +29,17 @@
          <sourceDesc>
             <biblStruct>
                <monogr>
-                  <title>Publii Terentii Comoediae VI</title>
-                  <author>P. Terentius Afer</author>
-                  <editor role="editor">Edward St. John Parry, M.A.</editor>
+                  <title xml:lang="lat">Publii Terentii Comoediae Sex</title>
+                  <author xml:lang="lat">P. Terentius Afer</author>
+                  <editor>Edward St. John Parry</editor>
                   <imprint>
                      <pubPlace>London</pubPlace>
-                     <publisher>Whitaker and Co., Ave Maria Lane;  George Bell, Fleet Street</publisher>
+                     <publisher>Whitaker and Co</publisher>
+                     <publisher>George Bell</publisher>
                      <date>1857</date>
                   </imprint>
                </monogr>
+               <ref target="https://archive.org/details/comoediaesexwith00tereuoft/page/242/mode/2up">Internet Archive</ref>
             </biblStruct>
          </sourceDesc>
       </fileDesc>


### PR DESCRIPTION
Deleted Latin name from textgroup with up to date practice, but left the
full Latin name for author in header and bibl descriptions.

Updated cts_.xml files
Updated the bibls and added in page links to online files.