### PR TITLE
remove double opening typo

### DIFF
--- a/data/stoa0089/stoa001/stoa0089.stoa001.perseus-eng1.xml
+++ b/data/stoa0089/stoa001/stoa0089.stoa001.perseus-eng1.xml
@@ -35,7 +35,7 @@
             <imprint>
               <publisher>Harvard University Press</publisher>
               <pubPlace>Cambridge, MA</pubPlace>
-              <pubPlace>London, England<</pubPlace>
+              <pubPlace>London, England</pubPlace>
               <date>1922</date>
             </imprint>
             <biblScope unit="volume">2</biblScope>


### PR DESCRIPTION
There is a double `<` on this line:

```
<pubPlace>London, England<</pubPlace>
```