### PR TITLE
Adding in missing cts_xml files-but not updating texts

### DIFF
--- a/data/phi0692/__cts__.xml
+++ b/data/phi0692/__cts__.xml
@@ -1,0 +1,4 @@
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:cts="http://chs.harvard.edu/xmlns/cts/ti" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:phi0692">
+          <ti:groupname xml:lang="lat">Appendix Vergiliana</ti:groupname>
+          </ti:textgroup>
+      

--- a/data/phi0692/phi001/__cts__.xml
+++ b/data/phi0692/phi001/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi001" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+            <ti:title xml:lang="lat">Dirae</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi001.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi001">
+              <ti:label xml:lang="lat">Dirae</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi002/__cts__.xml
+++ b/data/phi0692/phi002/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi002" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+            <ti:title xml:lang="lat">Lydia</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi002.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi002">
+              <ti:label xml:lang="lat">Lydia</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi003/__cts__.xml
+++ b/data/phi0692/phi003/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi003" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+            <ti:title xml:lang="lat">Culex</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi003.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi003">
+              <ti:label xml:lang="lat">Culex</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi005/__cts__.xml
+++ b/data/phi0692/phi005/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi005" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+            <ti:title xml:lang="lat">Copa</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi005.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi005">
+              <ti:label xml:lang="lat">Copa</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi006/__cts__.xml
+++ b/data/phi0692/phi006/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi006" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+  <ti:title xml:lang="lat">Elegiae in Maecenatem</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi006.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi006">
+              <ti:label xml:lang="lat">Elegiae in Maecenatem</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi007/__cts__.xml
+++ b/data/phi0692/phi007/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi007" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+            <ti:title xml:lang="lat">Ciris</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi007.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi007">
+              <ti:label xml:lang="lat">Ciris</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi008/__cts__.xml
+++ b/data/phi0692/phi008/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi008" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+            <ti:title xml:lang="lat">Priapea</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi008.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi008">
+              <ti:label xml:lang="lat">Priapea</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi009/__cts__.xml
+++ b/data/phi0692/phi009/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi009" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+            <ti:title xml:lang="lat">Catalepton</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi009.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi009">
+              <ti:label xml:lang="lat">Catalepton</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi011/__cts__.xml
+++ b/data/phi0692/phi011/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi011" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+  <ti:title xml:lang="lat">Moretum</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi011.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi011">
+              <ti:label xml:lang="lat">Moretum</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi012/__cts__.xml
+++ b/data/phi0692/phi012/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi012" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+  <ti:title xml:lang="lat">De Institutione Viri Boni</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi012.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi012">
+              <ti:label xml:lang="lat">De Institutione Viri Boni</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi0692/phi013/__cts__.xml
+++ b/data/phi0692/phi013/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi0692.phi013" xml:lang="lat" groupUrn="urn:cts:latinLit:phi0692">
+  <ti:title xml:lang="lat">De Est et Non</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi0692.phi013.perseus-lat1" workUrn="urn:cts:latinLit:phi0692.phi013">
+              <ti:label xml:lang="lat">De Est et Non</ti:label>
+              <ti:description xml:lang="mul">Appendix Vergiliana sive carmina minora Vergilio adtributa. Ellis, Robinson, editor. Oxford: Clarendon Press, 1907.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/phi2003/__cts__.xml
+++ b/data/phi2003/__cts__.xml
@@ -1,0 +1,4 @@
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:phi2003">
+          <ti:groupname xml:lang="lat">Apicius</ti:groupname>
+          </ti:textgroup>
+      

--- a/data/phi2003/phi001/__cts__.xml
+++ b/data/phi2003/phi001/__cts__.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:phi02003.phi001" xml:lang="lat" groupUrn="urn:cts:latinLit:phi2003">
+            <ti:title xml:lang="lat">De Re Coquinaria</ti:title>
+            <ti:edition urn="urn:cts:latinLit:phi2003.phi001.perseus-lat1" workUrn="urn:cts:latinLit:phi2003.phi001">
+              <ti:label xml:lang="lat">De Re Coquinaria</ti:label>
+              <ti:description xml:lang="mul">Apicius. Apici Caeli De re coquinaria libri decem. Schuch, Christian Theophil, editor. Heidelberg: Winter, 1867.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/stoa0040/__cts__.xml
+++ b/data/stoa0040/__cts__.xml
@@ -1,0 +1,4 @@
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:cts="http://chs.harvard.edu/xmlns/cts/ti" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:stoa0040">
+          <ti:groupname xml:lang="eng">Augustine, Saint</ti:groupname>
+          </ti:textgroup>
+      

--- a/data/stoa0040/stoa011/__cts__.xml
+++ b/data/stoa0040/stoa011/__cts__.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:stoa0040.stoa011" xml:lang="lat" groupUrn="urn:cts:latinLit:stoa0040">
+            <ti:title xml:lang="lat">Epistulae</ti:title>
+            <ti:edition urn="urn:cts:latinLit:stoa0040.stoa001.perseus-lat1" workUrn="urn:cts:latinLit:stoa0040.stoa001">
+              <ti:label xml:lang="lat">Epistulae</ti:label>
+              <ti:description xml:lang="eng">Augustine, Saint. Select Letters. Baxter, James Houston, editor. London, Cambridge, MA: 
+              William Heinemann, Ltd.; Harvard University Press, 1930 (printing).</ti:description>
+            </ti:edition>
+  <ti:edition urn="urn:cts:latinLit:stoa0040.stoa001.perseus-lat2" workUrn="urn:cts:latinLit:stoa0040.stoa001">
+    <ti:label xml:lang="lat">Epistulae</ti:label>
+    <ti:description xml:lang="eng">Augustine, Saint. Select Letters. Baxter, James Houston, editor. London, Cambridge, MA: 
+      William Heinemann, Ltd.; Harvard University Press, 1930 (printing).</ti:description>
+  </ti:edition>
+        <ti:translation urn="urn:cts:latinLit:stoa0040.stoa001.perseus-eng1" workUrn="urn:cts:latinLit:stoa0040.stoa001">
+        <ti:label xml:lang="lat">Letters</ti:label>
+          <ti:description xml:lang="eng">Augustine, Saint. Select Letters. Baxter, James Houston, editor. London, Cambridge, MA: 
+            William Heinemann, Ltd.; Harvard University Press, 1930 (printing).</ti:description>
+      </ti:translation>         
+</ti:work> 

--- a/data/stoa0040/stoa011/__cts__.xml
+++ b/data/stoa0040/stoa011/__cts__.xml
@@ -1,17 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:stoa0040.stoa011" xml:lang="lat" groupUrn="urn:cts:latinLit:stoa0040">
             <ti:title xml:lang="lat">Epistulae</ti:title>
-            <ti:edition urn="urn:cts:latinLit:stoa0040.stoa001.perseus-lat1" workUrn="urn:cts:latinLit:stoa0040.stoa001">
+            <ti:edition urn="urn:cts:latinLit:stoa0040.stoa011.perseus-lat1" workUrn="urn:cts:latinLit:stoa0040.stoa011">
               <ti:label xml:lang="lat">Epistulae</ti:label>
               <ti:description xml:lang="eng">Augustine, Saint. Select Letters. Baxter, James Houston, editor. London, Cambridge, MA: 
               William Heinemann, Ltd.; Harvard University Press, 1930 (printing).</ti:description>
             </ti:edition>
-  <ti:edition urn="urn:cts:latinLit:stoa0040.stoa001.perseus-lat2" workUrn="urn:cts:latinLit:stoa0040.stoa001">
+  <ti:edition urn="urn:cts:latinLit:stoa0040.stoa011.perseus-lat2" workUrn="urn:cts:latinLit:stoa0040.stoa011">
     <ti:label xml:lang="lat">Epistulae</ti:label>
     <ti:description xml:lang="eng">Augustine, Saint. Select Letters. Baxter, James Houston, editor. London, Cambridge, MA: 
       William Heinemann, Ltd.; Harvard University Press, 1930 (printing).</ti:description>
   </ti:edition>
-        <ti:translation urn="urn:cts:latinLit:stoa0040.stoa001.perseus-eng1" workUrn="urn:cts:latinLit:stoa0040.stoa001">
+        <ti:translation urn="urn:cts:latinLit:stoa0040.stoa011.perseus-eng1" workUrn="urn:cts:latinLit:stoa0040.stoa011">
         <ti:label xml:lang="lat">Letters</ti:label>
           <ti:description xml:lang="eng">Augustine, Saint. Select Letters. Baxter, James Houston, editor. London, Cambridge, MA: 
             William Heinemann, Ltd.; Harvard University Press, 1930 (printing).</ti:description>

--- a/data/stoa0079/__cts__.xml
+++ b/data/stoa0079/__cts__.xml
@@ -1,0 +1,4 @@
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:cts="http://chs.harvard.edu/xmlns/cts/ti" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:stoa0079">
+          <ti:groupname xml:lang="lat">Cato, Marcus Porcius</ti:groupname>
+          </ti:textgroup>
+      

--- a/data/stoa0079/stoa001/__cts__.xml
+++ b/data/stoa0079/stoa001/__cts__.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:stoa0079.stoa001" xml:lang="lat" groupUrn="urn:cts:latinLit:stoa0079">
+            <ti:title xml:lang="lat">De agricultura</ti:title>
+            <ti:edition urn="urn:cts:latinLit:stoa0079.stoa001.perseus-lat1" workUrn="urn:cts:latinLit:stoa0079.stoa001">
+              <ti:label xml:lang="lat">De agri cultura</ti:label>
+              <ti:description xml:lang="mul">Cato, Marcus Porcius. M. Porci Catonis De agri cutura liber. Keil, Heinrich; Goetz, Georg, editors.
+              Leipzig: Teubner, 1922.</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/stoa0261/__cts__.xml
+++ b/data/stoa0261/__cts__.xml
@@ -1,0 +1,4 @@
+<ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" xmlns:cts="http://chs.harvard.edu/xmlns/cts/ti" xmlns:atom="http://www.w3.org/2005/Atom" urn="urn:cts:latinLit:stoa0261">
+          <ti:groupname xml:lang="lat">Sidonius Apollinaris</ti:groupname>
+          </ti:textgroup>
+      

--- a/data/stoa0261/stoa0001/__cts__.xml
+++ b/data/stoa0261/stoa0001/__cts__.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:stoa0261.stoa001" xml:lang="lat" groupUrn="urn:cts:latinLit:stoa0261">
+            <ti:title xml:lang="lat">Carmina</ti:title>
+            <ti:edition urn="urn:cts:latinLit:stoa0261.stoa001.perseus-lat1" workUrn="urn:cts:latinLit:stoa0261.stoa001">
+              <ti:label xml:lang="lat">Carmina</ti:label>
+              <ti:description xml:lang="mul">Sidonius Apollinaris. Poems and Letters, Vol 1. Anderson, W.B. London: William Heinemann, Ltd.; Cambridge, MA: Harvard
+              University Press, 1936 (printing).</ti:description>
+            </ti:edition>
+</ti:work> 

--- a/data/stoa0261/stoa0002/__cts__.xml
+++ b/data/stoa0261/stoa0002/__cts__.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ti:work xmlns:ti="http://chs.harvard.edu/xmlns/cts" urn="urn:cts:latinLit:stoa0261.stoa002" xml:lang="lat" groupUrn="urn:cts:latinLit:stoa0261">
+            <ti:title xml:lang="lat">Epistulae</ti:title>
+            <ti:edition urn="urn:cts:latinLit:stoa0261.stoa002.perseus-lat1" workUrn="urn:cts:latinLit:stoa0261.stoa002">
+              <ti:label xml:lang="lat">Epistulae, Books I-IX</ti:label>
+              <ti:description xml:lang="mul">Sidonius Apollinaris. Poems and Letters, Vol 1-2. Anderson, W.B. London: William Heinemann, Ltd.; Cambridge, MA: Harvard
+                University Press, 1936 (printing).</ti:description>
+            </ti:edition>
+  <ti:edition urn="urn:cts:latinLit:stoa0261.stoa002.perseus-lat2" workUrn="urn:cts:latinLit:stoa0261.stoa002">
+    <ti:label xml:lang="lat">Epistulae, Books VIII-IX </ti:label>
+    <ti:description xml:lang="mul">Sidonius Apollinaris. Gai Sollii Apollinaris Sidonii Epistulae et carmina. Luetjohann, Christiannus, editor.
+    Berlin: Weidmann, 1887.</ti:description>
+  </ti:edition>
+</ti:work> 


### PR DESCRIPTION
In order to support display names for all textgroups on Beta Perseus, I added in textgroup level and work level cts_xml files for the following textgroups:

stoa0040-Augustine
stoa0079-Cato, Marcus Porcius
stoa0261-Sidonius Apollinaris
phi0692-Appendix Vergiliana
phi2003-Apicius

I believe in some cases these files were never released but they are currently viewable in Beta Perseus.
The texts all need to be ctsized and updated but I didn't even touch the headers because I know lots of work is going on with files right now. 