### PR TITLE
Keeping HookTest below v2.0 for compatibility.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           distribution: "zulu"
           java-version: "11"
       - name: Install Hooktest
-        run: pip3 install HookTest
+        run: pip3 install "hooktest<2.0.0"
       - name: Restore manifest.txt
         id: restore_manifest
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Keeping HookTest below v2.0 for compatibility.

@lcerrato @AlisonBabeu I hope you're doing well!

I am proposing this change to pin HookTest to <2.0 to ensure your repository remains functional. The upcoming HookTest v2.0 (scheduled for release the week of June 22nd) only supports CiteStructure approaches, which would break your current setup. By pinning the version now, you can maintain stability.