### PR TITLE
(phi0478)phi0478.phi003

### DIFF
--- a/data/phi0478/__cts__.xml
+++ b/data/phi0478/__cts__.xml
@@ -1,4 +1,4 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0478">
-    <ti:groupname xml:lang="eng">Quintus Tullius Cicero</ti:groupname>
+    <ti:groupname xml:lang="lat">Quintus Tullius Cicero</ti:groupname>
 </ti:textgroup>
     

--- a/data/phi0478/phi003/__cts__.xml
+++ b/data/phi0478/phi003/__cts__.xml
@@ -1,7 +1,8 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0478.phi003" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0478">
 	<ti:title xml:lang="lat">Commentariolum Petitionis</ti:title>
 	<ti:edition urn="urn:cts:latinLit:phi0478.phi003.perseus-lat2" workUrn="urn:cts:latinLit:phi0478.phi003">
-		<ti:label xml:lang="eng">Commentariolum Petitionis, Epistulae Volume III</ti:label>
-		<ti:description xml:lang="eng">Cicero, Quintus Tullius, creator; Cicero, Marcus Tullius, creator; Purser, Louis Claude, 1854-1932, editor</ti:description>
+		<ti:label xml:lang="lat">Commentariolum Petitionis</ti:label>
+		<ti:description xml:lang="mul">Cicero, Quintus Tullius. M. Tullis Ciceronis. Epistulae, Volume 3. Purser, Louis Claude, editor.
+		Oxford: Clarendon Press, 1901.</ti:description>
 	</ti:edition>
 </ti:work>

--- a/data/phi0478/phi003/phi0478.phi003.perseus-lat2.xml
+++ b/data/phi0478/phi003/phi0478.phi003.perseus-lat2.xml
@@ -6,7 +6,7 @@
   <teiHeader xml:lang="eng">
     <fileDesc>
       <titleStmt>
-        <title>Commentariolum Petitionis</title>        
+        <title xml:lang="lat">Commentariolum Petitionis</title>        
         <author xml:lang="lat">Q. Tullius Cicero</author>
         <editor>Louis Claude Purser</editor>
         <sponsor>Perseus Project, Tufts University</sponsor>

--- a/data/phi0478/phi003/phi0478.phi003.perseus-lat2.xml
+++ b/data/phi0478/phi003/phi0478.phi003.perseus-lat2.xml
@@ -3,13 +3,13 @@
   schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"
   schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
+  <teiHeader xml:lang="eng">
     <fileDesc>
       <titleStmt>
-        <title>Essay on Running for Consul</title>
-        
-        <author>Q. Tullius Cicero</author>
-        <editor role="editor" n="OCT">L. C. Purser</editor> <sponsor>Perseus Project, Tufts University</sponsor>
+        <title>Commentariolum Petitionis</title>        
+        <author xml:lang="lat">Q. Tullius Cicero</author>
+        <editor>Louis Claude Purser</editor>
+        <sponsor>Perseus Project, Tufts University</sponsor>
     <principal>Gregory Crane</principal>
     <respStmt>
     <resp>Prepared under the supervision of</resp>
@@ -32,7 +32,26 @@
         <date type="release">2000-08-01</date>
     </publicationStmt> 
       <sourceDesc>
-        <p>Follows the 1902 OCT</p>
+        <biblStruct>
+          <monogr>
+            <author>M. Tullius Cicero</author>
+            <title xml:lang="lat">M. Tulli Ciceronis</title>
+            <title xml:lang="lat" type="sub">Epistulae</title>
+            <editor>Louise Claude Purser</editor>
+            <imprint>
+              <pubPlace>Oxford</pubPlace>
+              <publisher>Oxonii</publisher>
+              <date>1902</date>
+            </imprint>
+            <biblScope unit="volume">3</biblScope>
+          </monogr>
+          <series>
+            <title xml:lang="lat">Scriptorum classicorum bibliotheca Oxoniensis</title>
+          </series>
+          <ref target="https://archive.org/details/epistulaerecogno03ciceuoft/page/80/mode/2up">Internet Archive</ref>
+          <!--         <p>Follows the 1902 OCT</p> -->
+        </biblStruct>
+
       </sourceDesc>
     </fileDesc>
 
@@ -49,7 +68,7 @@
 
     <profileDesc>
       <langUsage>
-        <language  ident="lat">Latin </language>
+        <language  ident="lat">Latin</language>
       </langUsage>
     </profileDesc>
 


### PR DESCRIPTION
Updated cts_.xml
Added in a structured bibl for phi0478.phi003.opp-lat2

@lcerrato  I added in a fill bibliographic description according to the cts metadata. Is that ok?
Previously it had simply said:
`<p>Follows the 1902 OCT</p>`
