### PR TITLE
(phi2331)_all_files

### DIFF
--- a/data/phi2331/__cts__.xml
+++ b/data/phi2331/__cts__.xml
@@ -1,4 +1,4 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:cts="http://chs.harvard.edu/xmlns/cts/ti" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:phi2331">
-          <ti:groupname xml:lang="lat">Vopiscus, Flavius</ti:groupname>
+          <ti:groupname xml:lang="lat">Scriptores Historiae Augustae</ti:groupname>
           </ti:textgroup>
       

--- a/data/phi2331/phi001/__cts__.xml
+++ b/data/phi2331/phi001/__cts__.xml
@@ -1,8 +1,9 @@
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi2331.phi001" xml:lang="lat" groupUrn="urn:cts:latinLit:phi2331">
             <ti:title xml:lang="lat">De Vita Hadriani</ti:title>
             <ti:edition urn="urn:cts:latinLit:phi2331.phi001.perseus-lat2" workUrn="urn:cts:latinLit:phi2331.phi001">
-              <ti:label xml:lang="eng">De Vita Hadriani, The Scriptores historiae augustae Volume I</ti:label>
-              <ti:description xml:lang="eng">Spartianus, Aelius, fl.3./4. Jh.‏, attributed author; Magie, David, 1877-, translator; O'Brien-Moore, Ainsworth, 1897-1936, translator; Ballou, Susan Helen, 1868-, translator; Ballou, Susan Helen, b. 1868, editor</ti:description>
+              <ti:label xml:lang="lat">De Vita Hadriani</ti:label>
+              <ti:description xml:lang="mul">Scriptores Historiae Augustae, Volume 1. Magie, David, editor; Ballou, Susan Helen, editor. London, New York: William Heinemann, G. P. Putnam's
+                Sons, 1922.</ti:description>
             </ti:edition>
           </ti:work>
         

--- a/data/phi2331/phi001/phi2331.phi001.perseus-lat2.xml
+++ b/data/phi2331/phi001/phi2331.phi001.perseus-lat2.xml
@@ -3,14 +3,12 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"
   schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-    <teiHeader>
+    <teiHeader xml:lang="eng">
         <fileDesc>
             <titleStmt>
-                <title type="work" n="Hadr">De vita Hadriani </title>
-		
-                <editor role="editor" n="Magie">David Magie</editor>
-                <editor role="editor" n="O'Brien-Moore">Ainsworth O'Brien-Moore</editor>
-                <editor role="editor" n="Ballou">Susan Helen Ballou</editor>
+                <title xml:lang="lat">De vita Hadriani</title>		
+                <editor>David Magie</editor>
+                <editor>Susan Helen Ballou</editor>
                 <sponsor>Perseus Project, Tufts University</sponsor>
 <principal>Gregory Crane</principal>
 <respStmt>
@@ -37,19 +35,23 @@
             <sourceDesc>
                 <biblStruct>
                     <monogr>
-                        <title>Scriptores Historiae Augustae, Vol 1</title>
-                        <editor role="editor" n="Magie">David Magie</editor>
-                <editor role="editor" n="O'Brien-Moore">Ainsworth O'Brien-Moore</editor>
-                <editor role="editor" n="Ballou">Susan Helen Ballou</editor><imprint>
-                            <publisher>William Heinemann</publisher>
+                        <title xml:lang="lat">Scriptores Historiae Augustae</title>
+                        <editor>David Magie</editor>
+                <editor>Susan Helen Ballou</editor>
+                 <imprint>
+                <publisher>William Heinemann</publisher>
+                    <publisher>G.P. Putnam's Sons</publisher>
 			    <pubPlace>London</pubPlace>
-			    <publisher>G.P. Putnam's Sons</publisher>
 			    <pubPlace>New York</pubPlace>
-                            <date>1921</date>
+                            <date>1922</date>
                         </imprint>
+                        <biblScope unit="volume">1</biblScope>
                     </monogr>
+                    <series>
+                        <title>Loeb CLassical Library</title>
+                    </series>
+                    <ref target="https://archive.org/details/scriptoreshistor01camb/page/2/mode/2up">Internet Archive</ref>
                 </biblStruct>
-		
                 </sourceDesc>      
         </fileDesc>      
         <encodingDesc>


### PR DESCRIPTION
This is an initial pull request to start updating the files for the Scriptores Historiae Augustae.

The textgroup for this group was in error, it was one of the attributed author names so I changed it from
`   <ti:groupname xml:lang="lat">Vopiscus, Flavius</ti:groupname>` to
   <ti:groupname xml:lang="lat">Scriptores Historiae Augustae</ti:groupname>

I am also making a number of changes to the headers @lcerrato if you approve. 
I'm taking out  Ainsworth O'Brien-Moore as an editor/translator from those work files where he didn't contribute and will do the same for Susan Ballou, only David Magie should be at the individual work header level for all of the files.

I'm also taking out the attributed author names for works such as Capitolinus, Julius, fl. 300, etc. and instead am going to go with something like this in the edition_level cts_xml file
`    <ti:description xml:lang="mul">Scriptores Historiae Augustae, Volume 1. Magie, David, editor; Ballou, Susan Helen, editor. London, New York: William Heinemann, G. P. Putnam's Sons, 1922.</ti:description>`

I will make changes to each file header based on whether it should include Magie plus Ballou, or Magie plus O'Brien, or Magie alone. I have all of that data in the catalog_data.  


