### PR TITLE
(phi1017)_textgroup_name_change

### DIFF
--- a/data/phi1017/__cts__.xml
+++ b/data/phi1017/__cts__.xml
@@ -1,3 +1,3 @@
 <cts:textgroup xmlns:cts="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi1017">
-  <cts:groupname xml:lang="eng">Seneca, Lucius Annaeus (Plays)</cts:groupname>
+  <cts:groupname xml:lang="eng">Seneca, Lucius Annaeus</cts:groupname>
 </cts:textgroup>


### PR DESCRIPTION
Updated textgroup name to eliminate plays as a first step towards merging the two Seneca the Younger textgroups per discussion in Scaife meeting today re issue (https://github.com/scaife-viewer/scaife-viewer/issues/571).