### PR TITLE
(phi1017.phi004.perseus-lat2.xml) Fix typo on line 480

### DIFF
--- a/data/phi1017/phi004/phi1017.phi004.perseus-lat2.xml
+++ b/data/phi1017/phi004/phi1017.phi004.perseus-lat2.xml
@@ -862,7 +862,7 @@
 
                <l n="478">per spes tuorum liberum et certum larem, </l>
                <l n="479">per victa monstra, per manus, pro te quibus</l>
-               <l n="480">numquam peperci, perque prseteritos metus, </l>
+               <l n="480">numquam peperci, perque praeteritos metus, </l>
                <l n="481">per caelum et undas, coniugi testes mei,</l>
                <l n="482">miserere, redde supplici felix vicem. </l>
 


### PR DESCRIPTION
In Seneca's Medea, [line 480](https://github.com/PerseusDL/canonical-latinLit/blob/81cbbe22b100a58efdefffee787265075876fc3c/data/phi1017/phi004/phi1017.phi004.perseus-lat2.xml#L865) reads "numquam peperci, perque prseteritos metus," instead of "praeteritos metus".

Fix #681 