### PR TITLE
(phi1212).phi1212.001_phi1212.phi002

### DIFF
--- a/data/phi1212/phi001/phi1212.phi001.perseus-lat1.xml
+++ b/data/phi1212/phi001/phi1212.phi001.perseus-lat1.xml
@@ -4,13 +4,13 @@
 <?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"
   schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-   <teiHeader>
+   <teiHeader xml:lang="eng">
       <fileDesc>
          <titleStmt>
-            <title type="work">Apologia</title>
-            
-            <author n="Apuleius">Apuleius</author>
-            <funder n="org:Mellon">The Mellon Foundation</funder>
+            <title xml:lang="lat">Apologia</title>            
+            <author>Apuleius</author>
+            <editor>Rudolf Helm</editor>
+            <funder>The Mellon Foundation</funder>
             <sponsor>Perseus Project, Tufts University</sponsor>
             <principal>Gregory Crane</principal>
             <respStmt>
@@ -35,13 +35,15 @@
             <biblStruct>
                <monogr>
                   <author>Apuleius</author>
-                  <title>Apulei Platonici Madaurensis, Pro se de magia liber (Apologia)</title>
+                  <title xml:lang="lat">Apulei Platonici Madaurensis, Pro se de magia liber (Apologia)</title>
                   <editor>Rudolf Helm</editor>
                   <imprint>
-                     <publisher>Lipsiae : B.G. Teubneri</publisher>
+                     <pubPlace>Leipzig</pubPlace>
+                     <publisher>Teubner</publisher>
                      <date>1912</date>
                   </imprint>
                </monogr>
+               <ref target="https://hdl.handle.net/2027/njp.32101060178538?urlappend=%3Bseq=11%3Bownerid=27021597769469484-15">HatihTrust</ref>
             </biblStruct>
             <list>
                <item>Keyboarding</item>
@@ -69,6 +71,7 @@
       </profileDesc>
       <revisionDesc>
          <change who="Zach Himes" when="2015-11-11">Converted to TEI P5 and EpiDoc</change>
+         <change who="Zach Himes" when="2022-11-03">Converted to TEI P5 and EpiDoc</change>
       </revisionDesc>
    </teiHeader>
    <text xml:lang="lat">

--- a/data/phi1212/phi002/phi1212.phi002.perseus-lat1.xml
+++ b/data/phi1212/phi002/phi1212.phi002.perseus-lat1.xml
@@ -6,11 +6,10 @@
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title type="work">Metamorphoses</title>
-        
-        <author n="Apuleius">Apuleius</author>
+        <title>Metamorphoses</title>        
+        <author>Apuleius</author>
         <editor>Stephen Gaselee</editor>
-      <funder n="org:Mellon">The Mellon Foundation</funder>
+      <funder>The Mellon Foundation</funder>
         <sponsor>Perseus Project, Tufts University</sponsor>
         <principal>Gregory Crane</principal>
         <respStmt>


### PR DESCRIPTION
I fixed the metadata and headers for these Apuleius files but they are also both showing up in Scaife without having their URNs bumped.

@lcerrato I don't want to flood you with data issues regarding bumping but figured I would create a separate issue for Apuleius rather than conflate it with Seneca the elder. 