### PR TITLE
phi1017.phi011.perseus-lat2.xml Restore missing greek/ocr errors

### DIFF
--- a/data/phi1017/phi011/phi1017.phi011.perseus-lat2.xml
+++ b/data/phi1017/phi011/phi1017.phi011.perseus-lat2.xml
@@ -167,7 +167,7 @@
                 illud plena manu, et Neroni multos annos de suo donat. Claudium autem iubent
                     omnes<quote rend="blockquote">
                     <l>
-                        <foreign xml:lang="grc">χαίροντας, εὐφημοῦντασ ἐκπέμπειν δόμων.</foreign>
+                        <foreign xml:lang="grc">χαίροντας, εὐφημοῦντας ἐκπέμπειν δόμων.</foreign>
                         <note>A fragment from the Cresphontes of Euripides (Nauck, 452).</note>
                     </l>
                 </quote> Et ille quidem animam ebulliit, et ex eo desiit vivere videri. Exspiravit
@@ -193,7 +193,7 @@
                 tertium decimum laborem venisse. Diligentius intuenti visus est quasi homo. Accessit
                 itaque et quod facillimum fuit Graeculo, ait:<quote rend="blockquote">
                     <l>
-                        <foreign xml:lang="grc">τίσ πόθεν εί</foreign>
+                        <foreign xml:lang="grc">τίς πόθεν εἶς ἀνδρῶν, πόθι τοι πόλις ἠδὲ τοκῆες;</foreign>
                     </l>
                 </quote>
                 <pb n="p.382"/> Claudius gaudet esse illic philologos homines, sperat futurum
@@ -201,13 +201,13 @@
                 significant ait:</p>
             <quote rend="blockquote">
                 <l>
-                    <foreign xml:lang="grc"></foreign>
+                    <foreign xml:lang="grc">Ἰλιόθεν με φέρων ἄνεμος Κικόνεσσι πέλασσεν.</foreign>
                 </l>
             </quote>
             <p>Erat autem sequens versus verior, aeque Homericus:</p>
             <quote rend="blockquote">
                 <l>
-                    <foreign xml:lang="grc">ἔνθα δ</foreign>
+                    <foreign xml:lang="grc">ἔνθα δʼ ἐγὼ πόλιν ἔπραθον, ὤλεσα δʼ αὐτούς.</foreign>
                 </l>
             </quote>
             <p>Et imposuerat Herculi minime vafro,
@@ -261,8 +261,8 @@
 </p></div>
 
 <div type="textpart" subtype="section" n="8"><p><quote>Non mirum quod in curiam impetum fecisti: nihil tibi clausi
-                    est. Modo dic nobis, qualem deum istum fieri velis. <foreign xml:lang="grc"></foreign> non potest esse: <foreign xml:lang="grc">οὔτε</foreign>
-                    <foreign xml:lang="grc">αὐτὸσ πρᾶγμα ἔχει τι οὔτε ἄλλοις                    παρέχει;</foreign> Stoicus? Quomodo potest 'rotundus' esse, ut ait Varro, 'sine
+                    est. Modo dic nobis, qualem deum istum fieri velis. <foreign xml:lang="grc">Ἐπικούρειος θεὸς</foreign> non potest esse: <foreign xml:lang="grc">οὔτε
+                    αὐτὸς πρᾶγμα ἔχει τι οὔτε ἄλλοις παρέχει;</foreign> Stoicus? Quomodo potest 'rotundus' esse, ut ait Varro, 'sine
                     capite, sine praeputio'? Est aliquid in illo Stoici dei, iam video: nec cor nec
                     caput habet. Si mehercules a Saturno petisset hoc beneficium, cuius mensem toto
                     anno celebravit, Saturnalicius princeps, non tulisset illud, nedum ab Iove, quem
@@ -283,13 +283,13 @@
                     mapalia fecistis. Volo ut servetis disciplinam curiae. Hic qualiscunque est,
                     quid de nobis existimabit?</quote> Illo dimisso primus interrogatur sententiam
                 Ianus pater. Is designatus erat in kal. Iulias postmeridianus consul, homo
-                quantumvis vafer, qui semper videt <foreign xml:lang="grc">ἅμα πρόσσω καὶ</foreign>
+                quantumvis vafer, qui semper videt <foreign xml:lang="grc">ἅμα πρόσσω καὶ ὀπίσσω.</foreign>
                 <pb n="p.390"/> Is multa diserte, quod in foro vivebat, dixit, quae notarius
                 persequi non potuit, et ideo non refero, ne aliis verbis ponam, quae ab illo dicta
                 sunt. Multa dixit de magnitudine deorum: non debere hunc vulgo dari honorem.
                     <quote>Olim</quote> inquit <quote>magna res erat deum fieri: iam famam mimum
                     fecistis. Itaque ne videar in personam, non in rem dicere sententiam, censeo ne
-                    quis post hunc diem deus fiat ex his, qui <foreign xml:lang="grc">ἀρούρης                        καρπὸν ἔδουσιν,</foreign> aut ex his, quos alit <foreign xml:lang="grc">ζείδωροσ ἄρουρα.</foreign>. Qui contra hoc senatus consultum deus
+                    quis post hunc diem deus fiat ex his, qui <foreign xml:lang="grc">ἀρούρης                        καρπὸν ἔδουσιν,</foreign> aut ex his, quos alit <foreign xml:lang="grc">ζείδωρος ἄρουρα.</foreign>. Qui contra hoc senatus consultum deus
                     factus, dictus pictusve erit, eum dedi Laruis et proximo munere inter novos
                     auctoratos ferulis vapulare placet.</quote> Proximus interrogatur sententiam
                 Diespiter Vicae Potae filius, et ipse designatus consul, nummulariolus: hoc quaestu
@@ -328,7 +328,7 @@
 <milestone unit="section" n="11"/> In caelo non fit. Ecce Iuppiter, qui tot annos regnat,
                 uni Volcano crus fregit, quem<quote rend="blockquote">
                     <l>
-                        <foreign xml:lang="grc">ῤῖψε ποδὸσ τεταγὼν ἀπὸ βηλοῦ</foreign>
+                        <foreign xml:lang="grc">ῤῖψε ποδὸς τεταγὼν ἀπὸ βηλοῦ θεσπεσίοιο</foreign>
                     </l>
                 </quote> et iratus fuit uxori et suspendit illam: numquid occidit? Tu Messalinam,
                 cuius aeque avunculus maior eram quam tuus, occidisti. <quote>Nescio</quote> inquis.
@@ -435,7 +435,7 @@
                 praemiserat. Deinde praefecti duo Iustus Catonius et Rufrius Pollio. Deinde amici
                 Saturninus Lusius et Pedo Pompeius et Lupus et Celer Asinius consulares. Novissime
                 fratris filia, sororis filia, generi, soceri, socrus, omnes plane consanguinei. Et
-                agmine facto Claudio occurrunt. Quos cum vidisset Claudius, exclamat: <foreign xml:lang="grc">πάντα φίλων πγήρη</foreign>
+                agmine facto Claudio occurrunt. Quos cum vidisset Claudius, exclamat: <foreign xml:lang="grc">πάντα φίλων πλήρη</foreign>
                 <quote>quomodo huc venistis vos?</quote> Tum Pedo Pompeius: <quote>Quid dicis, homo
                     crudelissime? Quaeris, quomodo? Quis enim nos alius hue misit quam tu, omnium
                     amicorum interfector? In ius eamus, ego tibi hic sellas ostendam.</quote></p>
@@ -444,11 +444,11 @@
 
 <div type="textpart" subtype="section" n="14"><p>Ducit illum ad tribunal Aeaci: is lege Cornelia
                 quae de sicariis lata est, quaerebat. Postulat, nomen eius recipiat; edit
-                subscriptionem: occisos senatores XXXV, equites R. CCXXI, ceteros <foreign xml:lang="grc">ὅσα ψάμαθόσ τε κόνισ τε.</foreign>. Advocatum non invenit.
+                subscriptionem: occisos senatores XXXV, equites R. CCXXI, ceteros <foreign xml:lang="grc">ὅσα ψάμαθός τε κόνις τε.</foreign>. Advocatum non invenit.
                 Tandem procedit P. Petronius, vetus convictor eius, homo Claudiana lingua disertus,
                 et postulat advocationem. Non datur. Accusat Pedo Pompeius magnis clamoribus.
                 Incipit patronus velle respondere. Aeacus, homo iustissimus,<pb n="p.404"/> vetat,
-                et illum altera tantum parte audita condemnat et ait: <foreign xml:lang="grc">αἴκε</foreign> Ingens silentium
+                et illum altera tantum parte audita condemnat et ait: <foreign xml:lang="grc">αἴκε πάθοι τά τʼ ἔρεξε, δίκη κʼ ἰθεῖα γένοιτο.</foreign> Ingens silentium
                 factum est. Stupebant omnes novitate rei attoniti, negabant hoc unquam factum.
                 Claudio magis iniquum videbatur quam novum. De genere poenae diu disputatum est,
                 quid illum pati oporteret. Erant qui dicerent, Sisyphum satis diu laturam fecisse,


### PR DESCRIPTION
Fixed some final sigmas (σ/ς) and restored quite a few missing Greek words from the source edition on archive.org (https://archive.org/details/petronius00petruoft/page/378/mode/2up).